### PR TITLE
Increase MAX_DESCRIPTION_SIZE

### DIFF
--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -85,7 +85,7 @@ public class Group {
 
 	public static final int MIN_NAME_SIZE = 3;
 	public static final int MAX_NAME_SIZE = 32;
-	public static final int MAX_DESCRIPTION_SIZE = 128;
+	public static final int MAX_DESCRIPTION_SIZE = 256;
 	/** Max size of kick/ban reason */
 	public static final int MAX_REASON_SIZE = 128;
 


### PR DESCRIPTION
**Credit to QuickMythril for pointing out the location of the code for me.**

Increase the max description size for a group from 128 to 256 characters.