### PR TITLE
Upgrade to TLSv1.3

### DIFF
--- a/src/main/java/org/qortal/api/DevProxyService.java
+++ b/src/main/java/org/qortal/api/DevProxyService.java
@@ -70,7 +70,7 @@ public class DevProxyService {
 					throw new RuntimeException("Failed to start SSL API due to broken keystore");
 
 				// BouncyCastle-specific SSLContext build
-				SSLContext sslContext = SSLContext.getInstance("TLS", "BCJSSE");
+				SSLContext sslContext = SSLContext.getInstance("TLSv1.3", "BCJSSE");
 				KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("PKIX", "BCJSSE");
 
 				KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType(), "BC");

--- a/src/main/java/org/qortal/crypto/TrustlessSSLSocketFactory.java
+++ b/src/main/java/org/qortal/crypto/TrustlessSSLSocketFactory.java
@@ -27,7 +27,7 @@ public abstract class TrustlessSSLSocketFactory {
 	private static final SSLContext sc;
 	static {
 		try {
-			sc = SSLContext.getInstance("SSL");
+			sc = SSLContext.getInstance("TLSv1.3");
 			sc.init(null, TRUSTLESS_MANAGER, new java.security.SecureRandom());
 		} catch (Exception e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
There does not appear to be any incompatibility or errors that will occur from using the newer more secure version of TLS.  If this version will not work with the code being used, then please let me know what issues would be caused.

Reference information:
https://www.bouncycastle.org/releasenotes.html
https://security.stackexchange.com/questions/224050/tls1-2-vs-tls1-3