### PR TITLE
Improvements to ByteArray to leverage Java 11 'native' Arrays methods

### DIFF
--- a/src/main/java/org/qortal/controller/Controller.java
+++ b/src/main/java/org/qortal/controller/Controller.java
@@ -675,7 +675,7 @@ public class Controller extends Thread {
 	public static final Predicate<Peer> hasInferiorChainTip = peer -> {
 		final PeerChainTipData peerChainTipData = peer.getChainTipData();
 		final List<ByteArray> inferiorChainTips = Synchronizer.getInstance().inferiorChainSignatures;
-		return peerChainTipData == null || peerChainTipData.getLastBlockSignature() == null || inferiorChainTips.contains(new ByteArray(peerChainTipData.getLastBlockSignature()));
+		return peerChainTipData == null || peerChainTipData.getLastBlockSignature() == null || inferiorChainTips.contains(ByteArray.wrap(peerChainTipData.getLastBlockSignature()));
 	};
 
 	public static final Predicate<Peer> hasOldVersion = peer -> {
@@ -1203,7 +1203,7 @@ public class Controller extends Thread {
 		byte[] signature = getBlockMessage.getSignature();
 		this.stats.getBlockMessageStats.requests.incrementAndGet();
 
-		ByteArray signatureAsByteArray = new ByteArray(signature);
+		ByteArray signatureAsByteArray = ByteArray.wrap(signature);
 
 		CachedBlockMessage cachedBlockMessage = this.blockMessageCache.get(signatureAsByteArray);
 		int blockCacheSize = Settings.getInstance().getBlockCacheSize();
@@ -1283,7 +1283,7 @@ public class Controller extends Thread {
 			if (getChainHeight() - blockData.getHeight() <= blockCacheSize) {
 				this.stats.getBlockMessageStats.cacheFills.incrementAndGet();
 
-				this.blockMessageCache.put(new ByteArray(blockData.getSignature()), blockMessage);
+				this.blockMessageCache.put(ByteArray.wrap(blockData.getSignature()), blockMessage);
 			}
 		} catch (DataException e) {
 			LOGGER.error(String.format("Repository issue while send block %s to peer %s", Base58.encode(signature), peer), e);

--- a/src/main/java/org/qortal/controller/Synchronizer.java
+++ b/src/main/java/org/qortal/controller/Synchronizer.java
@@ -314,7 +314,7 @@ public class Synchronizer extends Thread {
 
 				case INFERIOR_CHAIN: {
 					// Update our list of inferior chain tips
-					ByteArray inferiorChainSignature = new ByteArray(peer.getChainTipData().getLastBlockSignature());
+					ByteArray inferiorChainSignature = ByteArray.wrap(peer.getChainTipData().getLastBlockSignature());
 					if (!inferiorChainSignatures.contains(inferiorChainSignature))
 						inferiorChainSignatures.add(inferiorChainSignature);
 
@@ -343,7 +343,7 @@ public class Synchronizer extends Thread {
 					// fall-through...
 				case NOTHING_TO_DO: {
 					// Update our list of inferior chain tips
-					ByteArray inferiorChainSignature = new ByteArray(peer.getChainTipData().getLastBlockSignature());
+					ByteArray inferiorChainSignature = ByteArray.wrap(peer.getChainTipData().getLastBlockSignature());
 					if (!inferiorChainSignatures.contains(inferiorChainSignature))
 						inferiorChainSignatures.add(inferiorChainSignature);
 
@@ -419,7 +419,7 @@ public class Synchronizer extends Thread {
 
 	public void addInferiorChainSignature(byte[] inferiorSignature) {
 		// Update our list of inferior chain tips
-		ByteArray inferiorChainSignature = new ByteArray(inferiorSignature);
+		ByteArray inferiorChainSignature = ByteArray.wrap(inferiorSignature);
 		if (!inferiorChainSignatures.contains(inferiorChainSignature))
 			inferiorChainSignatures.add(inferiorChainSignature);
 	}

--- a/src/main/java/org/qortal/controller/tradebot/TradeBot.java
+++ b/src/main/java/org/qortal/controller/tradebot/TradeBot.java
@@ -402,7 +402,7 @@ public class TradeBot implements Listener {
 
 		long now = NTP.getTime();
 		long newExpiry = generateExpiry(now);
-		ByteArray pubkeyByteArray = ByteArray.of(tradeNativeAccount.getPublicKey());
+		ByteArray pubkeyByteArray = ByteArray.wrap(tradeNativeAccount.getPublicKey());
 
 		// If map entry's timestamp is missing, or within early renewal period, use the new expiry - otherwise use existing timestamp.
 		synchronized (this.ourTradePresenceTimestampsByPubkey) {
@@ -489,7 +489,7 @@ public class TradeBot implements Listener {
 		int knownCount = entriesUnknownToPeer.size();
 
 		for (TradePresenceData peersTradePresence : peersTradePresences) {
-			ByteArray pubkeyByteArray = ByteArray.of(peersTradePresence.getPublicKey());
+			ByteArray pubkeyByteArray = ByteArray.wrap(peersTradePresence.getPublicKey());
 
 			TradePresenceData ourEntry = entriesUnknownToPeer.get(pubkeyByteArray);
 
@@ -546,7 +546,7 @@ public class TradeBot implements Listener {
 					continue;
 				}
 
-				ByteArray pubkeyByteArray = ByteArray.of(peersTradePresence.getPublicKey());
+				ByteArray pubkeyByteArray = ByteArray.wrap(peersTradePresence.getPublicKey());
 
 				// Ignore if we've previously verified this timestamp+publickey combo or sent timestamp is older
 				TradePresenceData existingTradeData = this.safeAllTradePresencesByPubkey.get(pubkeyByteArray);
@@ -589,7 +589,7 @@ public class TradeBot implements Listener {
 					continue;
 				}
 
-				ByteArray atCodeHash = new ByteArray(atData.getCodeHash());
+				ByteArray atCodeHash = ByteArray.wrap(atData.getCodeHash());
 				Supplier<ACCT> acctSupplier = acctSuppliersByCodeHash.get(atCodeHash);
 				if (acctSupplier == null) {
 					LOGGER.trace("Ignoring trade presence {} from peer {} as AT isn't a known ACCT?",
@@ -642,7 +642,7 @@ public class TradeBot implements Listener {
 
 	public void bridgePresence(long timestamp, byte[] publicKey, byte[] signature, String atAddress) {
 		long expiry = generateExpiry(timestamp);
-		ByteArray pubkeyByteArray = ByteArray.of(publicKey);
+		ByteArray pubkeyByteArray = ByteArray.wrap(publicKey);
 
 		TradePresenceData fakeTradePresenceData = new TradePresenceData(expiry, publicKey, signature, atAddress);
 

--- a/src/main/java/org/qortal/crosschain/SupportedBlockchain.java
+++ b/src/main/java/org/qortal/crosschain/SupportedBlockchain.java
@@ -62,7 +62,7 @@ public enum SupportedBlockchain {
 	private static final Map<ByteArray, Supplier<ACCT>> supportedAcctsByCodeHash = Arrays.stream(SupportedBlockchain.values())
 			.map(supportedBlockchain -> supportedBlockchain.supportedAccts)
 			.flatMap(List::stream)
-			.collect(Collectors.toUnmodifiableMap(triple -> new ByteArray(triple.getB()), Triple::getC));
+			.collect(Collectors.toUnmodifiableMap(triple -> ByteArray.wrap(triple.getB()), Triple::getC));
 
 	private static final Map<String, Supplier<ACCT>> supportedAcctsByName = Arrays.stream(SupportedBlockchain.values())
 			.map(supportedBlockchain -> supportedBlockchain.supportedAccts)
@@ -94,7 +94,7 @@ public enum SupportedBlockchain {
 			return getAcctMap();
 
 		return blockchain.supportedAccts.stream()
-				.collect(Collectors.toUnmodifiableMap(triple -> new ByteArray(triple.getB()), Triple::getC));
+				.collect(Collectors.toUnmodifiableMap(triple -> ByteArray.wrap(triple.getB()), Triple::getC));
 	}
 
 	public static Map<ByteArray, Supplier<ACCT>> getFilteredAcctMap(String specificBlockchain) {
@@ -109,7 +109,7 @@ public enum SupportedBlockchain {
 	}
 
 	public static ACCT getAcctByCodeHash(byte[] codeHash) {
-		ByteArray wrappedCodeHash = new ByteArray(codeHash);
+		ByteArray wrappedCodeHash = ByteArray.wrap(codeHash);
 
 		Supplier<ACCT> acctInstanceSupplier = supportedAcctsByCodeHash.get(wrappedCodeHash);
 

--- a/src/main/java/org/qortal/transaction/PresenceTransaction.java
+++ b/src/main/java/org/qortal/transaction/PresenceTransaction.java
@@ -185,7 +185,7 @@ public class PresenceTransaction extends Transaction {
 		String signerAddress = Crypto.toAddress(this.transactionData.getCreatorPublicKey());
 
 		for (ATData atData : atsData) {
-			ByteArray atCodeHash = new ByteArray(atData.getCodeHash());
+			ByteArray atCodeHash = ByteArray.wrap(atData.getCodeHash());
 			Supplier<ACCT> acctSupplier = acctSuppliersByCodeHash.get(atCodeHash);
 			if (acctSupplier == null)
 				continue;

--- a/src/main/java/org/qortal/utils/ByteArray.java
+++ b/src/main/java/org/qortal/utils/ByteArray.java
@@ -8,12 +8,16 @@ public class ByteArray implements Comparable<ByteArray> {
 	private int hash;
 	public final byte[] value;
 
-	public ByteArray(byte[] value) {
-		this.value = Objects.requireNonNull(value);
+	private ByteArray(byte[] value) {
+		this.value = value;
 	}
 
-	public static ByteArray of(byte[] value) {
-		return new ByteArray(value);
+	public static ByteArray wrap(byte[] value) {
+		return new ByteArray(Objects.requireNonNull(value));
+	}
+
+	public static ByteArray copyOf(byte[] value) {
+		return new ByteArray(Arrays.copyOf(value, value.length));
 	}
 
 	@Override
@@ -36,12 +40,7 @@ public class ByteArray implements Comparable<ByteArray> {
 		byte[] val = this.value;
 
 		if (h == 0 && val.length > 0) {
-			h = 1;
-
-			for (int i = 0; i < val.length; ++i)
-				h = 31 * h + val[i];
-
-			this.hash = h;
+			this.hash = h = Arrays.hashCode(val);
 		}
 		return h;
 	}
@@ -53,24 +52,7 @@ public class ByteArray implements Comparable<ByteArray> {
 	}
 
 	public int compareToPrimitive(byte[] otherValue) {
-		byte[] val = this.value;
-
-		if (val.length < otherValue.length)
-			return -1;
-
-		if (val.length > otherValue.length)
-			return 1;
-
-		for (int i = 0; i < val.length; ++i) {
-			int a = val[i] & 0xFF;
-			int b = otherValue[i] & 0xFF;
-			if (a < b)
-				return -1;
-			if (a > b)
-				return 1;
-		}
-
-		return 0;
+		return Arrays.compareUnsigned(this.value, otherValue);
 	}
 
 	public String toString() {

--- a/src/test/java/org/qortal/test/crosschain/TradeBotPresenceTests.java
+++ b/src/test/java/org/qortal/test/crosschain/TradeBotPresenceTests.java
@@ -55,7 +55,7 @@ public class TradeBotPresenceTests {
 
     @Test
     public void testEnforceLatestTimestamp() {
-        ByteArray pubkeyByteArray = ByteArray.of("publickey".getBytes(StandardCharsets.UTF_8));
+        ByteArray pubkeyByteArray = ByteArray.wrap("publickey".getBytes(StandardCharsets.UTF_8));
 
         Map<ByteArray, Long> timestampsByPublicKey = new HashMap<>();
 


### PR DESCRIPTION
Use Arrays.hashCode and Arrays.compareUnsigned for speed.

Also modified ambiguous ByteArray::new and ByteArray::of to ByteArray::wrap and ByteArray::copyOf.
Modifications to other classes that use ByteArray.