### PR TITLE
Change AES to GCM/NoPadding mode

### DIFF
--- a/src/main/java/org/qortal/arbitrary/ArbitraryDataReader.java
+++ b/src/main/java/org/qortal/arbitrary/ArbitraryDataReader.java
@@ -453,15 +453,22 @@ public class ArbitraryDataReader {
 
     private void decrypt() throws DataException {
         try {
-            // First try with explicit parameters (CBC mode with PKCS5 padding)
-            this.decryptUsingAlgo("AES/CBC/PKCS5Padding");
+            // First try with new parameters (GCM mode with no padding)
+            this.decryptUsingAlgo("AES/GCM/NoPadding");
 
         } catch (DataException e) {
-            LOGGER.info("Unable to decrypt using specific parameters: {}", e.getMessage());
-            // Something went wrong, so fall back to default AES params (necessary for legacy resource support)
-            this.decryptUsingAlgo("AES");
+            LOGGER.info("Unable to decrypt using new parameters: {}", e.getMessage());
+            try {
+                // Next try with old parameters (CBC mode with PKCS5 padding)
+                this.decryptUsingAlgo("AES/CBC/PKCS5Padding");
 
-            // TODO: delete files and block this resource if privateDataEnabled is false and the second attempt fails too
+            } catch (DataException f) {
+                LOGGER.info("Unable to decrypt using old parameters: {}", f.getMessage());
+                // Something went wrong, so fall back to default AES params (necessary for legacy resource support)
+                this.decryptUsingAlgo("AES");
+            }
+
+            // TODO: delete files and block this resource if privateDataEnabled is false and the final attempt fails too
         }
     }
 

--- a/src/main/java/org/qortal/arbitrary/ArbitraryDataTransactionBuilder.java
+++ b/src/main/java/org/qortal/arbitrary/ArbitraryDataTransactionBuilder.java
@@ -197,7 +197,7 @@ public class ArbitraryDataTransactionBuilder {
 
             // We can't use PATCH for on-chain data because this requires the .qortal directory, which can't be put on chain
             final boolean isSingleFileResource = FilesystemUtils.isSingleFileResource(this.path, false);
-            final boolean shouldUseOnChainData = (isSingleFileResource && AES.getEncryptedFileSize(FilesystemUtils.getSingleFileContents(path).length) <= ArbitraryTransaction.MAX_DATA_SIZE);
+            final boolean shouldUseOnChainData = (isSingleFileResource && AES.getGcmEncryptedFileSize(FilesystemUtils.getSingleFileContents(path).length) <= ArbitraryTransaction.MAX_DATA_SIZE);
             if (shouldUseOnChainData) {
                 LOGGER.info("Data size is small enough to go on chain - using PUT");
                 return Method.PUT;
@@ -245,7 +245,7 @@ public class ArbitraryDataTransactionBuilder {
 
             // Single file resources are handled differently, especially for very small data payloads, as these go on chain
             final boolean isSingleFileResource = FilesystemUtils.isSingleFileResource(path, false);
-            final boolean shouldUseOnChainData = (isSingleFileResource && AES.getEncryptedFileSize(FilesystemUtils.getSingleFileContents(path).length) <= ArbitraryTransaction.MAX_DATA_SIZE);
+            final boolean shouldUseOnChainData = (isSingleFileResource && AES.getGcmEncryptedFileSize(FilesystemUtils.getSingleFileContents(path).length) <= ArbitraryTransaction.MAX_DATA_SIZE);
 
             // Use zip compression if data isn't going on chain
             Compression compression = shouldUseOnChainData ? Compression.NONE : Compression.ZIP;

--- a/src/main/java/org/qortal/arbitrary/ArbitraryDataWriter.java
+++ b/src/main/java/org/qortal/arbitrary/ArbitraryDataWriter.java
@@ -295,7 +295,7 @@ public class ArbitraryDataWriter {
             // Encrypt the file with AES
             LOGGER.info("Encrypting...");
             this.aesKey = AES.generateKey(256);
-            AES.encryptFile("AES/CBC/PKCS5Padding", this.aesKey, this.filePath.toString(), this.encryptedPath.toString());
+            AES.encryptFile("AES/GCM/NoPadding", this.aesKey, this.filePath.toString(), this.encryptedPath.toString());
 
             // Delete the input file
             if (FilesystemUtils.pathInsideDataOrTempPath(this.filePath)) {

--- a/src/test/java/org/qortal/test/arbitrary/ArbitraryTransactionTests.java
+++ b/src/test/java/org/qortal/test/arbitrary/ArbitraryTransactionTests.java
@@ -444,7 +444,7 @@ public class ArbitraryTransactionTests extends Common {
             String identifier = null; // Not used for this test
             Service service = Service.ARBITRARY_DATA;
             int chunkSize = 1000;
-            int dataLength = 239; // Max possible size. Becomes 256 bytes after encryption.
+            int dataLength = 228; // Max possible size. Becomes 256 bytes after encryption.
 
             // Register the name to Alice
             RegisterNameTransactionData transactionData = new RegisterNameTransactionData(TestTransaction.generateBase(alice), name, "");
@@ -499,7 +499,7 @@ public class ArbitraryTransactionTests extends Common {
             String identifier = null; // Not used for this test
             Service service = Service.ARBITRARY_DATA;
             int chunkSize = 1000;
-            int dataLength = 239; // Max possible size. Becomes 256 bytes after encryption.
+            int dataLength = 228; // Max possible size. Becomes 256 bytes after encryption.
 
             String title = "Test title";
             String description = "Test description";
@@ -563,7 +563,7 @@ public class ArbitraryTransactionTests extends Common {
             String identifier = null; // Not used for this test
             Service service = Service.ARBITRARY_DATA;
             int chunkSize = 1000;
-            int dataLength = 240; // Min possible size. Becomes 257 bytes after encryption.
+            int dataLength = 229; // Min possible size. Becomes 257 bytes after encryption.
 
             // Register the name to Alice
             RegisterNameTransactionData transactionData = new RegisterNameTransactionData(TestTransaction.generateBase(alice), name, "");


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Common_modes
- GCM can take full advantage of parallel processing and implementing GCM can make efficient use of an instruction pipeline or a hardware pipeline. The CBC mode of operation incurs pipeline stalls that hamper its efficiency and performance.
- CBC has been the most commonly used mode of operation. Its main drawbacks are that encryption is sequential (i.e., it cannot be parallelized), and that the message must be padded to a multiple of the cipher block size.

https://www.baeldung.com/java-aes-encryption-decryption
- The GCM has received significant attention and is recommended by NIST. The GCM model outputs ciphertext and an authentication tag. The main advantage of this mode, compared to other operation modes of the algorithm, is its efficiency.

https://isuruka.medium.com/selecting-the-best-aes-block-cipher-mode-aes-gcm-vs-aes-cbc-ee3ebae173c
- Both the AES-CBC and AES-GCM are able to secure your valuable data with a good implementation. but to prevent complex CBC attacks such as Chosen Plaintext Attack(CPA) and Chosen Ciphertext Attack(CCA) it is necessary to use Authenticated Encryption. So the best option is for that is GCM. AES-GCM is written in parallel which means throughput is significantly higher than AES-CBC by lowering encryption overheads.

https://helpdesk.privateinternetaccess.com/kb/articles/what-s-the-difference-between-aes-cbc-and-aes-gcm
- AES-GCM is a more secure cipher than AES-CBC, because AES-CBC, operates by XOR'ing (eXclusive OR) each block with the previous block and cannot be written in parallel. This affects performance due to the complex mathematics involved requiring serial encryption. AES-CBC also is vulnerable to padding oracle attacks, which exploit the tendency of block ciphers to add arbitrary values onto the end of the last block in a sequence in order to meet the specified block size.
- AES-GCM is written in parallel which means throughput is significantly higher than AES-CBC by lowering encryption overheads. Each block with AES-GCM can be encrypted independently. The AES-GCM mode of operation can actually be carried out in parallel both for encryption and decryption.

https://en.wikipedia.org/wiki/Padding_oracle_attack
- In symmetric cryptography, the padding oracle attack can be applied to the CBC mode of operation, where the "oracle" (usually a server) leaks data about whether the padding of an encrypted message is correct or not. Such data can allow attackers to decrypt (and sometimes encrypt) messages through the oracle using the oracle's key, without knowing the encryption key.