### PR TITLE
Fix website sub-folder rendering 404

### DIFF
--- a/src/main/java/org/qortal/arbitrary/ArbitraryDataRenderer.java
+++ b/src/main/java/org/qortal/arbitrary/ArbitraryDataRenderer.java
@@ -127,6 +127,11 @@ public class ArbitraryDataRenderer {
             String filename = this.getFilename(unzippedPath, inPath);
             Path filePath = Paths.get(unzippedPath, filename);
             boolean usingCustomRouting = false;
+            if (Files.isDirectory(filePath) && (!inPath.endsWith("/"))) {
+                inPath = inPath + "/";
+                filename = this.getFilename(unzippedPath, inPath);
+                filePath = Paths.get(unzippedPath, filename);
+            }
             
             // If the file doesn't exist, we may need to route the request elsewhere, or cleanup
             if (!Files.exists(filePath)) {


### PR DESCRIPTION
In case a website url points to a sub-directory the url has to either end in a '/' or explicityl name the html page to render.
The default html page resolution only works if the trailing '/' is included.
This fix adds it if necessary on folder content items.
