### PR TITLE
Fix creatorPublicKey not being unmarshalled when calling POST /at to deploy an AT

### DIFF
--- a/src/main/java/org/qortal/data/transaction/DeployAtTransactionData.java
+++ b/src/main/java/org/qortal/data/transaction/DeployAtTransactionData.java
@@ -2,6 +2,7 @@ package org.qortal.data.transaction;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.qortal.transaction.Transaction.TransactionType;
@@ -88,6 +89,19 @@ public class DeployAtTransactionData extends TransactionData {
 
 	public void setAtAddress(String AtAddress) {
 		this.aTAddress = AtAddress;
+	}
+
+	// Re-expose creatorPublicKey for this transaction type for JAXB
+	@XmlElement(name = "creatorPublicKey")
+	@Schema(name = "creatorPublicKey", description = "AT creator's public key", example = "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP")
+	public byte[] getAtCreatorPublicKey() {
+		return this.creatorPublicKey;
+	}
+
+	@XmlElement(name = "creatorPublicKey")
+	@Schema(name = "creatorPublicKey", description = "AT creator's public key", example = "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP")
+	public void setAtCreatorPublicKey(byte[] creatorPublicKey) {
+		this.creatorPublicKey = creatorPublicKey;
 	}
 
 }


### PR DESCRIPTION
If you send request body JSON containing "creatorPublicKey" entry, it is not unmarshalled by JAXB before being presented to AtResource.createDeployAt() which results in an Internal Server Error / HTTP 500 response.

Fix is in line with other transaction types DTO, e.g. CancelAssetOrderTransactionData.

This type of fix might need to be applied elsewhere, e.g. CreatePollTransactionData & VoteOnPollTransactionData.

Found while attempting to deploy new lottery AT.