### PR TITLE
Increase fee when redeeming P2SH-A

### DIFF
--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -63,8 +63,8 @@ public class TradeBot {
 
 	private static final Logger LOGGER = LogManager.getLogger(TradeBot.class);
 	private static final Random RANDOM = new SecureRandom();
-	private static final long P2SHA_FEE_AMOUNT = 5000L;
-	private static final long P2SHB_FEE_AMOUNT = 5000L;
+	private static final long P2SHA_FEE_AMOUNT = 10000L; // We ideally need to use a higher fee when redeeming PS2H-A than we do for P2SH-B, as we'd like Bob's redeemed BTC to be confirmed in a reasonable amount of time. 10k sats will confirm within 6 blocks (1 hour) at current rates (Aug 2020).
+	private static final long P2SHB_FEE_AMOUNT = 5000L; // P2SH-B can use a lower fee because we accept a slower confirmation time for the redeemed value.
 
 	private static TradeBot instance;
 

--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -63,7 +63,7 @@ public class TradeBot {
 
 	private static final Logger LOGGER = LogManager.getLogger(TradeBot.class);
 	private static final Random RANDOM = new SecureRandom();
-	private static final long P2SHA_FEE_AMOUNT = 10000L; // We ideally need to use a higher fee when redeeming PS2H-A than we do for P2SH-B, as we'd like Bob's redeemed BTC to be confirmed in a reasonable amount of time. 10k sats will confirm within 6 blocks (1 hour) at current rates (Aug 2020).
+	private static final long P2SHA_FEE_AMOUNT = 42000L; // We ideally need to use a higher fee when redeeming PS2H-A than we do for P2SH-B, as we'd like Bob's redeemed BTC to be confirmed in a reasonable amount of time. It would be more efficient if this were dynamically calculated based based on the current network fees.
 	private static final long P2SHB_FEE_AMOUNT = 5000L; // P2SH-B can use a lower fee because we accept a slower confirmation time for the redeemed value.
 
 	private static TradeBot instance;

--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -63,7 +63,8 @@ public class TradeBot {
 
 	private static final Logger LOGGER = LogManager.getLogger(TradeBot.class);
 	private static final Random RANDOM = new SecureRandom();
-	private static final long FEE_AMOUNT = 5000L;
+	private static final long P2SHA_FEE_AMOUNT = 5000L;
+	private static final long P2SHB_FEE_AMOUNT = 5000L;
 
 	private static TradeBot instance;
 
@@ -246,7 +247,7 @@ public class TradeBot {
 		// Check we have enough funds via xprv58 to fund both P2SHs to cover expectedBitcoin
 		String tradeForeignAddress = BTC.getInstance().pkhToAddress(tradeForeignPublicKeyHash);
 
-		long totalFundsRequired = crossChainTradeData.expectedBitcoin + FEE_AMOUNT /* P2SH-A */ + FEE_AMOUNT /* P2SH-B */;
+		long totalFundsRequired = crossChainTradeData.expectedBitcoin + P2SHA_FEE_AMOUNT + P2SHB_FEE_AMOUNT;
 
 		Transaction fundingCheckTransaction = BTC.getInstance().buildSpend(xprv58, tradeForeignAddress, totalFundsRequired);
 		if (fundingCheckTransaction == null)
@@ -257,7 +258,7 @@ public class TradeBot {
 		String p2shAddress = BTC.getInstance().deriveP2shAddress(redeemScriptBytes);
 
 		// Fund P2SH-A
-		Transaction p2shFundingTransaction = BTC.getInstance().buildSpend(tradeBotData.getXprv58(), p2shAddress, crossChainTradeData.expectedBitcoin + FEE_AMOUNT);
+		Transaction p2shFundingTransaction = BTC.getInstance().buildSpend(tradeBotData.getXprv58(), p2shAddress, crossChainTradeData.expectedBitcoin + P2SHA_FEE_AMOUNT);
 		if (p2shFundingTransaction == null) {
 			LOGGER.warn(() -> String.format("Unable to build P2SH-A funding transaction - lack of funds?"));
 			return ResponseResult.BTC_BALANCE_ISSUE;
@@ -694,7 +695,7 @@ public class TradeBot {
 		byte[] redeemScriptBytes = BTCP2SH.buildScript(tradeBotData.getTradeForeignPublicKeyHash(), lockTimeB, crossChainTradeData.creatorBitcoinPKH, crossChainTradeData.hashOfSecretB);
 		String p2shAddress = BTC.getInstance().deriveP2shAddress(redeemScriptBytes);
 
-		Transaction p2shFundingTransaction = BTC.getInstance().buildSpend(tradeBotData.getXprv58(), p2shAddress, FEE_AMOUNT);
+		Transaction p2shFundingTransaction = BTC.getInstance().buildSpend(tradeBotData.getXprv58(), p2shAddress, P2SHB_FEE_AMOUNT);
 		if (p2shFundingTransaction == null) {
 			LOGGER.warn(() -> String.format("Unable to build P2SH-B funding transaction - lack of funds?"));
 			return;
@@ -758,9 +759,9 @@ public class TradeBot {
 		String p2shAddress = BTC.getInstance().deriveP2shAddress(redeemScriptBytes);
 
 		Long balance = BTC.getInstance().getBalance(p2shAddress);
-		if (balance == null || balance < FEE_AMOUNT) {
+		if (balance == null || balance < P2SHB_FEE_AMOUNT) {
 			if (balance != null && balance > 0)
-				LOGGER.debug(() -> String.format("P2SH-B balance %s lower than expected %s", BTC.format(balance), BTC.format(FEE_AMOUNT)));
+				LOGGER.debug(() -> String.format("P2SH-B balance %s lower than expected %s", BTC.format(balance), BTC.format(P2SHB_FEE_AMOUNT)));
 
 			return;
 		}


### PR DESCRIPTION
As mentioned in issue #15, Bob's redeemed BTC currently takes many hours (8+) to be included in a block due to its low 5000 sat fee. I felt that it would be worth increasing this, as doubling the fee (an extra $0.60 at current prices) gets it in a block almost an order of magnitude faster.

I have taken the approach of separating the fees assigned to P2SH-A and P2SH-B. I don't see much point in Alice paying extra for fast confirmation times when Bob redeems P2SH-B, as it doesn't appear that a slow confirmation affects the trade. But please correct me if I'm wrong on that one!

For now, I have doubled the P2SH-A fee from 5k to 10k sats. Based on the current transaction volume, this gets it in a block within an hour (6 blocks). Whereas at 5k sats it can take around 50 blocks, or 8.5 hours.