### PR TITLE
Fix for dust error when redeeming P2SH-B

### DIFF
--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -977,7 +977,7 @@ public class TradeBot {
 		byte[] redeemScriptBytes = BTCP2SH.buildScript(tradeBotData.getTradeForeignPublicKeyHash(), crossChainTradeData.lockTimeB, crossChainTradeData.creatorBitcoinPKH, crossChainTradeData.hashOfSecretB);
 		String p2shAddress = BTC.getInstance().deriveP2shAddress(redeemScriptBytes);
 
-		Coin refundAmount = Coin.ZERO;
+		Coin refundAmount = Coin.valueOf(P2SHB_REDEEM_AMOUNT); // We need to redeem an amount higher than the dust threshold (3000 sats/kB). The rest will be used to pay the fee.
 		ECKey refundKey = ECKey.fromPrivate(tradeBotData.getTradePrivateKey());
 		List<TransactionOutput> fundingOutputs = BTC.getInstance().getUnspentOutputs(p2shAddress);
 

--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -767,7 +767,7 @@ public class TradeBot {
 		}
 
 		// Redeem P2SH-B using secret-B
-		Coin redeemAmount = Coin.valueOf(P2SHB_REDEEM_AMOUNT); // The real funds are in P2SH-A
+		Coin redeemAmount = Coin.valueOf(P2SHB_REDEEM_AMOUNT); // We need to redeem an amount higher than the dust threshold (3000 sats/kB). The real funds are in P2SH-A
 		ECKey redeemKey = ECKey.fromPrivate(tradeBotData.getTradePrivateKey());
 		List<TransactionOutput> fundingOutputs = BTC.getInstance().getUnspentOutputs(p2shAddress);
 		byte[] receivingAccountInfo = tradeBotData.getReceivingAccountInfo();

--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -64,6 +64,7 @@ public class TradeBot {
 	private static final Logger LOGGER = LogManager.getLogger(TradeBot.class);
 	private static final Random RANDOM = new SecureRandom();
 	private static final long FEE_AMOUNT = 5000L;
+	private static final long P2SHB_REDEEM_AMOUNT = 1000L;
 
 	private static TradeBot instance;
 
@@ -766,7 +767,7 @@ public class TradeBot {
 		}
 
 		// Redeem P2SH-B using secret-B
-		Coin redeemAmount = Coin.ZERO; // The real funds are in P2SH-A
+		Coin redeemAmount = Coin.valueOf(P2SHB_REDEEM_AMOUNT); // The real funds are in P2SH-A
 		ECKey redeemKey = ECKey.fromPrivate(tradeBotData.getTradePrivateKey());
 		List<TransactionOutput> fundingOutputs = BTC.getInstance().getUnspentOutputs(p2shAddress);
 		byte[] receivingAccountInfo = tradeBotData.getReceivingAccountInfo();


### PR DESCRIPTION
I have committed my fix for the 'dust' error #14 when attempting to redeem P2SH-B with a zero amount. It is now redeeming 1000 sats, which was enough to allow a mainnet transaction to progress and ultimately succeed.

The trade-off of this approach is that the seller receives an extra 1000 sats, rather than them being used as part of the fee. In my trade, the remaining 4000 sats were still enough for the transaction to be included in a block 9 hours later, and this delay didn't affect the trade in any noticeable way.

I'll completely understand if you want to come up with better fix than this, but since it worked correctly for me and unblocks a critical issue with the TradeBot, I figured I'd submit a pull request.