### PR TITLE
linux tooltip fix

### DIFF
--- a/src/main/java/org/qortal/controller/Controller.java
+++ b/src/main/java/org/qortal/controller/Controller.java
@@ -877,7 +877,7 @@ public class Controller extends Thread {
 				actionText = Translator.INSTANCE.translate("SysTray", "MINTING_DISABLED");
 		}
 
-		String tooltip = String.format("%s - %d %s - %s %d", actionText, numberOfPeers, connectionsText, heightText, height) + "\n" + String.format("Build version: %s", this.buildVersion);
+		String tooltip = String.format("%s (%d %s)%n %s:%d%n %s", actionText, numberOfPeers, connectionsText, heightText, height, this.buildVersion);
 		SysTray.getInstance().setToolTipText(tooltip);
 
 		this.callbackExecutor.execute(() -> {


### PR DESCRIPTION
reformatting the tootip to look nice (accounting for the single line limitation on linux)
while also minimizing characters used (to account for the string length limitation on linux)
![image](https://user-images.githubusercontent.com/20410795/123052990-69b49500-d3d1-11eb-9cef-60f9ce72e8ac.png)