### PR TITLE
Fix for stuck trades due to missing lockTimeA

### DIFF
--- a/src/main/java/org/qortal/controller/TradeBot.java
+++ b/src/main/java/org/qortal/controller/TradeBot.java
@@ -590,6 +590,7 @@ public class TradeBot {
 
 			tradeBotData.setState(TradeBotData.State.BOB_WAITING_FOR_P2SH_B);
 			tradeBotData.setTimestamp(NTP.getTime());
+			tradeBotData.setLockTimeA(Integer.valueOf(lockTimeA));
 			repository.getCrossChainRepository().save(tradeBotData);
 			repository.saveChanges();
 


### PR DESCRIPTION
Since 1.3.4, another issue has been introduced which causes the trading process to get stuck in the BOB_WAITING_FOR_P2SH_B state. In order to use estimateFee(), Bob must have access to lockTimeA, which is not the case in the latest code. This causes it to fail at line 788:

```int lockTimeA = tradeBotData.getLockTimeA();```

lockTimeA is not present in Bob's tradeBotData, because it is never persisted in Bob's db.

To fix this, I am storing lockTimeA in Bob's tradeBotData in the previous `handleBobWaitingForMessage()` method. This then becomes available to use in `handleBobWaitingForP2shB()`.

I have tested this on the BTC mainnet, both before and after the fix, and can confirm that it solves the problem.

Note that this won't fix trades that are already stuck at `BOB_WAITING_FOR_P2SH_B`, but it will fix new trades, along with any trades that haven't yet reached the `BOB_WAITING_FOR_MESSAGE` state.