### PR TITLE
Added missing parameter to test

### DIFF
--- a/src/test/java/org/qortal/test/arbitrary/ArbitraryDataFileTests.java
+++ b/src/test/java/org/qortal/test/arbitrary/ArbitraryDataFileTests.java
@@ -20,7 +20,7 @@ public class ArbitraryDataFileTests extends Common {
 	@Test
 	public void testSplitAndJoin() throws DataException {
 		String dummyDataString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-		ArbitraryDataFile arbitraryDataFile = new ArbitraryDataFile(dummyDataString.getBytes(), null);
+		ArbitraryDataFile arbitraryDataFile = new ArbitraryDataFile(dummyDataString.getBytes(), null, false);
 		assertTrue(arbitraryDataFile.exists());
 		assertEquals(62, arbitraryDataFile.size());
 		assertEquals("3eyjYjturyVe61grRX42bprGr3Cvw6ehTy4iknVnosDj", arbitraryDataFile.digest58());
@@ -50,7 +50,7 @@ public class ArbitraryDataFileTests extends Common {
 		byte[] randomData = new byte[fileSize];
 		new Random().nextBytes(randomData); // No need for SecureRandom here
 
-		ArbitraryDataFile arbitraryDataFile = new ArbitraryDataFile(randomData, null);
+		ArbitraryDataFile arbitraryDataFile = new ArbitraryDataFile(randomData, null, false);
 		assertTrue(arbitraryDataFile.exists());
 		assertEquals(fileSize, arbitraryDataFile.size());
 		String originalFileDigest = arbitraryDataFile.digest58();


### PR DESCRIPTION
This fixes a build error:
```
[ERROR] /home/qortal/git/qortal/src/test/java/org/qortal/test/arbitrary/ArbitraryDataFileTests.java:[23,101] incompatible types: byte[] cannot be converted to java.lang.String
[ERROR] /home/qortal/git/qortal/src/test/java/org/qortal/test/arbitrary/ArbitraryDataFileTests.java:[53,77] incompatible types: byte[] cannot be converted to java.lang.String
```