### PR TITLE
Add new supported ACCTs

### DIFF
--- a/src/main/java/org/qortal/crosschain/Dash.java
+++ b/src/main/java/org/qortal/crosschain/Dash.java
@@ -1,0 +1,174 @@
+package org.qortal.crosschain;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
+// import org.libdohj.params.DashMainNetParams;
+import org.bitcoinj.params.MainNetParams; // temporary, not for use
+import org.qortal.crosschain.ElectrumX.Server;
+import org.qortal.crosschain.ChainableServer.ConnectionType;
+import org.qortal.settings.Settings;
+
+public class Dash extends Bitcoiny {
+
+	public static final String CURRENCY_CODE = "DASH";
+
+	private static final Coin DEFAULT_FEE_PER_KB = Coin.valueOf(1100); // 0.00001100 DASH per 1000 bytes
+
+	private static final long MINIMUM_ORDER_AMOUNT = 1000000; // 0.01 DASH minimum order, to avoid dust errors
+
+	// Temporary values until a dynamic fee system is written.
+	private static final long MAINNET_FEE = 1000L;
+	private static final long NON_MAINNET_FEE = 1000L; // enough for TESTNET3 and should be OK for REGTEST
+
+	private static final Map<ConnectionType, Integer> DEFAULT_ELECTRUMX_PORTS = new EnumMap<>(ConnectionType.class);
+	static {
+		DEFAULT_ELECTRUMX_PORTS.put(ConnectionType.TCP, 50001);
+		DEFAULT_ELECTRUMX_PORTS.put(ConnectionType.SSL, 50002);
+	}
+
+	public enum DashNet {
+		MAIN {
+			@Override
+			public NetworkParameters getParams() {
+				return MainNetParams.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(
+						// Servers chosen on NO BASIS WHATSOEVER from various sources!
+						// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=dash
+						new Server("electrum1.cipig.net", ConnectionType.SSL, 20061),
+						new Server("electrum2.cipig.net", ConnectionType.SSL, 20061),
+						new Server("electrum3.cipig.net", ConnectionType.SSL, 20061));
+			}
+
+			@Override
+			public String getGenesisHash() {
+				return "00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6";
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				// TODO: This will need to be replaced with something better in the near future!
+				return MAINNET_FEE;
+			}
+		},
+		TEST3 {
+			@Override
+			public NetworkParameters getParams() {
+				return TestNet3Params.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(); // TODO: find testnet servers
+			}
+
+			@Override
+			public String getGenesisHash() {
+				return "00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c";
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				return NON_MAINNET_FEE;
+			}
+		},
+		REGTEST {
+			@Override
+			public NetworkParameters getParams() {
+				return RegTestParams.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(
+						new Server("localhost", ConnectionType.TCP, 50001),
+						new Server("localhost", ConnectionType.SSL, 50002));
+			}
+
+			@Override
+			public String getGenesisHash() {
+				// This is unique to each regtest instance
+				return null;
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				return NON_MAINNET_FEE;
+			}
+		};
+
+		public abstract NetworkParameters getParams();
+		public abstract Collection<Server> getServers();
+		public abstract String getGenesisHash();
+		public abstract long getP2shFee(Long timestamp) throws ForeignBlockchainException;
+	}
+
+	private static Dash instance;
+
+	private final DashNet dashNet;
+
+	// Constructors and instance
+
+	private Dash(DashNet dashNet, BitcoinyBlockchainProvider blockchain, Context bitcoinjContext, String currencyCode) {
+		super(blockchain, bitcoinjContext, currencyCode);
+		this.dashNet = dashNet;
+
+		LOGGER.info(() -> String.format("Starting Dash support using %s", this.dashNet.name()));
+	}
+
+	public static synchronized Dash getInstance() {
+		if (instance == null) {
+			DashNet dashNet = Settings.getInstance().getDashNet();
+
+			BitcoinyBlockchainProvider electrumX = new ElectrumX("Dash-" + dashNet.name(), dashNet.getGenesisHash(), dashNet.getServers(), DEFAULT_ELECTRUMX_PORTS);
+			Context bitcoinjContext = new Context(dashNet.getParams());
+
+			instance = new Dash(dashNet, electrumX, bitcoinjContext, CURRENCY_CODE);
+
+			electrumX.setBlockchain(instance);
+		}
+
+		return instance;
+	}
+
+	// Getters & setters
+
+	public static synchronized void resetForTesting() {
+		instance = null;
+	}
+
+	// Actual useful methods for use by other classes
+
+	@Override
+	public Coin getFeePerKb() {
+		return DEFAULT_FEE_PER_KB;
+	}
+
+	@Override
+	public long getMinimumOrderAmount() {
+		return MINIMUM_ORDER_AMOUNT;
+	}
+
+	/**
+	 * Returns estimated DASH fee, in sats per 1000bytes, optionally for historic timestamp.
+	 * 
+	 * @param timestamp optional milliseconds since epoch, or null for 'now'
+	 * @return sats per 1000bytes, or throws ForeignBlockchainException if something went wrong
+	 */
+	@Override
+	public long getP2shFee(Long timestamp) throws ForeignBlockchainException {
+		return this.dashNet.getP2shFee(timestamp);
+	}
+
+}

--- a/src/main/java/org/qortal/crosschain/DashACCTv3.java
+++ b/src/main/java/org/qortal/crosschain/DashACCTv3.java
@@ -1,0 +1,858 @@
+package org.qortal.crosschain;
+
+import com.google.common.hash.HashCode;
+import com.google.common.primitives.Bytes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ciyam.at.*;
+import org.qortal.account.Account;
+import org.qortal.asset.Asset;
+import org.qortal.at.QortalFunctionCode;
+import org.qortal.crypto.Crypto;
+import org.qortal.data.at.ATData;
+import org.qortal.data.at.ATStateData;
+import org.qortal.data.crosschain.CrossChainTradeData;
+import org.qortal.data.transaction.MessageTransactionData;
+import org.qortal.repository.DataException;
+import org.qortal.repository.Repository;
+import org.qortal.utils.Base58;
+import org.qortal.utils.BitTwiddling;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.ciyam.at.OpCode.calcOffset;
+
+/**
+ * Cross-chain trade AT
+ * 
+ * <p>
+ * <ul>
+ * <li>Bob generates Dash & Qortal 'trade' keys
+ * 		<ul>
+ * 			<li>private key required to sign P2SH redeem tx</li>
+ * 			<li>private key could be used to create 'secret' (e.g. double-SHA256)</li>
+ * 			<li>encrypted private key could be stored in Qortal AT for access by Bob from any node</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob deploys Qortal AT
+ * 		<ul>
+ * 		</ul>
+ * </li>
+ * <li>Alice finds Qortal AT and wants to trade
+ * 		<ul>
+ * 			<li>Alice generates Dash & Qortal 'trade' keys</li>
+ * 			<li>Alice funds Dash P2SH-A</li>
+ * 			<li>Alice sends 'offer' MESSAGE to Bob from her Qortal trade address, containing:
+ * 				<ul>
+ * 					<li>hash-of-secret-A</li>
+ * 					<li>her 'trade' Dash PKH</li>
+ * 				</ul>
+ * 			</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob receives "offer" MESSAGE
+ * 		<ul>
+ * 			<li>Checks Alice's P2SH-A</li>
+ * 			<li>Sends 'trade' MESSAGE to Qortal AT from his trade address, containing:
+ * 				<ul>
+ * 					<li>Alice's trade Qortal address</li>
+ * 					<li>Alice's trade Dash PKH</li>
+ * 					<li>hash-of-secret-A</li>
+ * 				</ul>
+ * 			</li>
+ * 		</ul>
+ * </li>
+ * <li>Alice checks Qortal AT to confirm it's locked to her
+ * 		<ul>
+ * 			<li>Alice sends 'redeem' MESSAGE to Qortal AT from her trade address, containing:
+ * 				<ul>
+ * 					<li>secret-A</li>
+ * 					<li>Qortal receiving address of her chosing</li>
+ * 				</ul>
+ * 			</li>
+ * 			<li>AT's QORT funds are sent to Qortal receiving address</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob checks AT, extracts secret-A
+ * 		<ul>
+ * 			<li>Bob redeems P2SH-A using his Dash trade key and secret-A</li>
+ * 			<li>P2SH-A DASH funds end up at Dash address determined by redeem transaction output(s)</li>
+ * 		</ul>
+ * </li>
+ * </ul>
+ */
+public class DashACCTv3 implements ACCT {
+
+	private static final Logger LOGGER = LogManager.getLogger(DashACCTv3.class);
+
+	public static final String NAME = DashACCTv3.class.getSimpleName();
+	public static final byte[] CODE_BYTES_HASH = HashCode.fromString("1dbe64aed46a93883cb364aba35855363f9c60a0a7a3cbd105b10d62c6ffdb93").asBytes(); // SHA256 of AT code bytes
+
+	public static final int SECRET_LENGTH = 32;
+
+	/** <b>Value</b> offset into AT segment where 'mode' variable (long) is stored. (Multiply by MachineState.VALUE_SIZE for byte offset). */
+	private static final int MODE_VALUE_OFFSET = 61;
+	/** <b>Byte</b> offset into AT state data where 'mode' variable (long) is stored. */
+	public static final int MODE_BYTE_OFFSET = MachineState.HEADER_LENGTH + (MODE_VALUE_OFFSET * MachineState.VALUE_SIZE);
+
+	public static class OfferMessageData {
+		public byte[] partnerDashPKH;
+		public byte[] hashOfSecretA;
+		public long lockTimeA;
+	}
+	public static final int OFFER_MESSAGE_LENGTH = 20 /*partnerDashPKH*/ + 20 /*hashOfSecretA*/ + 8 /*lockTimeA*/;
+	public static final int TRADE_MESSAGE_LENGTH = 32 /*partner's Qortal trade address (padded from 25 to 32)*/
+			+ 24 /*partner's Dash PKH (padded from 20 to 24)*/
+			+ 8 /*AT trade timeout (minutes)*/
+			+ 24 /*hash of secret-A (padded from 20 to 24)*/
+			+ 8 /*lockTimeA*/;
+	public static final int REDEEM_MESSAGE_LENGTH = 32 /*secret-A*/ + 32 /*partner's Qortal receiving address padded from 25 to 32*/;
+	public static final int CANCEL_MESSAGE_LENGTH = 32 /*AT creator's Qortal address*/;
+
+	private static DashACCTv3 instance;
+
+	private DashACCTv3() {
+	}
+
+	public static synchronized DashACCTv3 getInstance() {
+		if (instance == null)
+			instance = new DashACCTv3();
+
+		return instance;
+	}
+
+	@Override
+	public byte[] getCodeBytesHash() {
+		return CODE_BYTES_HASH;
+	}
+
+	@Override
+	public int getModeByteOffset() {
+		return MODE_BYTE_OFFSET;
+	}
+
+	@Override
+	public ForeignBlockchain getBlockchain() {
+		return Dash.getInstance();
+	}
+
+	/**
+	 * Returns Qortal AT creation bytes for cross-chain trading AT.
+	 * <p>
+	 * <tt>tradeTimeout</tt> (minutes) is the time window for the trade partner to send the
+	 * 32-byte secret to the AT, before the AT automatically refunds the AT's creator.
+	 * 
+	 * @param creatorTradeAddress AT creator's trade Qortal address
+	 * @param dashPublicKeyHash 20-byte HASH160 of creator's trade Dash public key
+	 * @param qortAmount how much QORT to pay trade partner if they send correct 32-byte secrets to AT
+	 * @param dashAmount how much DASH the AT creator is expecting to trade
+	 * @param tradeTimeout suggested timeout for entire trade
+	 */
+	public static byte[] buildQortalAT(String creatorTradeAddress, byte[] dashPublicKeyHash, long qortAmount, long dashAmount, int tradeTimeout) {
+		if (dashPublicKeyHash.length != 20)
+			throw new IllegalArgumentException("Dash public key hash should be 20 bytes");
+
+		// Labels for data segment addresses
+		int addrCounter = 0;
+
+		// Constants (with corresponding dataByteBuffer.put*() calls below)
+
+		final int addrCreatorTradeAddress1 = addrCounter++;
+		final int addrCreatorTradeAddress2 = addrCounter++;
+		final int addrCreatorTradeAddress3 = addrCounter++;
+		final int addrCreatorTradeAddress4 = addrCounter++;
+
+		final int addrDashPublicKeyHash = addrCounter;
+		addrCounter += 4;
+
+		final int addrQortAmount = addrCounter++;
+		final int addrDashAmount = addrCounter++;
+		final int addrTradeTimeout = addrCounter++;
+
+		final int addrMessageTxnType = addrCounter++;
+		final int addrExpectedTradeMessageLength = addrCounter++;
+		final int addrExpectedRedeemMessageLength = addrCounter++;
+
+		final int addrCreatorAddressPointer = addrCounter++;
+		final int addrQortalPartnerAddressPointer = addrCounter++;
+		final int addrMessageSenderPointer = addrCounter++;
+
+		final int addrTradeMessagePartnerDashPKHOffset = addrCounter++;
+		final int addrPartnerDashPKHPointer = addrCounter++;
+		final int addrTradeMessageHashOfSecretAOffset = addrCounter++;
+		final int addrHashOfSecretAPointer = addrCounter++;
+
+		final int addrRedeemMessageReceivingAddressOffset = addrCounter++;
+
+		final int addrMessageDataPointer = addrCounter++;
+		final int addrMessageDataLength = addrCounter++;
+
+		final int addrPartnerReceivingAddressPointer = addrCounter++;
+
+		final int addrEndOfConstants = addrCounter;
+
+		// Variables
+
+		final int addrCreatorAddress1 = addrCounter++;
+		final int addrCreatorAddress2 = addrCounter++;
+		final int addrCreatorAddress3 = addrCounter++;
+		final int addrCreatorAddress4 = addrCounter++;
+
+		final int addrQortalPartnerAddress1 = addrCounter++;
+		final int addrQortalPartnerAddress2 = addrCounter++;
+		final int addrQortalPartnerAddress3 = addrCounter++;
+		final int addrQortalPartnerAddress4 = addrCounter++;
+
+		final int addrLockTimeA = addrCounter++;
+		final int addrRefundTimeout = addrCounter++;
+		final int addrRefundTimestamp = addrCounter++;
+		final int addrLastTxnTimestamp = addrCounter++;
+		final int addrBlockTimestamp = addrCounter++;
+		final int addrTxnType = addrCounter++;
+		final int addrResult = addrCounter++;
+
+		final int addrMessageSender1 = addrCounter++;
+		final int addrMessageSender2 = addrCounter++;
+		final int addrMessageSender3 = addrCounter++;
+		final int addrMessageSender4 = addrCounter++;
+
+		final int addrMessageLength = addrCounter++;
+
+		final int addrMessageData = addrCounter;
+		addrCounter += 4;
+
+		final int addrHashOfSecretA = addrCounter;
+		addrCounter += 4;
+
+		final int addrPartnerDashPKH = addrCounter;
+		addrCounter += 4;
+
+		final int addrPartnerReceivingAddress = addrCounter;
+		addrCounter += 4;
+
+		final int addrMode = addrCounter++;
+		assert addrMode == MODE_VALUE_OFFSET : String.format("addrMode %d does not match MODE_VALUE_OFFSET %d", addrMode, MODE_VALUE_OFFSET);
+
+		// Data segment
+		ByteBuffer dataByteBuffer = ByteBuffer.allocate(addrCounter * MachineState.VALUE_SIZE);
+
+		// AT creator's trade Qortal address, decoded from Base58
+		assert dataByteBuffer.position() == addrCreatorTradeAddress1 * MachineState.VALUE_SIZE : "addrCreatorTradeAddress1 incorrect";
+		byte[] creatorTradeAddressBytes = Base58.decode(creatorTradeAddress);
+		dataByteBuffer.put(Bytes.ensureCapacity(creatorTradeAddressBytes, 32, 0));
+
+		// Dash public key hash
+		assert dataByteBuffer.position() == addrDashPublicKeyHash * MachineState.VALUE_SIZE : "addrDashPublicKeyHash incorrect";
+		dataByteBuffer.put(Bytes.ensureCapacity(dashPublicKeyHash, 32, 0));
+
+		// Redeem Qort amount
+		assert dataByteBuffer.position() == addrQortAmount * MachineState.VALUE_SIZE : "addrQortAmount incorrect";
+		dataByteBuffer.putLong(qortAmount);
+
+		// Expected Dash amount
+		assert dataByteBuffer.position() == addrDashAmount * MachineState.VALUE_SIZE : "addrDashAmount incorrect";
+		dataByteBuffer.putLong(dashAmount);
+
+		// Suggested trade timeout (minutes)
+		assert dataByteBuffer.position() == addrTradeTimeout * MachineState.VALUE_SIZE : "addrTradeTimeout incorrect";
+		dataByteBuffer.putLong(tradeTimeout);
+
+		// We're only interested in MESSAGE transactions
+		assert dataByteBuffer.position() == addrMessageTxnType * MachineState.VALUE_SIZE : "addrMessageTxnType incorrect";
+		dataByteBuffer.putLong(API.ATTransactionType.MESSAGE.value);
+
+		// Expected length of 'trade' MESSAGE data from AT creator
+		assert dataByteBuffer.position() == addrExpectedTradeMessageLength * MachineState.VALUE_SIZE : "addrExpectedTradeMessageLength incorrect";
+		dataByteBuffer.putLong(TRADE_MESSAGE_LENGTH);
+
+		// Expected length of 'redeem' MESSAGE data from trade partner
+		assert dataByteBuffer.position() == addrExpectedRedeemMessageLength * MachineState.VALUE_SIZE : "addrExpectedRedeemMessageLength incorrect";
+		dataByteBuffer.putLong(REDEEM_MESSAGE_LENGTH);
+
+		// Index into data segment of AT creator's address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrCreatorAddressPointer * MachineState.VALUE_SIZE : "addrCreatorAddressPointer incorrect";
+		dataByteBuffer.putLong(addrCreatorAddress1);
+
+		// Index into data segment of partner's Qortal address, used by SET_B_IND
+		assert dataByteBuffer.position() == addrQortalPartnerAddressPointer * MachineState.VALUE_SIZE : "addrQortalPartnerAddressPointer incorrect";
+		dataByteBuffer.putLong(addrQortalPartnerAddress1);
+
+		// Index into data segment of (temporary) transaction's sender's address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrMessageSenderPointer * MachineState.VALUE_SIZE : "addrMessageSenderPointer incorrect";
+		dataByteBuffer.putLong(addrMessageSender1);
+
+		// Offset into 'trade' MESSAGE data payload for extracting partner's Dash PKH
+		assert dataByteBuffer.position() == addrTradeMessagePartnerDashPKHOffset * MachineState.VALUE_SIZE : "addrTradeMessagePartnerDashPKHOffset incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Index into data segment of partner's Dash PKH, used by GET_B_IND
+		assert dataByteBuffer.position() == addrPartnerDashPKHPointer * MachineState.VALUE_SIZE : "addrPartnerDashPKHPointer incorrect";
+		dataByteBuffer.putLong(addrPartnerDashPKH);
+
+		// Offset into 'trade' MESSAGE data payload for extracting hash-of-secret-A
+		assert dataByteBuffer.position() == addrTradeMessageHashOfSecretAOffset * MachineState.VALUE_SIZE : "addrTradeMessageHashOfSecretAOffset incorrect";
+		dataByteBuffer.putLong(64L);
+
+		// Index into data segment to hash of secret A, used by GET_B_IND
+		assert dataByteBuffer.position() == addrHashOfSecretAPointer * MachineState.VALUE_SIZE : "addrHashOfSecretAPointer incorrect";
+		dataByteBuffer.putLong(addrHashOfSecretA);
+
+		// Offset into 'redeem' MESSAGE data payload for extracting Qortal receiving address
+		assert dataByteBuffer.position() == addrRedeemMessageReceivingAddressOffset * MachineState.VALUE_SIZE : "addrRedeemMessageReceivingAddressOffset incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Source location and length for hashing any passed secret
+		assert dataByteBuffer.position() == addrMessageDataPointer * MachineState.VALUE_SIZE : "addrMessageDataPointer incorrect";
+		dataByteBuffer.putLong(addrMessageData);
+		assert dataByteBuffer.position() == addrMessageDataLength * MachineState.VALUE_SIZE : "addrMessageDataLength incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Pointer into data segment of where to save partner's receiving Qortal address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrPartnerReceivingAddressPointer * MachineState.VALUE_SIZE : "addrPartnerReceivingAddressPointer incorrect";
+		dataByteBuffer.putLong(addrPartnerReceivingAddress);
+
+		assert dataByteBuffer.position() == addrEndOfConstants * MachineState.VALUE_SIZE : "dataByteBuffer position not at end of constants";
+
+		// Code labels
+		Integer labelRefund = null;
+
+		Integer labelTradeTxnLoop = null;
+		Integer labelCheckTradeTxn = null;
+		Integer labelCheckCancelTxn = null;
+		Integer labelNotTradeNorCancelTxn = null;
+		Integer labelCheckNonRefundTradeTxn = null;
+		Integer labelTradeTxnExtract = null;
+		Integer labelRedeemTxnLoop = null;
+		Integer labelCheckRedeemTxn = null;
+		Integer labelCheckRedeemTxnSender = null;
+		Integer labelPayout = null;
+
+		ByteBuffer codeByteBuffer = ByteBuffer.allocate(768);
+
+		// Two-pass version
+		for (int pass = 0; pass < 2; ++pass) {
+			codeByteBuffer.clear();
+
+			try {
+				/* Initialization */
+
+				// Use AT creation 'timestamp' as starting point for finding transactions sent to AT
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_CREATION_TIMESTAMP, addrLastTxnTimestamp));
+
+				// Load B register with AT creator's address so we can save it into addrCreatorAddress1-4
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_CREATOR_INTO_B));
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrCreatorAddressPointer));
+
+				// Set restart position to after this opcode
+				codeByteBuffer.put(OpCode.SET_PCS.compile());
+
+				/* Loop, waiting for message from AT creator's trade address containing trade partner details, or AT owner's address to cancel offer */
+
+				/* Transaction processing loop */
+				labelTradeTxnLoop = codeByteBuffer.position();
+
+				/* NOP - to ensure DASH ACCT is unique */
+				codeByteBuffer.put(OpCode.NOP.compile());
+
+				/* Sleep until message arrives */
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.SLEEP_UNTIL_MESSAGE.value, addrLastTxnTimestamp));
+
+				// Find next transaction (if any) to this AT since the last one (referenced by addrLastTxnTimestamp)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PUT_TX_AFTER_TIMESTAMP_INTO_A, addrLastTxnTimestamp));
+				// If no transaction found, A will be zero. If A is zero, set addrResult to 1, otherwise 0.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.CHECK_A_IS_ZERO, addrResult));
+				// If addrResult is zero (i.e. A is non-zero, transaction was found) then go check transaction
+				codeByteBuffer.put(OpCode.BZR_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelCheckTradeTxn)));
+				// Stop and wait for next block
+				codeByteBuffer.put(OpCode.STP_IMD.compile());
+
+				/* Check transaction */
+				labelCheckTradeTxn = codeByteBuffer.position();
+
+				// Update our 'last found transaction's timestamp' using 'timestamp' from transaction
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TIMESTAMP_FROM_TX_IN_A, addrLastTxnTimestamp));
+				// Extract transaction type (message/payment) from transaction and save type in addrTxnType
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TYPE_FROM_TX_IN_A, addrTxnType));
+				// If transaction type is not MESSAGE type then go look for another transaction
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrTxnType, addrMessageTxnType, calcOffset(codeByteBuffer, labelTradeTxnLoop)));
+
+				/* Check transaction's sender. We're expecting AT creator's trade address for 'trade' message, or AT creator's own address for 'cancel' message. */
+
+				// Extract sender address from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_ADDRESS_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageSender1 (as pointed to by addrMessageSenderPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageSenderPointer));
+				// Compare each part of message sender's address with AT creator's trade address. If they don't match, check for cancel situation.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrCreatorTradeAddress1, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrCreatorTradeAddress2, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrCreatorTradeAddress3, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrCreatorTradeAddress4, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				// Message sender's address matches AT creator's trade address so go process 'trade' message
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelCheckNonRefundTradeTxn == null ? 0 : labelCheckNonRefundTradeTxn));
+
+				/* Checking message sender for possible cancel message */
+				labelCheckCancelTxn = codeByteBuffer.position();
+
+				// Compare each part of message sender's address with AT creator's address. If they don't match, look for another transaction.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrCreatorAddress1, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrCreatorAddress2, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrCreatorAddress3, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrCreatorAddress4, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				// Partner address is AT creator's address, so cancel offer and finish.
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.CANCELLED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+
+				/* Not trade nor cancel message */
+				labelNotTradeNorCancelTxn = codeByteBuffer.position();
+
+				// Loop to find another transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelTradeTxnLoop == null ? 0 : labelTradeTxnLoop));
+
+				/* Possible switch-to-trade-mode message */
+				labelCheckNonRefundTradeTxn = codeByteBuffer.position();
+
+				// Check 'trade' message we received has expected number of message bytes
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(QortalFunctionCode.GET_MESSAGE_LENGTH_FROM_TX_IN_A.value, addrMessageLength));
+				// If message length matches, branch to info extraction code
+				codeByteBuffer.put(OpCode.BEQ_DAT.compile(addrMessageLength, addrExpectedTradeMessageLength, calcOffset(codeByteBuffer, labelTradeTxnExtract)));
+				// Message length didn't match - go back to finding another 'trade' MESSAGE transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelTradeTxnLoop == null ? 0 : labelTradeTxnLoop));
+
+				/* Extracting info from 'trade' MESSAGE transaction */
+				labelTradeTxnExtract = codeByteBuffer.position();
+
+				// Extract message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_MESSAGE_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrQortalPartnerAddress1 (as pointed to by addrQortalPartnerAddressPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrQortalPartnerAddressPointer));
+
+				// Extract trade partner's Dash public key hash (PKH) from message into B
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrTradeMessagePartnerDashPKHOffset));
+				// Store partner's Dash PKH (we only really use values from B1-B3)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrPartnerDashPKHPointer));
+				// Extract AT trade timeout (minutes) (from B4)
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_B4, addrRefundTimeout));
+
+				// Grab next 32 bytes
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrTradeMessageHashOfSecretAOffset));
+
+				// Extract hash-of-secret-A (we only really use values from B1-B3)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrHashOfSecretAPointer));
+				// Extract lockTime-A (from B4)
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_B4, addrLockTimeA));
+
+				// Calculate trade timeout refund 'timestamp' by adding addrRefundTimeout minutes to this transaction's 'timestamp', then save into addrRefundTimestamp
+				codeByteBuffer.put(OpCode.EXT_FUN_RET_DAT_2.compile(FunctionCode.ADD_MINUTES_TO_TIMESTAMP, addrRefundTimestamp, addrLastTxnTimestamp, addrRefundTimeout));
+
+				/* We are in 'trade mode' */
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.TRADING.value));
+
+				// Set restart position to after this opcode
+				codeByteBuffer.put(OpCode.SET_PCS.compile());
+
+				/* Loop, waiting for trade timeout or 'redeem' MESSAGE from Qortal trade partner */
+
+				// Fetch current block 'timestamp'
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_BLOCK_TIMESTAMP, addrBlockTimestamp));
+				// If we're not past refund 'timestamp' then look for next transaction
+				codeByteBuffer.put(OpCode.BLT_DAT.compile(addrBlockTimestamp, addrRefundTimestamp, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				// We're past refund 'timestamp' so go refund everything back to AT creator
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRefund == null ? 0 : labelRefund));
+
+				/* Transaction processing loop */
+				labelRedeemTxnLoop = codeByteBuffer.position();
+
+				// Find next transaction to this AT since the last one (if any)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PUT_TX_AFTER_TIMESTAMP_INTO_A, addrLastTxnTimestamp));
+				// If no transaction found, A will be zero. If A is zero, set addrComparator to 1, otherwise 0.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.CHECK_A_IS_ZERO, addrResult));
+				// If addrResult is zero (i.e. A is non-zero, transaction was found) then go check transaction
+				codeByteBuffer.put(OpCode.BZR_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelCheckRedeemTxn)));
+				// Stop and wait for next block
+				codeByteBuffer.put(OpCode.STP_IMD.compile());
+
+				/* Check transaction */
+				labelCheckRedeemTxn = codeByteBuffer.position();
+
+				// Update our 'last found transaction's timestamp' using 'timestamp' from transaction
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TIMESTAMP_FROM_TX_IN_A, addrLastTxnTimestamp));
+				// Extract transaction type (message/payment) from transaction and save type in addrTxnType
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TYPE_FROM_TX_IN_A, addrTxnType));
+				// If transaction type is not MESSAGE type then go look for another transaction
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrTxnType, addrMessageTxnType, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+
+				/* Check message payload length */
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(QortalFunctionCode.GET_MESSAGE_LENGTH_FROM_TX_IN_A.value, addrMessageLength));
+				// If message length matches, branch to sender checking code
+				codeByteBuffer.put(OpCode.BEQ_DAT.compile(addrMessageLength, addrExpectedRedeemMessageLength, calcOffset(codeByteBuffer, labelCheckRedeemTxnSender)));
+				// Message length didn't match - go back to finding another 'redeem' MESSAGE transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRedeemTxnLoop == null ? 0 : labelRedeemTxnLoop));
+
+				/* Check transaction's sender */
+				labelCheckRedeemTxnSender = codeByteBuffer.position();
+
+				// Extract sender address from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_ADDRESS_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageSender1 (as pointed to by addrMessageSenderPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageSenderPointer));
+				// Compare each part of transaction's sender's address with expected address. If they don't match, look for another transaction.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrQortalPartnerAddress1, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrQortalPartnerAddress2, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrQortalPartnerAddress3, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrQortalPartnerAddress4, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+
+				/* Check 'secret-A' in transaction's message */
+
+				// Extract secret-A from first 32 bytes of message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_MESSAGE_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageData (as pointed to by addrMessageDataPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageDataPointer));
+				// Load B register with expected hash result (as pointed to by addrHashOfSecretAPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.SET_B_IND, addrHashOfSecretAPointer));
+				// Perform HASH160 using source data at addrMessageData. (Location and length specified via addrMessageDataPointer and addrMessageDataLength).
+				// Save the equality result (1 if they match, 0 otherwise) into addrResult.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET_DAT_2.compile(FunctionCode.CHECK_HASH160_WITH_B, addrResult, addrMessageDataPointer, addrMessageDataLength));
+				// If hashes don't match, addrResult will be zero so go find another transaction
+				codeByteBuffer.put(OpCode.BNZ_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelPayout)));
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRedeemTxnLoop == null ? 0 : labelRedeemTxnLoop));
+
+				/* Success! Pay arranged amount to receiving address */
+				labelPayout = codeByteBuffer.position();
+
+				// Extract Qortal receiving address from next 32 bytes of message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrRedeemMessageReceivingAddressOffset));
+				// Save B register into data segment starting at addrPartnerReceivingAddress (as pointed to by addrPartnerReceivingAddressPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrPartnerReceivingAddressPointer));
+				// Pay AT's balance to receiving address
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PAY_TO_ADDRESS_IN_B, addrQortAmount));
+				// Set redeemed mode
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.REDEEMED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+
+				// Fall-through to refunding any remaining balance back to AT creator
+
+				/* Refund balance back to AT creator */
+				labelRefund = codeByteBuffer.position();
+
+				// Set refunded mode
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.REFUNDED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+			} catch (CompilationException e) {
+				throw new IllegalStateException("Unable to compile DASH-QORT ACCT?", e);
+			}
+		}
+
+		codeByteBuffer.flip();
+
+		byte[] codeBytes = new byte[codeByteBuffer.limit()];
+		codeByteBuffer.get(codeBytes);
+
+		assert Arrays.equals(Crypto.digest(codeBytes), DashACCTv3.CODE_BYTES_HASH)
+			: String.format("BTCACCT.CODE_BYTES_HASH mismatch: expected %s, actual %s", HashCode.fromBytes(CODE_BYTES_HASH), HashCode.fromBytes(Crypto.digest(codeBytes)));
+
+		final short ciyamAtVersion = 2;
+		final short numCallStackPages = 0;
+		final short numUserStackPages = 0;
+		final long minActivationAmount = 0L;
+
+		return MachineState.toCreationBytes(ciyamAtVersion, codeBytes, dataByteBuffer.array(), numCallStackPages, numUserStackPages, minActivationAmount);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	@Override
+	public CrossChainTradeData populateTradeData(Repository repository, ATData atData) throws DataException {
+		ATStateData atStateData = repository.getATRepository().getLatestATState(atData.getATAddress());
+		return populateTradeData(repository, atData.getCreatorPublicKey(), atData.getCreation(), atStateData);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	@Override
+	public CrossChainTradeData populateTradeData(Repository repository, ATStateData atStateData) throws DataException {
+		ATData atData = repository.getATRepository().fromATAddress(atStateData.getATAddress());
+		return populateTradeData(repository, atData.getCreatorPublicKey(), atData.getCreation(), atStateData);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	public CrossChainTradeData populateTradeData(Repository repository, byte[] creatorPublicKey, long creationTimestamp, ATStateData atStateData) throws DataException {
+		byte[] addressBytes = new byte[25]; // for general use
+		String atAddress = atStateData.getATAddress();
+
+		CrossChainTradeData tradeData = new CrossChainTradeData();
+
+		tradeData.foreignBlockchain = SupportedBlockchain.DASH.name();
+		tradeData.acctName = NAME;
+
+		tradeData.qortalAtAddress = atAddress;
+		tradeData.qortalCreator = Crypto.toAddress(creatorPublicKey);
+		tradeData.creationTimestamp = creationTimestamp;
+
+		Account atAccount = new Account(repository, atAddress);
+		tradeData.qortBalance = atAccount.getConfirmedBalance(Asset.QORT);
+
+		byte[] stateData = atStateData.getStateData();
+		ByteBuffer dataByteBuffer = ByteBuffer.wrap(stateData);
+		dataByteBuffer.position(MachineState.HEADER_LENGTH);
+
+		/* Constants */
+
+		// Skip creator's trade address
+		dataByteBuffer.get(addressBytes);
+		tradeData.qortalCreatorTradeAddress = Base58.encode(addressBytes);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - addressBytes.length);
+
+		// Creator's Dash/foreign public key hash
+		tradeData.creatorForeignPKH = new byte[20];
+		dataByteBuffer.get(tradeData.creatorForeignPKH);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - tradeData.creatorForeignPKH.length); // skip to 32 bytes
+
+		// We don't use secret-B
+		tradeData.hashOfSecretB = null;
+
+		// Redeem payout
+		tradeData.qortAmount = dataByteBuffer.getLong();
+
+		// Expected DASH amount
+		tradeData.expectedForeignAmount = dataByteBuffer.getLong();
+
+		// Trade timeout
+		tradeData.tradeTimeout = (int) dataByteBuffer.getLong();
+
+		// Skip MESSAGE transaction type
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip expected 'trade' message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip expected 'redeem' message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to creator's address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's Qortal trade address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to message sender
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'trade' message data offset for partner's Dash PKH
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's Dash PKH
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'trade' message data offset for hash-of-secret-A
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to hash-of-secret-A
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'redeem' message data offset for partner's Qortal receiving address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to message data
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip message data length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's receiving address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		/* End of constants / begin variables */
+
+		// Skip AT creator's address
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Partner's trade address (if present)
+		dataByteBuffer.get(addressBytes);
+		String qortalRecipient = Base58.encode(addressBytes);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - addressBytes.length);
+
+		// Potential lockTimeA (if in trade mode)
+		int lockTimeA = (int) dataByteBuffer.getLong();
+
+		// AT refund timeout (probably only useful for debugging)
+		int refundTimeout = (int) dataByteBuffer.getLong();
+
+		// Trade-mode refund timestamp (AT 'timestamp' converted to Qortal block height)
+		long tradeRefundTimestamp = dataByteBuffer.getLong();
+
+		// Skip last transaction timestamp
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip block timestamp
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip transaction type
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary result
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary message sender
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Skip message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary message data
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Potential hash160 of secret A
+		byte[] hashOfSecretA = new byte[20];
+		dataByteBuffer.get(hashOfSecretA);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - hashOfSecretA.length); // skip to 32 bytes
+
+		// Potential partner's Dash PKH
+		byte[] partnerDashPKH = new byte[20];
+		dataByteBuffer.get(partnerDashPKH);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - partnerDashPKH.length); // skip to 32 bytes
+
+		// Partner's receiving address (if present)
+		byte[] partnerReceivingAddress = new byte[25];
+		dataByteBuffer.get(partnerReceivingAddress);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - partnerReceivingAddress.length); // skip to 32 bytes
+
+		// Trade AT's 'mode'
+		long modeValue = dataByteBuffer.getLong();
+		AcctMode mode = AcctMode.valueOf((int) (modeValue & 0xffL));
+
+		/* End of variables */
+
+		if (mode != null && mode != AcctMode.OFFERING) {
+			tradeData.mode = mode;
+			tradeData.refundTimeout = refundTimeout;
+			tradeData.tradeRefundHeight = new Timestamp(tradeRefundTimestamp).blockHeight;
+			tradeData.qortalPartnerAddress = qortalRecipient;
+			tradeData.hashOfSecretA = hashOfSecretA;
+			tradeData.partnerForeignPKH = partnerDashPKH;
+			tradeData.lockTimeA = lockTimeA;
+
+			if (mode == AcctMode.REDEEMED)
+				tradeData.qortalPartnerReceivingAddress = Base58.encode(partnerReceivingAddress);
+		} else {
+			tradeData.mode = AcctMode.OFFERING;
+		}
+
+		tradeData.duplicateDeprecated();
+
+		return tradeData;
+	}
+
+	/** Returns 'offer' MESSAGE payload for trade partner to send to AT creator's trade address. */
+	public static byte[] buildOfferMessage(byte[] partnerBitcoinPKH, byte[] hashOfSecretA, int lockTimeA) {
+		byte[] lockTimeABytes = BitTwiddling.toBEByteArray((long) lockTimeA);
+		return Bytes.concat(partnerBitcoinPKH, hashOfSecretA, lockTimeABytes);
+	}
+
+	/** Returns info extracted from 'offer' MESSAGE payload sent by trade partner to AT creator's trade address, or null if not valid. */
+	public static OfferMessageData extractOfferMessageData(byte[] messageData) {
+		if (messageData == null || messageData.length != OFFER_MESSAGE_LENGTH)
+			return null;
+
+		OfferMessageData offerMessageData = new OfferMessageData();
+		offerMessageData.partnerDashPKH = Arrays.copyOfRange(messageData, 0, 20);
+		offerMessageData.hashOfSecretA = Arrays.copyOfRange(messageData, 20, 40);
+		offerMessageData.lockTimeA = BitTwiddling.longFromBEBytes(messageData, 40);
+
+		return offerMessageData;
+	}
+
+	/** Returns 'trade' MESSAGE payload for AT creator to send to AT. */
+	public static byte[] buildTradeMessage(String partnerQortalTradeAddress, byte[] partnerBitcoinPKH, byte[] hashOfSecretA, int lockTimeA, int refundTimeout) {
+		byte[] data = new byte[TRADE_MESSAGE_LENGTH];
+		byte[] partnerQortalAddressBytes = Base58.decode(partnerQortalTradeAddress);
+		byte[] lockTimeABytes = BitTwiddling.toBEByteArray((long) lockTimeA);
+		byte[] refundTimeoutBytes = BitTwiddling.toBEByteArray((long) refundTimeout);
+
+		System.arraycopy(partnerQortalAddressBytes, 0, data, 0, partnerQortalAddressBytes.length);
+		System.arraycopy(partnerBitcoinPKH, 0, data, 32, partnerBitcoinPKH.length);
+		System.arraycopy(refundTimeoutBytes, 0, data, 56, refundTimeoutBytes.length);
+		System.arraycopy(hashOfSecretA, 0, data, 64, hashOfSecretA.length);
+		System.arraycopy(lockTimeABytes, 0, data, 88, lockTimeABytes.length);
+
+		return data;
+	}
+
+	/** Returns 'cancel' MESSAGE payload for AT creator to cancel trade AT. */
+	@Override
+	public byte[] buildCancelMessage(String creatorQortalAddress) {
+		byte[] data = new byte[CANCEL_MESSAGE_LENGTH];
+		byte[] creatorQortalAddressBytes = Base58.decode(creatorQortalAddress);
+
+		System.arraycopy(creatorQortalAddressBytes, 0, data, 0, creatorQortalAddressBytes.length);
+
+		return data;
+	}
+
+	/** Returns 'redeem' MESSAGE payload for trade partner to send to AT. */
+	public static byte[] buildRedeemMessage(byte[] secretA, String qortalReceivingAddress) {
+		byte[] data = new byte[REDEEM_MESSAGE_LENGTH];
+		byte[] qortalReceivingAddressBytes = Base58.decode(qortalReceivingAddress);
+
+		System.arraycopy(secretA, 0, data, 0, secretA.length);
+		System.arraycopy(qortalReceivingAddressBytes, 0, data, 32, qortalReceivingAddressBytes.length);
+
+		return data;
+	}
+
+	/** Returns refund timeout (minutes) based on trade partner's 'offer' MESSAGE timestamp and P2SH-A locktime. */
+	public static int calcRefundTimeout(long offerMessageTimestamp, int lockTimeA) {
+		// refund should be triggered halfway between offerMessageTimestamp and lockTimeA
+		return (int) ((lockTimeA - (offerMessageTimestamp / 1000L)) / 2L / 60L);
+	}
+
+	@Override
+	public byte[] findSecretA(Repository repository, CrossChainTradeData crossChainTradeData) throws DataException {
+		String atAddress = crossChainTradeData.qortalAtAddress;
+		String redeemerAddress = crossChainTradeData.qortalPartnerAddress;
+
+		// We don't have partner's public key so we check every message to AT
+		List<MessageTransactionData> messageTransactionsData = repository.getMessageRepository().getMessagesByParticipants(null, atAddress, null, null, null);
+		if (messageTransactionsData == null)
+			return null;
+
+		// Find 'redeem' message
+		for (MessageTransactionData messageTransactionData : messageTransactionsData) {
+			// Check message payload type/encryption
+			if (messageTransactionData.isText() || messageTransactionData.isEncrypted())
+				continue;
+
+			// Check message payload size
+			byte[] messageData = messageTransactionData.getData();
+			if (messageData.length != REDEEM_MESSAGE_LENGTH)
+				// Wrong payload length
+				continue;
+
+			// Check sender
+			if (!Crypto.toAddress(messageTransactionData.getSenderPublicKey()).equals(redeemerAddress))
+				// Wrong sender;
+				continue;
+
+			// Extract secretA
+			byte[] secretA = new byte[32];
+			System.arraycopy(messageData, 0, secretA, 0, secretA.length);
+
+			byte[] hashOfSecretA = Crypto.hash160(secretA);
+			if (!Arrays.equals(hashOfSecretA, crossChainTradeData.hashOfSecretA))
+				continue;
+
+			return secretA;
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/org/qortal/crosschain/Firo.java
+++ b/src/main/java/org/qortal/crosschain/Firo.java
@@ -1,0 +1,176 @@
+package org.qortal.crosschain;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
+// import org.libdohj.params.FiroMainNetParams;
+import org.bitcoinj.params.MainNetParams; // temporary, not for use
+import org.qortal.crosschain.ElectrumX.Server;
+import org.qortal.crosschain.ChainableServer.ConnectionType;
+import org.qortal.settings.Settings;
+
+public class Firo extends Bitcoiny {
+
+	public static final String CURRENCY_CODE = "FIRO";
+
+	private static final Coin DEFAULT_FEE_PER_KB = Coin.valueOf(1100); // 0.00001100 FIRO per 1000 bytes
+
+	private static final long MINIMUM_ORDER_AMOUNT = 1000000; // 0.01 FIRO minimum order, to avoid dust errors
+
+	// Temporary values until a dynamic fee system is written.
+	private static final long MAINNET_FEE = 1000L;
+	private static final long NON_MAINNET_FEE = 1000L; // enough for TESTNET3 and should be OK for REGTEST
+
+	private static final Map<ConnectionType, Integer> DEFAULT_ELECTRUMX_PORTS = new EnumMap<>(ConnectionType.class);
+	static {
+		DEFAULT_ELECTRUMX_PORTS.put(ConnectionType.TCP, 50001);
+		DEFAULT_ELECTRUMX_PORTS.put(ConnectionType.SSL, 50002);
+	}
+
+	public enum FiroNet {
+		MAIN {
+			@Override
+			public NetworkParameters getParams() {
+				return MainNetParams.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(
+						// Servers chosen on NO BASIS WHATSOEVER from various sources!
+						// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=firo
+						// new Server("electrumx.firo.org", ConnectionType.SSL, 50002),
+						new Server("electrumx01.firo.org", ConnectionType.SSL, 50002),
+						new Server("electrumx02.firo.org", ConnectionType.SSL, 50002),
+						new Server("electrumx03.firo.org", ConnectionType.SSL, 50002),
+						new Server("electrumx05.firo.org", ConnectionType.SSL, 50002));
+			}
+
+			@Override
+			public String getGenesisHash() {
+				return "4381deb85b1b2c9843c222944b616d997516dcbd6a964e1eaf0def0830695233";
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				// TODO: This will need to be replaced with something better in the near future!
+				return MAINNET_FEE;
+			}
+		},
+		TEST3 {
+			@Override
+			public NetworkParameters getParams() {
+				return TestNet3Params.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(); // TODO: find testnet servers
+			}
+
+			@Override
+			public String getGenesisHash() {
+				return "aa22adcc12becaf436027ffe62a8fb21b234c58c23865291e5dc52cf53f64fca";
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				return NON_MAINNET_FEE;
+			}
+		},
+		REGTEST {
+			@Override
+			public NetworkParameters getParams() {
+				return RegTestParams.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(
+						new Server("localhost", ConnectionType.TCP, 50001),
+						new Server("localhost", ConnectionType.SSL, 50002));
+			}
+
+			@Override
+			public String getGenesisHash() {
+				// This is unique to each regtest instance
+				return null;
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				return NON_MAINNET_FEE;
+			}
+		};
+
+		public abstract NetworkParameters getParams();
+		public abstract Collection<Server> getServers();
+		public abstract String getGenesisHash();
+		public abstract long getP2shFee(Long timestamp) throws ForeignBlockchainException;
+	}
+
+	private static Firo instance;
+
+	private final FiroNet firoNet;
+
+	// Constructors and instance
+
+	private Firo(FiroNet firoNet, BitcoinyBlockchainProvider blockchain, Context bitcoinjContext, String currencyCode) {
+		super(blockchain, bitcoinjContext, currencyCode);
+		this.firoNet = firoNet;
+
+		LOGGER.info(() -> String.format("Starting Firo support using %s", this.firoNet.name()));
+	}
+
+	public static synchronized Firo getInstance() {
+		if (instance == null) {
+			FiroNet firoNet = Settings.getInstance().getFiroNet();
+
+			BitcoinyBlockchainProvider electrumX = new ElectrumX("Firo-" + firoNet.name(), firoNet.getGenesisHash(), firoNet.getServers(), DEFAULT_ELECTRUMX_PORTS);
+			Context bitcoinjContext = new Context(firoNet.getParams());
+
+			instance = new Firo(firoNet, electrumX, bitcoinjContext, CURRENCY_CODE);
+
+			electrumX.setBlockchain(instance);
+		}
+
+		return instance;
+	}
+
+	// Getters & setters
+
+	public static synchronized void resetForTesting() {
+		instance = null;
+	}
+
+	// Actual useful methods for use by other classes
+
+	@Override
+	public Coin getFeePerKb() {
+		return DEFAULT_FEE_PER_KB;
+	}
+
+	@Override
+	public long getMinimumOrderAmount() {
+		return MINIMUM_ORDER_AMOUNT;
+	}
+
+	/**
+	 * Returns estimated FIRO fee, in sats per 1000bytes, optionally for historic timestamp.
+	 * 
+	 * @param timestamp optional milliseconds since epoch, or null for 'now'
+	 * @return sats per 1000bytes, or throws ForeignBlockchainException if something went wrong
+	 */
+	@Override
+	public long getP2shFee(Long timestamp) throws ForeignBlockchainException {
+		return this.firoNet.getP2shFee(timestamp);
+	}
+
+}

--- a/src/main/java/org/qortal/crosschain/FiroACCTv3.java
+++ b/src/main/java/org/qortal/crosschain/FiroACCTv3.java
@@ -1,0 +1,858 @@
+package org.qortal.crosschain;
+
+import com.google.common.hash.HashCode;
+import com.google.common.primitives.Bytes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ciyam.at.*;
+import org.qortal.account.Account;
+import org.qortal.asset.Asset;
+import org.qortal.at.QortalFunctionCode;
+import org.qortal.crypto.Crypto;
+import org.qortal.data.at.ATData;
+import org.qortal.data.at.ATStateData;
+import org.qortal.data.crosschain.CrossChainTradeData;
+import org.qortal.data.transaction.MessageTransactionData;
+import org.qortal.repository.DataException;
+import org.qortal.repository.Repository;
+import org.qortal.utils.Base58;
+import org.qortal.utils.BitTwiddling;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.ciyam.at.OpCode.calcOffset;
+
+/**
+ * Cross-chain trade AT
+ * 
+ * <p>
+ * <ul>
+ * <li>Bob generates Firo & Qortal 'trade' keys
+ * 		<ul>
+ * 			<li>private key required to sign P2SH redeem tx</li>
+ * 			<li>private key could be used to create 'secret' (e.g. double-SHA256)</li>
+ * 			<li>encrypted private key could be stored in Qortal AT for access by Bob from any node</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob deploys Qortal AT
+ * 		<ul>
+ * 		</ul>
+ * </li>
+ * <li>Alice finds Qortal AT and wants to trade
+ * 		<ul>
+ * 			<li>Alice generates Firo & Qortal 'trade' keys</li>
+ * 			<li>Alice funds Firo P2SH-A</li>
+ * 			<li>Alice sends 'offer' MESSAGE to Bob from her Qortal trade address, containing:
+ * 				<ul>
+ * 					<li>hash-of-secret-A</li>
+ * 					<li>her 'trade' Firo PKH</li>
+ * 				</ul>
+ * 			</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob receives "offer" MESSAGE
+ * 		<ul>
+ * 			<li>Checks Alice's P2SH-A</li>
+ * 			<li>Sends 'trade' MESSAGE to Qortal AT from his trade address, containing:
+ * 				<ul>
+ * 					<li>Alice's trade Qortal address</li>
+ * 					<li>Alice's trade Firo PKH</li>
+ * 					<li>hash-of-secret-A</li>
+ * 				</ul>
+ * 			</li>
+ * 		</ul>
+ * </li>
+ * <li>Alice checks Qortal AT to confirm it's locked to her
+ * 		<ul>
+ * 			<li>Alice sends 'redeem' MESSAGE to Qortal AT from her trade address, containing:
+ * 				<ul>
+ * 					<li>secret-A</li>
+ * 					<li>Qortal receiving address of her chosing</li>
+ * 				</ul>
+ * 			</li>
+ * 			<li>AT's QORT funds are sent to Qortal receiving address</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob checks AT, extracts secret-A
+ * 		<ul>
+ * 			<li>Bob redeems P2SH-A using his Firo trade key and secret-A</li>
+ * 			<li>P2SH-A FIRO funds end up at Firo address determined by redeem transaction output(s)</li>
+ * 		</ul>
+ * </li>
+ * </ul>
+ */
+public class FiroACCTv3 implements ACCT {
+
+	private static final Logger LOGGER = LogManager.getLogger(FiroACCTv3.class);
+
+	public static final String NAME = FiroACCTv3.class.getSimpleName();
+	public static final byte[] CODE_BYTES_HASH = HashCode.fromString("6ac0f22499fbb5ec9d5b1ebaf736054671ba52552da6f5a9cbab50ddb5d15866").asBytes(); // SHA256 of AT code bytes
+
+	public static final int SECRET_LENGTH = 32;
+
+	/** <b>Value</b> offset into AT segment where 'mode' variable (long) is stored. (Multiply by MachineState.VALUE_SIZE for byte offset). */
+	private static final int MODE_VALUE_OFFSET = 61;
+	/** <b>Byte</b> offset into AT state data where 'mode' variable (long) is stored. */
+	public static final int MODE_BYTE_OFFSET = MachineState.HEADER_LENGTH + (MODE_VALUE_OFFSET * MachineState.VALUE_SIZE);
+
+	public static class OfferMessageData {
+		public byte[] partnerFiroPKH;
+		public byte[] hashOfSecretA;
+		public long lockTimeA;
+	}
+	public static final int OFFER_MESSAGE_LENGTH = 20 /*partnerFiroPKH*/ + 20 /*hashOfSecretA*/ + 8 /*lockTimeA*/;
+	public static final int TRADE_MESSAGE_LENGTH = 32 /*partner's Qortal trade address (padded from 25 to 32)*/
+			+ 24 /*partner's Firo PKH (padded from 20 to 24)*/
+			+ 8 /*AT trade timeout (minutes)*/
+			+ 24 /*hash of secret-A (padded from 20 to 24)*/
+			+ 8 /*lockTimeA*/;
+	public static final int REDEEM_MESSAGE_LENGTH = 32 /*secret-A*/ + 32 /*partner's Qortal receiving address padded from 25 to 32*/;
+	public static final int CANCEL_MESSAGE_LENGTH = 32 /*AT creator's Qortal address*/;
+
+	private static FiroACCTv3 instance;
+
+	private FiroACCTv3() {
+	}
+
+	public static synchronized FiroACCTv3 getInstance() {
+		if (instance == null)
+			instance = new FiroACCTv3();
+
+		return instance;
+	}
+
+	@Override
+	public byte[] getCodeBytesHash() {
+		return CODE_BYTES_HASH;
+	}
+
+	@Override
+	public int getModeByteOffset() {
+		return MODE_BYTE_OFFSET;
+	}
+
+	@Override
+	public ForeignBlockchain getBlockchain() {
+		return Firo.getInstance();
+	}
+
+	/**
+	 * Returns Qortal AT creation bytes for cross-chain trading AT.
+	 * <p>
+	 * <tt>tradeTimeout</tt> (minutes) is the time window for the trade partner to send the
+	 * 32-byte secret to the AT, before the AT automatically refunds the AT's creator.
+	 * 
+	 * @param creatorTradeAddress AT creator's trade Qortal address
+	 * @param firoPublicKeyHash 20-byte HASH160 of creator's trade Firo public key
+	 * @param qortAmount how much QORT to pay trade partner if they send correct 32-byte secrets to AT
+	 * @param firoAmount how much FIRO the AT creator is expecting to trade
+	 * @param tradeTimeout suggested timeout for entire trade
+	 */
+	public static byte[] buildQortalAT(String creatorTradeAddress, byte[] firoPublicKeyHash, long qortAmount, long firoAmount, int tradeTimeout) {
+		if (firoPublicKeyHash.length != 20)
+			throw new IllegalArgumentException("Firo public key hash should be 20 bytes");
+
+		// Labels for data segment addresses
+		int addrCounter = 0;
+
+		// Constants (with corresponding dataByteBuffer.put*() calls below)
+
+		final int addrCreatorTradeAddress1 = addrCounter++;
+		final int addrCreatorTradeAddress2 = addrCounter++;
+		final int addrCreatorTradeAddress3 = addrCounter++;
+		final int addrCreatorTradeAddress4 = addrCounter++;
+
+		final int addrFiroPublicKeyHash = addrCounter;
+		addrCounter += 4;
+
+		final int addrQortAmount = addrCounter++;
+		final int addrFiroAmount = addrCounter++;
+		final int addrTradeTimeout = addrCounter++;
+
+		final int addrMessageTxnType = addrCounter++;
+		final int addrExpectedTradeMessageLength = addrCounter++;
+		final int addrExpectedRedeemMessageLength = addrCounter++;
+
+		final int addrCreatorAddressPointer = addrCounter++;
+		final int addrQortalPartnerAddressPointer = addrCounter++;
+		final int addrMessageSenderPointer = addrCounter++;
+
+		final int addrTradeMessagePartnerFiroPKHOffset = addrCounter++;
+		final int addrPartnerFiroPKHPointer = addrCounter++;
+		final int addrTradeMessageHashOfSecretAOffset = addrCounter++;
+		final int addrHashOfSecretAPointer = addrCounter++;
+
+		final int addrRedeemMessageReceivingAddressOffset = addrCounter++;
+
+		final int addrMessageDataPointer = addrCounter++;
+		final int addrMessageDataLength = addrCounter++;
+
+		final int addrPartnerReceivingAddressPointer = addrCounter++;
+
+		final int addrEndOfConstants = addrCounter;
+
+		// Variables
+
+		final int addrCreatorAddress1 = addrCounter++;
+		final int addrCreatorAddress2 = addrCounter++;
+		final int addrCreatorAddress3 = addrCounter++;
+		final int addrCreatorAddress4 = addrCounter++;
+
+		final int addrQortalPartnerAddress1 = addrCounter++;
+		final int addrQortalPartnerAddress2 = addrCounter++;
+		final int addrQortalPartnerAddress3 = addrCounter++;
+		final int addrQortalPartnerAddress4 = addrCounter++;
+
+		final int addrLockTimeA = addrCounter++;
+		final int addrRefundTimeout = addrCounter++;
+		final int addrRefundTimestamp = addrCounter++;
+		final int addrLastTxnTimestamp = addrCounter++;
+		final int addrBlockTimestamp = addrCounter++;
+		final int addrTxnType = addrCounter++;
+		final int addrResult = addrCounter++;
+
+		final int addrMessageSender1 = addrCounter++;
+		final int addrMessageSender2 = addrCounter++;
+		final int addrMessageSender3 = addrCounter++;
+		final int addrMessageSender4 = addrCounter++;
+
+		final int addrMessageLength = addrCounter++;
+
+		final int addrMessageData = addrCounter;
+		addrCounter += 4;
+
+		final int addrHashOfSecretA = addrCounter;
+		addrCounter += 4;
+
+		final int addrPartnerFiroPKH = addrCounter;
+		addrCounter += 4;
+
+		final int addrPartnerReceivingAddress = addrCounter;
+		addrCounter += 4;
+
+		final int addrMode = addrCounter++;
+		assert addrMode == MODE_VALUE_OFFSET : String.format("addrMode %d does not match MODE_VALUE_OFFSET %d", addrMode, MODE_VALUE_OFFSET);
+
+		// Data segment
+		ByteBuffer dataByteBuffer = ByteBuffer.allocate(addrCounter * MachineState.VALUE_SIZE);
+
+		// AT creator's trade Qortal address, decoded from Base58
+		assert dataByteBuffer.position() == addrCreatorTradeAddress1 * MachineState.VALUE_SIZE : "addrCreatorTradeAddress1 incorrect";
+		byte[] creatorTradeAddressBytes = Base58.decode(creatorTradeAddress);
+		dataByteBuffer.put(Bytes.ensureCapacity(creatorTradeAddressBytes, 32, 0));
+
+		// Firo public key hash
+		assert dataByteBuffer.position() == addrFiroPublicKeyHash * MachineState.VALUE_SIZE : "addrFiroPublicKeyHash incorrect";
+		dataByteBuffer.put(Bytes.ensureCapacity(firoPublicKeyHash, 32, 0));
+
+		// Redeem Qort amount
+		assert dataByteBuffer.position() == addrQortAmount * MachineState.VALUE_SIZE : "addrQortAmount incorrect";
+		dataByteBuffer.putLong(qortAmount);
+
+		// Expected Firo amount
+		assert dataByteBuffer.position() == addrFiroAmount * MachineState.VALUE_SIZE : "addrFiroAmount incorrect";
+		dataByteBuffer.putLong(firoAmount);
+
+		// Suggested trade timeout (minutes)
+		assert dataByteBuffer.position() == addrTradeTimeout * MachineState.VALUE_SIZE : "addrTradeTimeout incorrect";
+		dataByteBuffer.putLong(tradeTimeout);
+
+		// We're only interested in MESSAGE transactions
+		assert dataByteBuffer.position() == addrMessageTxnType * MachineState.VALUE_SIZE : "addrMessageTxnType incorrect";
+		dataByteBuffer.putLong(API.ATTransactionType.MESSAGE.value);
+
+		// Expected length of 'trade' MESSAGE data from AT creator
+		assert dataByteBuffer.position() == addrExpectedTradeMessageLength * MachineState.VALUE_SIZE : "addrExpectedTradeMessageLength incorrect";
+		dataByteBuffer.putLong(TRADE_MESSAGE_LENGTH);
+
+		// Expected length of 'redeem' MESSAGE data from trade partner
+		assert dataByteBuffer.position() == addrExpectedRedeemMessageLength * MachineState.VALUE_SIZE : "addrExpectedRedeemMessageLength incorrect";
+		dataByteBuffer.putLong(REDEEM_MESSAGE_LENGTH);
+
+		// Index into data segment of AT creator's address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrCreatorAddressPointer * MachineState.VALUE_SIZE : "addrCreatorAddressPointer incorrect";
+		dataByteBuffer.putLong(addrCreatorAddress1);
+
+		// Index into data segment of partner's Qortal address, used by SET_B_IND
+		assert dataByteBuffer.position() == addrQortalPartnerAddressPointer * MachineState.VALUE_SIZE : "addrQortalPartnerAddressPointer incorrect";
+		dataByteBuffer.putLong(addrQortalPartnerAddress1);
+
+		// Index into data segment of (temporary) transaction's sender's address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrMessageSenderPointer * MachineState.VALUE_SIZE : "addrMessageSenderPointer incorrect";
+		dataByteBuffer.putLong(addrMessageSender1);
+
+		// Offset into 'trade' MESSAGE data payload for extracting partner's Firo PKH
+		assert dataByteBuffer.position() == addrTradeMessagePartnerFiroPKHOffset * MachineState.VALUE_SIZE : "addrTradeMessagePartnerFiroPKHOffset incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Index into data segment of partner's Firo PKH, used by GET_B_IND
+		assert dataByteBuffer.position() == addrPartnerFiroPKHPointer * MachineState.VALUE_SIZE : "addrPartnerFiroPKHPointer incorrect";
+		dataByteBuffer.putLong(addrPartnerFiroPKH);
+
+		// Offset into 'trade' MESSAGE data payload for extracting hash-of-secret-A
+		assert dataByteBuffer.position() == addrTradeMessageHashOfSecretAOffset * MachineState.VALUE_SIZE : "addrTradeMessageHashOfSecretAOffset incorrect";
+		dataByteBuffer.putLong(64L);
+
+		// Index into data segment to hash of secret A, used by GET_B_IND
+		assert dataByteBuffer.position() == addrHashOfSecretAPointer * MachineState.VALUE_SIZE : "addrHashOfSecretAPointer incorrect";
+		dataByteBuffer.putLong(addrHashOfSecretA);
+
+		// Offset into 'redeem' MESSAGE data payload for extracting Qortal receiving address
+		assert dataByteBuffer.position() == addrRedeemMessageReceivingAddressOffset * MachineState.VALUE_SIZE : "addrRedeemMessageReceivingAddressOffset incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Source location and length for hashing any passed secret
+		assert dataByteBuffer.position() == addrMessageDataPointer * MachineState.VALUE_SIZE : "addrMessageDataPointer incorrect";
+		dataByteBuffer.putLong(addrMessageData);
+		assert dataByteBuffer.position() == addrMessageDataLength * MachineState.VALUE_SIZE : "addrMessageDataLength incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Pointer into data segment of where to save partner's receiving Qortal address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrPartnerReceivingAddressPointer * MachineState.VALUE_SIZE : "addrPartnerReceivingAddressPointer incorrect";
+		dataByteBuffer.putLong(addrPartnerReceivingAddress);
+
+		assert dataByteBuffer.position() == addrEndOfConstants * MachineState.VALUE_SIZE : "dataByteBuffer position not at end of constants";
+
+		// Code labels
+		Integer labelRefund = null;
+
+		Integer labelTradeTxnLoop = null;
+		Integer labelCheckTradeTxn = null;
+		Integer labelCheckCancelTxn = null;
+		Integer labelNotTradeNorCancelTxn = null;
+		Integer labelCheckNonRefundTradeTxn = null;
+		Integer labelTradeTxnExtract = null;
+		Integer labelRedeemTxnLoop = null;
+		Integer labelCheckRedeemTxn = null;
+		Integer labelCheckRedeemTxnSender = null;
+		Integer labelPayout = null;
+
+		ByteBuffer codeByteBuffer = ByteBuffer.allocate(768);
+
+		// Two-pass version
+		for (int pass = 0; pass < 2; ++pass) {
+			codeByteBuffer.clear();
+
+			try {
+				/* Initialization */
+
+				// Use AT creation 'timestamp' as starting point for finding transactions sent to AT
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_CREATION_TIMESTAMP, addrLastTxnTimestamp));
+
+				// Load B register with AT creator's address so we can save it into addrCreatorAddress1-4
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_CREATOR_INTO_B));
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrCreatorAddressPointer));
+
+				// Set restart position to after this opcode
+				codeByteBuffer.put(OpCode.SET_PCS.compile());
+
+				/* Loop, waiting for message from AT creator's trade address containing trade partner details, or AT owner's address to cancel offer */
+
+				/* Transaction processing loop */
+				labelTradeTxnLoop = codeByteBuffer.position();
+
+				/* Sleep until message arrives */
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.SLEEP_UNTIL_MESSAGE.value, addrLastTxnTimestamp));
+
+				/* NOP - to ensure FIRO ACCT is unique */
+				codeByteBuffer.put(OpCode.NOP.compile());
+
+				// Find next transaction (if any) to this AT since the last one (referenced by addrLastTxnTimestamp)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PUT_TX_AFTER_TIMESTAMP_INTO_A, addrLastTxnTimestamp));
+				// If no transaction found, A will be zero. If A is zero, set addrResult to 1, otherwise 0.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.CHECK_A_IS_ZERO, addrResult));
+				// If addrResult is zero (i.e. A is non-zero, transaction was found) then go check transaction
+				codeByteBuffer.put(OpCode.BZR_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelCheckTradeTxn)));
+				// Stop and wait for next block
+				codeByteBuffer.put(OpCode.STP_IMD.compile());
+
+				/* Check transaction */
+				labelCheckTradeTxn = codeByteBuffer.position();
+
+				// Update our 'last found transaction's timestamp' using 'timestamp' from transaction
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TIMESTAMP_FROM_TX_IN_A, addrLastTxnTimestamp));
+				// Extract transaction type (message/payment) from transaction and save type in addrTxnType
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TYPE_FROM_TX_IN_A, addrTxnType));
+				// If transaction type is not MESSAGE type then go look for another transaction
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrTxnType, addrMessageTxnType, calcOffset(codeByteBuffer, labelTradeTxnLoop)));
+
+				/* Check transaction's sender. We're expecting AT creator's trade address for 'trade' message, or AT creator's own address for 'cancel' message. */
+
+				// Extract sender address from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_ADDRESS_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageSender1 (as pointed to by addrMessageSenderPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageSenderPointer));
+				// Compare each part of message sender's address with AT creator's trade address. If they don't match, check for cancel situation.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrCreatorTradeAddress1, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrCreatorTradeAddress2, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrCreatorTradeAddress3, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrCreatorTradeAddress4, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				// Message sender's address matches AT creator's trade address so go process 'trade' message
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelCheckNonRefundTradeTxn == null ? 0 : labelCheckNonRefundTradeTxn));
+
+				/* Checking message sender for possible cancel message */
+				labelCheckCancelTxn = codeByteBuffer.position();
+
+				// Compare each part of message sender's address with AT creator's address. If they don't match, look for another transaction.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrCreatorAddress1, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrCreatorAddress2, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrCreatorAddress3, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrCreatorAddress4, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				// Partner address is AT creator's address, so cancel offer and finish.
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.CANCELLED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+
+				/* Not trade nor cancel message */
+				labelNotTradeNorCancelTxn = codeByteBuffer.position();
+
+				// Loop to find another transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelTradeTxnLoop == null ? 0 : labelTradeTxnLoop));
+
+				/* Possible switch-to-trade-mode message */
+				labelCheckNonRefundTradeTxn = codeByteBuffer.position();
+
+				// Check 'trade' message we received has expected number of message bytes
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(QortalFunctionCode.GET_MESSAGE_LENGTH_FROM_TX_IN_A.value, addrMessageLength));
+				// If message length matches, branch to info extraction code
+				codeByteBuffer.put(OpCode.BEQ_DAT.compile(addrMessageLength, addrExpectedTradeMessageLength, calcOffset(codeByteBuffer, labelTradeTxnExtract)));
+				// Message length didn't match - go back to finding another 'trade' MESSAGE transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelTradeTxnLoop == null ? 0 : labelTradeTxnLoop));
+
+				/* Extracting info from 'trade' MESSAGE transaction */
+				labelTradeTxnExtract = codeByteBuffer.position();
+
+				// Extract message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_MESSAGE_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrQortalPartnerAddress1 (as pointed to by addrQortalPartnerAddressPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrQortalPartnerAddressPointer));
+
+				// Extract trade partner's Firo public key hash (PKH) from message into B
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrTradeMessagePartnerFiroPKHOffset));
+				// Store partner's Firo PKH (we only really use values from B1-B3)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrPartnerFiroPKHPointer));
+				// Extract AT trade timeout (minutes) (from B4)
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_B4, addrRefundTimeout));
+
+				// Grab next 32 bytes
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrTradeMessageHashOfSecretAOffset));
+
+				// Extract hash-of-secret-A (we only really use values from B1-B3)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrHashOfSecretAPointer));
+				// Extract lockTime-A (from B4)
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_B4, addrLockTimeA));
+
+				// Calculate trade timeout refund 'timestamp' by adding addrRefundTimeout minutes to this transaction's 'timestamp', then save into addrRefundTimestamp
+				codeByteBuffer.put(OpCode.EXT_FUN_RET_DAT_2.compile(FunctionCode.ADD_MINUTES_TO_TIMESTAMP, addrRefundTimestamp, addrLastTxnTimestamp, addrRefundTimeout));
+
+				/* We are in 'trade mode' */
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.TRADING.value));
+
+				// Set restart position to after this opcode
+				codeByteBuffer.put(OpCode.SET_PCS.compile());
+
+				/* Loop, waiting for trade timeout or 'redeem' MESSAGE from Qortal trade partner */
+
+				// Fetch current block 'timestamp'
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_BLOCK_TIMESTAMP, addrBlockTimestamp));
+				// If we're not past refund 'timestamp' then look for next transaction
+				codeByteBuffer.put(OpCode.BLT_DAT.compile(addrBlockTimestamp, addrRefundTimestamp, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				// We're past refund 'timestamp' so go refund everything back to AT creator
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRefund == null ? 0 : labelRefund));
+
+				/* Transaction processing loop */
+				labelRedeemTxnLoop = codeByteBuffer.position();
+
+				// Find next transaction to this AT since the last one (if any)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PUT_TX_AFTER_TIMESTAMP_INTO_A, addrLastTxnTimestamp));
+				// If no transaction found, A will be zero. If A is zero, set addrComparator to 1, otherwise 0.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.CHECK_A_IS_ZERO, addrResult));
+				// If addrResult is zero (i.e. A is non-zero, transaction was found) then go check transaction
+				codeByteBuffer.put(OpCode.BZR_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelCheckRedeemTxn)));
+				// Stop and wait for next block
+				codeByteBuffer.put(OpCode.STP_IMD.compile());
+
+				/* Check transaction */
+				labelCheckRedeemTxn = codeByteBuffer.position();
+
+				// Update our 'last found transaction's timestamp' using 'timestamp' from transaction
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TIMESTAMP_FROM_TX_IN_A, addrLastTxnTimestamp));
+				// Extract transaction type (message/payment) from transaction and save type in addrTxnType
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TYPE_FROM_TX_IN_A, addrTxnType));
+				// If transaction type is not MESSAGE type then go look for another transaction
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrTxnType, addrMessageTxnType, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+
+				/* Check message payload length */
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(QortalFunctionCode.GET_MESSAGE_LENGTH_FROM_TX_IN_A.value, addrMessageLength));
+				// If message length matches, branch to sender checking code
+				codeByteBuffer.put(OpCode.BEQ_DAT.compile(addrMessageLength, addrExpectedRedeemMessageLength, calcOffset(codeByteBuffer, labelCheckRedeemTxnSender)));
+				// Message length didn't match - go back to finding another 'redeem' MESSAGE transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRedeemTxnLoop == null ? 0 : labelRedeemTxnLoop));
+
+				/* Check transaction's sender */
+				labelCheckRedeemTxnSender = codeByteBuffer.position();
+
+				// Extract sender address from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_ADDRESS_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageSender1 (as pointed to by addrMessageSenderPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageSenderPointer));
+				// Compare each part of transaction's sender's address with expected address. If they don't match, look for another transaction.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrQortalPartnerAddress1, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrQortalPartnerAddress2, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrQortalPartnerAddress3, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrQortalPartnerAddress4, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+
+				/* Check 'secret-A' in transaction's message */
+
+				// Extract secret-A from first 32 bytes of message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_MESSAGE_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageData (as pointed to by addrMessageDataPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageDataPointer));
+				// Load B register with expected hash result (as pointed to by addrHashOfSecretAPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.SET_B_IND, addrHashOfSecretAPointer));
+				// Perform HASH160 using source data at addrMessageData. (Location and length specified via addrMessageDataPointer and addrMessageDataLength).
+				// Save the equality result (1 if they match, 0 otherwise) into addrResult.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET_DAT_2.compile(FunctionCode.CHECK_HASH160_WITH_B, addrResult, addrMessageDataPointer, addrMessageDataLength));
+				// If hashes don't match, addrResult will be zero so go find another transaction
+				codeByteBuffer.put(OpCode.BNZ_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelPayout)));
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRedeemTxnLoop == null ? 0 : labelRedeemTxnLoop));
+
+				/* Success! Pay arranged amount to receiving address */
+				labelPayout = codeByteBuffer.position();
+
+				// Extract Qortal receiving address from next 32 bytes of message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrRedeemMessageReceivingAddressOffset));
+				// Save B register into data segment starting at addrPartnerReceivingAddress (as pointed to by addrPartnerReceivingAddressPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrPartnerReceivingAddressPointer));
+				// Pay AT's balance to receiving address
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PAY_TO_ADDRESS_IN_B, addrQortAmount));
+				// Set redeemed mode
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.REDEEMED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+
+				// Fall-through to refunding any remaining balance back to AT creator
+
+				/* Refund balance back to AT creator */
+				labelRefund = codeByteBuffer.position();
+
+				// Set refunded mode
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.REFUNDED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+			} catch (CompilationException e) {
+				throw new IllegalStateException("Unable to compile FIRO-QORT ACCT?", e);
+			}
+		}
+
+		codeByteBuffer.flip();
+
+		byte[] codeBytes = new byte[codeByteBuffer.limit()];
+		codeByteBuffer.get(codeBytes);
+
+		assert Arrays.equals(Crypto.digest(codeBytes), FiroACCTv3.CODE_BYTES_HASH)
+			: String.format("BTCACCT.CODE_BYTES_HASH mismatch: expected %s, actual %s", HashCode.fromBytes(CODE_BYTES_HASH), HashCode.fromBytes(Crypto.digest(codeBytes)));
+
+		final short ciyamAtVersion = 2;
+		final short numCallStackPages = 0;
+		final short numUserStackPages = 0;
+		final long minActivationAmount = 0L;
+
+		return MachineState.toCreationBytes(ciyamAtVersion, codeBytes, dataByteBuffer.array(), numCallStackPages, numUserStackPages, minActivationAmount);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	@Override
+	public CrossChainTradeData populateTradeData(Repository repository, ATData atData) throws DataException {
+		ATStateData atStateData = repository.getATRepository().getLatestATState(atData.getATAddress());
+		return populateTradeData(repository, atData.getCreatorPublicKey(), atData.getCreation(), atStateData);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	@Override
+	public CrossChainTradeData populateTradeData(Repository repository, ATStateData atStateData) throws DataException {
+		ATData atData = repository.getATRepository().fromATAddress(atStateData.getATAddress());
+		return populateTradeData(repository, atData.getCreatorPublicKey(), atData.getCreation(), atStateData);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	public CrossChainTradeData populateTradeData(Repository repository, byte[] creatorPublicKey, long creationTimestamp, ATStateData atStateData) throws DataException {
+		byte[] addressBytes = new byte[25]; // for general use
+		String atAddress = atStateData.getATAddress();
+
+		CrossChainTradeData tradeData = new CrossChainTradeData();
+
+		tradeData.foreignBlockchain = SupportedBlockchain.FIRO.name();
+		tradeData.acctName = NAME;
+
+		tradeData.qortalAtAddress = atAddress;
+		tradeData.qortalCreator = Crypto.toAddress(creatorPublicKey);
+		tradeData.creationTimestamp = creationTimestamp;
+
+		Account atAccount = new Account(repository, atAddress);
+		tradeData.qortBalance = atAccount.getConfirmedBalance(Asset.QORT);
+
+		byte[] stateData = atStateData.getStateData();
+		ByteBuffer dataByteBuffer = ByteBuffer.wrap(stateData);
+		dataByteBuffer.position(MachineState.HEADER_LENGTH);
+
+		/* Constants */
+
+		// Skip creator's trade address
+		dataByteBuffer.get(addressBytes);
+		tradeData.qortalCreatorTradeAddress = Base58.encode(addressBytes);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - addressBytes.length);
+
+		// Creator's Firo/foreign public key hash
+		tradeData.creatorForeignPKH = new byte[20];
+		dataByteBuffer.get(tradeData.creatorForeignPKH);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - tradeData.creatorForeignPKH.length); // skip to 32 bytes
+
+		// We don't use secret-B
+		tradeData.hashOfSecretB = null;
+
+		// Redeem payout
+		tradeData.qortAmount = dataByteBuffer.getLong();
+
+		// Expected FIRO amount
+		tradeData.expectedForeignAmount = dataByteBuffer.getLong();
+
+		// Trade timeout
+		tradeData.tradeTimeout = (int) dataByteBuffer.getLong();
+
+		// Skip MESSAGE transaction type
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip expected 'trade' message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip expected 'redeem' message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to creator's address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's Qortal trade address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to message sender
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'trade' message data offset for partner's Firo PKH
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's Firo PKH
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'trade' message data offset for hash-of-secret-A
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to hash-of-secret-A
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'redeem' message data offset for partner's Qortal receiving address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to message data
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip message data length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's receiving address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		/* End of constants / begin variables */
+
+		// Skip AT creator's address
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Partner's trade address (if present)
+		dataByteBuffer.get(addressBytes);
+		String qortalRecipient = Base58.encode(addressBytes);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - addressBytes.length);
+
+		// Potential lockTimeA (if in trade mode)
+		int lockTimeA = (int) dataByteBuffer.getLong();
+
+		// AT refund timeout (probably only useful for debugging)
+		int refundTimeout = (int) dataByteBuffer.getLong();
+
+		// Trade-mode refund timestamp (AT 'timestamp' converted to Qortal block height)
+		long tradeRefundTimestamp = dataByteBuffer.getLong();
+
+		// Skip last transaction timestamp
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip block timestamp
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip transaction type
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary result
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary message sender
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Skip message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary message data
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Potential hash160 of secret A
+		byte[] hashOfSecretA = new byte[20];
+		dataByteBuffer.get(hashOfSecretA);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - hashOfSecretA.length); // skip to 32 bytes
+
+		// Potential partner's Firo PKH
+		byte[] partnerFiroPKH = new byte[20];
+		dataByteBuffer.get(partnerFiroPKH);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - partnerFiroPKH.length); // skip to 32 bytes
+
+		// Partner's receiving address (if present)
+		byte[] partnerReceivingAddress = new byte[25];
+		dataByteBuffer.get(partnerReceivingAddress);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - partnerReceivingAddress.length); // skip to 32 bytes
+
+		// Trade AT's 'mode'
+		long modeValue = dataByteBuffer.getLong();
+		AcctMode mode = AcctMode.valueOf((int) (modeValue & 0xffL));
+
+		/* End of variables */
+
+		if (mode != null && mode != AcctMode.OFFERING) {
+			tradeData.mode = mode;
+			tradeData.refundTimeout = refundTimeout;
+			tradeData.tradeRefundHeight = new Timestamp(tradeRefundTimestamp).blockHeight;
+			tradeData.qortalPartnerAddress = qortalRecipient;
+			tradeData.hashOfSecretA = hashOfSecretA;
+			tradeData.partnerForeignPKH = partnerFiroPKH;
+			tradeData.lockTimeA = lockTimeA;
+
+			if (mode == AcctMode.REDEEMED)
+				tradeData.qortalPartnerReceivingAddress = Base58.encode(partnerReceivingAddress);
+		} else {
+			tradeData.mode = AcctMode.OFFERING;
+		}
+
+		tradeData.duplicateDeprecated();
+
+		return tradeData;
+	}
+
+	/** Returns 'offer' MESSAGE payload for trade partner to send to AT creator's trade address. */
+	public static byte[] buildOfferMessage(byte[] partnerBitcoinPKH, byte[] hashOfSecretA, int lockTimeA) {
+		byte[] lockTimeABytes = BitTwiddling.toBEByteArray((long) lockTimeA);
+		return Bytes.concat(partnerBitcoinPKH, hashOfSecretA, lockTimeABytes);
+	}
+
+	/** Returns info extracted from 'offer' MESSAGE payload sent by trade partner to AT creator's trade address, or null if not valid. */
+	public static OfferMessageData extractOfferMessageData(byte[] messageData) {
+		if (messageData == null || messageData.length != OFFER_MESSAGE_LENGTH)
+			return null;
+
+		OfferMessageData offerMessageData = new OfferMessageData();
+		offerMessageData.partnerFiroPKH = Arrays.copyOfRange(messageData, 0, 20);
+		offerMessageData.hashOfSecretA = Arrays.copyOfRange(messageData, 20, 40);
+		offerMessageData.lockTimeA = BitTwiddling.longFromBEBytes(messageData, 40);
+
+		return offerMessageData;
+	}
+
+	/** Returns 'trade' MESSAGE payload for AT creator to send to AT. */
+	public static byte[] buildTradeMessage(String partnerQortalTradeAddress, byte[] partnerBitcoinPKH, byte[] hashOfSecretA, int lockTimeA, int refundTimeout) {
+		byte[] data = new byte[TRADE_MESSAGE_LENGTH];
+		byte[] partnerQortalAddressBytes = Base58.decode(partnerQortalTradeAddress);
+		byte[] lockTimeABytes = BitTwiddling.toBEByteArray((long) lockTimeA);
+		byte[] refundTimeoutBytes = BitTwiddling.toBEByteArray((long) refundTimeout);
+
+		System.arraycopy(partnerQortalAddressBytes, 0, data, 0, partnerQortalAddressBytes.length);
+		System.arraycopy(partnerBitcoinPKH, 0, data, 32, partnerBitcoinPKH.length);
+		System.arraycopy(refundTimeoutBytes, 0, data, 56, refundTimeoutBytes.length);
+		System.arraycopy(hashOfSecretA, 0, data, 64, hashOfSecretA.length);
+		System.arraycopy(lockTimeABytes, 0, data, 88, lockTimeABytes.length);
+
+		return data;
+	}
+
+	/** Returns 'cancel' MESSAGE payload for AT creator to cancel trade AT. */
+	@Override
+	public byte[] buildCancelMessage(String creatorQortalAddress) {
+		byte[] data = new byte[CANCEL_MESSAGE_LENGTH];
+		byte[] creatorQortalAddressBytes = Base58.decode(creatorQortalAddress);
+
+		System.arraycopy(creatorQortalAddressBytes, 0, data, 0, creatorQortalAddressBytes.length);
+
+		return data;
+	}
+
+	/** Returns 'redeem' MESSAGE payload for trade partner to send to AT. */
+	public static byte[] buildRedeemMessage(byte[] secretA, String qortalReceivingAddress) {
+		byte[] data = new byte[REDEEM_MESSAGE_LENGTH];
+		byte[] qortalReceivingAddressBytes = Base58.decode(qortalReceivingAddress);
+
+		System.arraycopy(secretA, 0, data, 0, secretA.length);
+		System.arraycopy(qortalReceivingAddressBytes, 0, data, 32, qortalReceivingAddressBytes.length);
+
+		return data;
+	}
+
+	/** Returns refund timeout (minutes) based on trade partner's 'offer' MESSAGE timestamp and P2SH-A locktime. */
+	public static int calcRefundTimeout(long offerMessageTimestamp, int lockTimeA) {
+		// refund should be triggered halfway between offerMessageTimestamp and lockTimeA
+		return (int) ((lockTimeA - (offerMessageTimestamp / 1000L)) / 2L / 60L);
+	}
+
+	@Override
+	public byte[] findSecretA(Repository repository, CrossChainTradeData crossChainTradeData) throws DataException {
+		String atAddress = crossChainTradeData.qortalAtAddress;
+		String redeemerAddress = crossChainTradeData.qortalPartnerAddress;
+
+		// We don't have partner's public key so we check every message to AT
+		List<MessageTransactionData> messageTransactionsData = repository.getMessageRepository().getMessagesByParticipants(null, atAddress, null, null, null);
+		if (messageTransactionsData == null)
+			return null;
+
+		// Find 'redeem' message
+		for (MessageTransactionData messageTransactionData : messageTransactionsData) {
+			// Check message payload type/encryption
+			if (messageTransactionData.isText() || messageTransactionData.isEncrypted())
+				continue;
+
+			// Check message payload size
+			byte[] messageData = messageTransactionData.getData();
+			if (messageData.length != REDEEM_MESSAGE_LENGTH)
+				// Wrong payload length
+				continue;
+
+			// Check sender
+			if (!Crypto.toAddress(messageTransactionData.getSenderPublicKey()).equals(redeemerAddress))
+				// Wrong sender;
+				continue;
+
+			// Extract secretA
+			byte[] secretA = new byte[32];
+			System.arraycopy(messageData, 0, secretA, 0, secretA.length);
+
+			byte[] hashOfSecretA = Crypto.hash160(secretA);
+			if (!Arrays.equals(hashOfSecretA, crossChainTradeData.hashOfSecretA))
+				continue;
+
+			return secretA;
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/org/qortal/crosschain/Namecoin.java
+++ b/src/main/java/org/qortal/crosschain/Namecoin.java
@@ -1,0 +1,175 @@
+package org.qortal.crosschain;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
+// import org.libdohj.params.NamecoinMainNetParams;
+import org.bitcoinj.params.MainNetParams; // temporary, not for use
+import org.qortal.crosschain.ElectrumX.Server;
+import org.qortal.crosschain.ChainableServer.ConnectionType;
+import org.qortal.settings.Settings;
+
+public class Namecoin extends Bitcoiny {
+
+	public static final String CURRENCY_CODE = "NMC";
+
+	private static final Coin DEFAULT_FEE_PER_KB = Coin.valueOf(600000); // 0.006 NMC per 1000 bytes
+
+	private static final long MINIMUM_ORDER_AMOUNT = 10000000L; // 0.1 NMC minimum order, to avoid dust errors
+
+	// Temporary values until a dynamic fee system is written.
+	private static final long MAINNET_FEE = 200000L;
+	private static final long NON_MAINNET_FEE = 1000L; // enough for TESTNET3 and should be OK for REGTEST
+
+	private static final Map<ConnectionType, Integer> DEFAULT_ELECTRUMX_PORTS = new EnumMap<>(ConnectionType.class);
+	static {
+		DEFAULT_ELECTRUMX_PORTS.put(ConnectionType.TCP, 50001);
+		DEFAULT_ELECTRUMX_PORTS.put(ConnectionType.SSL, 50002);
+	}
+
+	public enum NamecoinNet {
+		MAIN {
+			@Override
+			public NetworkParameters getParams() {
+				return MainNetParams.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(
+						// Servers chosen on NO BASIS WHATSOEVER from various sources!
+						// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=nmc
+						//CLOSED new Server("electrum.namebrow.se", ConnectionType.SSL, 50002),
+						//CLOSED new Server("nmc.bitcoins.sk", ConnectionType.SSL, 50002),
+						new Server("46.229.238.187", ConnectionType.SSL, 57002),
+						new Server("nmc2.bitcoins.sk", ConnectionType.SSL, 57002));
+			}
+
+			@Override
+			public String getGenesisHash() {
+				return "000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770";
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				// TODO: This will need to be replaced with something better in the near future!
+				return MAINNET_FEE;
+			}
+		},
+		TEST3 {
+			@Override
+			public NetworkParameters getParams() {
+				return TestNet3Params.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(); // TODO: find testnet servers
+			}
+
+			@Override
+			public String getGenesisHash() {
+				return "00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008";
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				return NON_MAINNET_FEE;
+			}
+		},
+		REGTEST {
+			@Override
+			public NetworkParameters getParams() {
+				return RegTestParams.get();
+			}
+
+			@Override
+			public Collection<Server> getServers() {
+				return Arrays.asList(
+						new Server("localhost", ConnectionType.TCP, 50001),
+						new Server("localhost", ConnectionType.SSL, 50002));
+			}
+
+			@Override
+			public String getGenesisHash() {
+				// This is unique to each regtest instance
+				return null;
+			}
+
+			@Override
+			public long getP2shFee(Long timestamp) {
+				return NON_MAINNET_FEE;
+			}
+		};
+
+		public abstract NetworkParameters getParams();
+		public abstract Collection<Server> getServers();
+		public abstract String getGenesisHash();
+		public abstract long getP2shFee(Long timestamp) throws ForeignBlockchainException;
+	}
+
+	private static Namecoin instance;
+
+	private final NamecoinNet namecoinNet;
+
+	// Constructors and instance
+
+	private Namecoin(NamecoinNet namecoinNet, BitcoinyBlockchainProvider blockchain, Context bitcoinjContext, String currencyCode) {
+		super(blockchain, bitcoinjContext, currencyCode);
+		this.namecoinNet = namecoinNet;
+
+		LOGGER.info(() -> String.format("Starting Namecoin support using %s", this.namecoinNet.name()));
+	}
+
+	public static synchronized Namecoin getInstance() {
+		if (instance == null) {
+			NamecoinNet namecoinNet = Settings.getInstance().getNamecoinNet();
+
+			BitcoinyBlockchainProvider electrumX = new ElectrumX("Namecoin-" + namecoinNet.name(), namecoinNet.getGenesisHash(), namecoinNet.getServers(), DEFAULT_ELECTRUMX_PORTS);
+			Context bitcoinjContext = new Context(namecoinNet.getParams());
+
+			instance = new Namecoin(namecoinNet, electrumX, bitcoinjContext, CURRENCY_CODE);
+
+			electrumX.setBlockchain(instance);
+		}
+
+		return instance;
+	}
+
+	// Getters & setters
+
+	public static synchronized void resetForTesting() {
+		instance = null;
+	}
+
+	// Actual useful methods for use by other classes
+
+	@Override
+	public Coin getFeePerKb() {
+		return DEFAULT_FEE_PER_KB;
+	}
+
+	@Override
+	public long getMinimumOrderAmount() {
+		return MINIMUM_ORDER_AMOUNT;
+	}
+
+	/**
+	 * Returns estimated NMC fee, in sats per 1000bytes, optionally for historic timestamp.
+	 * 
+	 * @param timestamp optional milliseconds since epoch, or null for 'now'
+	 * @return sats per 1000bytes, or throws ForeignBlockchainException if something went wrong
+	 */
+	@Override
+	public long getP2shFee(Long timestamp) throws ForeignBlockchainException {
+		return this.namecoinNet.getP2shFee(timestamp);
+	}
+
+}

--- a/src/main/java/org/qortal/crosschain/NamecoinACCTv3.java
+++ b/src/main/java/org/qortal/crosschain/NamecoinACCTv3.java
@@ -1,0 +1,858 @@
+package org.qortal.crosschain;
+
+import com.google.common.hash.HashCode;
+import com.google.common.primitives.Bytes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ciyam.at.*;
+import org.qortal.account.Account;
+import org.qortal.asset.Asset;
+import org.qortal.at.QortalFunctionCode;
+import org.qortal.crypto.Crypto;
+import org.qortal.data.at.ATData;
+import org.qortal.data.at.ATStateData;
+import org.qortal.data.crosschain.CrossChainTradeData;
+import org.qortal.data.transaction.MessageTransactionData;
+import org.qortal.repository.DataException;
+import org.qortal.repository.Repository;
+import org.qortal.utils.Base58;
+import org.qortal.utils.BitTwiddling;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.ciyam.at.OpCode.calcOffset;
+
+/**
+ * Cross-chain trade AT
+ * 
+ * <p>
+ * <ul>
+ * <li>Bob generates Namecoin & Qortal 'trade' keys
+ * 		<ul>
+ * 			<li>private key required to sign P2SH redeem tx</li>
+ * 			<li>private key could be used to create 'secret' (e.g. double-SHA256)</li>
+ * 			<li>encrypted private key could be stored in Qortal AT for access by Bob from any node</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob deploys Qortal AT
+ * 		<ul>
+ * 		</ul>
+ * </li>
+ * <li>Alice finds Qortal AT and wants to trade
+ * 		<ul>
+ * 			<li>Alice generates Namecoin & Qortal 'trade' keys</li>
+ * 			<li>Alice funds Namecoin P2SH-A</li>
+ * 			<li>Alice sends 'offer' MESSAGE to Bob from her Qortal trade address, containing:
+ * 				<ul>
+ * 					<li>hash-of-secret-A</li>
+ * 					<li>her 'trade' Namecoin PKH</li>
+ * 				</ul>
+ * 			</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob receives "offer" MESSAGE
+ * 		<ul>
+ * 			<li>Checks Alice's P2SH-A</li>
+ * 			<li>Sends 'trade' MESSAGE to Qortal AT from his trade address, containing:
+ * 				<ul>
+ * 					<li>Alice's trade Qortal address</li>
+ * 					<li>Alice's trade Namecoin PKH</li>
+ * 					<li>hash-of-secret-A</li>
+ * 				</ul>
+ * 			</li>
+ * 		</ul>
+ * </li>
+ * <li>Alice checks Qortal AT to confirm it's locked to her
+ * 		<ul>
+ * 			<li>Alice sends 'redeem' MESSAGE to Qortal AT from her trade address, containing:
+ * 				<ul>
+ * 					<li>secret-A</li>
+ * 					<li>Qortal receiving address of her chosing</li>
+ * 				</ul>
+ * 			</li>
+ * 			<li>AT's QORT funds are sent to Qortal receiving address</li>
+ * 		</ul>
+ * </li>
+ * <li>Bob checks AT, extracts secret-A
+ * 		<ul>
+ * 			<li>Bob redeems P2SH-A using his Namecoin trade key and secret-A</li>
+ * 			<li>P2SH-A NMC funds end up at Namecoin address determined by redeem transaction output(s)</li>
+ * 		</ul>
+ * </li>
+ * </ul>
+ */
+public class NamecoinACCTv3 implements ACCT {
+
+	private static final Logger LOGGER = LogManager.getLogger(NamecoinACCTv3.class);
+
+	public static final String NAME = NamecoinACCTv3.class.getSimpleName();
+	public static final byte[] CODE_BYTES_HASH = HashCode.fromString("4f94fb38661c4d73593eeea384cb485e45a4fd7f0cfe18b8906dd535a9ee28f5").asBytes(); // SHA256 of AT code bytes
+
+	public static final int SECRET_LENGTH = 32;
+
+	/** <b>Value</b> offset into AT segment where 'mode' variable (long) is stored. (Multiply by MachineState.VALUE_SIZE for byte offset). */
+	private static final int MODE_VALUE_OFFSET = 61;
+	/** <b>Byte</b> offset into AT state data where 'mode' variable (long) is stored. */
+	public static final int MODE_BYTE_OFFSET = MachineState.HEADER_LENGTH + (MODE_VALUE_OFFSET * MachineState.VALUE_SIZE);
+
+	public static class OfferMessageData {
+		public byte[] partnerNamecoinPKH;
+		public byte[] hashOfSecretA;
+		public long lockTimeA;
+	}
+	public static final int OFFER_MESSAGE_LENGTH = 20 /*partnerNamecoinPKH*/ + 20 /*hashOfSecretA*/ + 8 /*lockTimeA*/;
+	public static final int TRADE_MESSAGE_LENGTH = 32 /*partner's Qortal trade address (padded from 25 to 32)*/
+			+ 24 /*partner's Namecoin PKH (padded from 20 to 24)*/
+			+ 8 /*AT trade timeout (minutes)*/
+			+ 24 /*hash of secret-A (padded from 20 to 24)*/
+			+ 8 /*lockTimeA*/;
+	public static final int REDEEM_MESSAGE_LENGTH = 32 /*secret-A*/ + 32 /*partner's Qortal receiving address padded from 25 to 32*/;
+	public static final int CANCEL_MESSAGE_LENGTH = 32 /*AT creator's Qortal address*/;
+
+	private static NamecoinACCTv3 instance;
+
+	private NamecoinACCTv3() {
+	}
+
+	public static synchronized NamecoinACCTv3 getInstance() {
+		if (instance == null)
+			instance = new NamecoinACCTv3();
+
+		return instance;
+	}
+
+	@Override
+	public byte[] getCodeBytesHash() {
+		return CODE_BYTES_HASH;
+	}
+
+	@Override
+	public int getModeByteOffset() {
+		return MODE_BYTE_OFFSET;
+	}
+
+	@Override
+	public ForeignBlockchain getBlockchain() {
+		return Namecoin.getInstance();
+	}
+
+	/**
+	 * Returns Qortal AT creation bytes for cross-chain trading AT.
+	 * <p>
+	 * <tt>tradeTimeout</tt> (minutes) is the time window for the trade partner to send the
+	 * 32-byte secret to the AT, before the AT automatically refunds the AT's creator.
+	 * 
+	 * @param creatorTradeAddress AT creator's trade Qortal address
+	 * @param namecoinPublicKeyHash 20-byte HASH160 of creator's trade Namecoin public key
+	 * @param qortAmount how much QORT to pay trade partner if they send correct 32-byte secrets to AT
+	 * @param namecoinAmount how much NMC the AT creator is expecting to trade
+	 * @param tradeTimeout suggested timeout for entire trade
+	 */
+	public static byte[] buildQortalAT(String creatorTradeAddress, byte[] namecoinPublicKeyHash, long qortAmount, long namecoinAmount, int tradeTimeout) {
+		if (namecoinPublicKeyHash.length != 20)
+			throw new IllegalArgumentException("Namecoin public key hash should be 20 bytes");
+
+		// Labels for data segment addresses
+		int addrCounter = 0;
+
+		// Constants (with corresponding dataByteBuffer.put*() calls below)
+
+		final int addrCreatorTradeAddress1 = addrCounter++;
+		final int addrCreatorTradeAddress2 = addrCounter++;
+		final int addrCreatorTradeAddress3 = addrCounter++;
+		final int addrCreatorTradeAddress4 = addrCounter++;
+
+		final int addrNamecoinPublicKeyHash = addrCounter;
+		addrCounter += 4;
+
+		final int addrQortAmount = addrCounter++;
+		final int addrNamecoinAmount = addrCounter++;
+		final int addrTradeTimeout = addrCounter++;
+
+		final int addrMessageTxnType = addrCounter++;
+		final int addrExpectedTradeMessageLength = addrCounter++;
+		final int addrExpectedRedeemMessageLength = addrCounter++;
+
+		final int addrCreatorAddressPointer = addrCounter++;
+		final int addrQortalPartnerAddressPointer = addrCounter++;
+		final int addrMessageSenderPointer = addrCounter++;
+
+		final int addrTradeMessagePartnerNamecoinPKHOffset = addrCounter++;
+		final int addrPartnerNamecoinPKHPointer = addrCounter++;
+		final int addrTradeMessageHashOfSecretAOffset = addrCounter++;
+		final int addrHashOfSecretAPointer = addrCounter++;
+
+		final int addrRedeemMessageReceivingAddressOffset = addrCounter++;
+
+		final int addrMessageDataPointer = addrCounter++;
+		final int addrMessageDataLength = addrCounter++;
+
+		final int addrPartnerReceivingAddressPointer = addrCounter++;
+
+		final int addrEndOfConstants = addrCounter;
+
+		// Variables
+
+		final int addrCreatorAddress1 = addrCounter++;
+		final int addrCreatorAddress2 = addrCounter++;
+		final int addrCreatorAddress3 = addrCounter++;
+		final int addrCreatorAddress4 = addrCounter++;
+
+		final int addrQortalPartnerAddress1 = addrCounter++;
+		final int addrQortalPartnerAddress2 = addrCounter++;
+		final int addrQortalPartnerAddress3 = addrCounter++;
+		final int addrQortalPartnerAddress4 = addrCounter++;
+
+		final int addrLockTimeA = addrCounter++;
+		final int addrRefundTimeout = addrCounter++;
+		final int addrRefundTimestamp = addrCounter++;
+		final int addrLastTxnTimestamp = addrCounter++;
+		final int addrBlockTimestamp = addrCounter++;
+		final int addrTxnType = addrCounter++;
+		final int addrResult = addrCounter++;
+
+		final int addrMessageSender1 = addrCounter++;
+		final int addrMessageSender2 = addrCounter++;
+		final int addrMessageSender3 = addrCounter++;
+		final int addrMessageSender4 = addrCounter++;
+
+		final int addrMessageLength = addrCounter++;
+
+		final int addrMessageData = addrCounter;
+		addrCounter += 4;
+
+		final int addrHashOfSecretA = addrCounter;
+		addrCounter += 4;
+
+		final int addrPartnerNamecoinPKH = addrCounter;
+		addrCounter += 4;
+
+		final int addrPartnerReceivingAddress = addrCounter;
+		addrCounter += 4;
+
+		final int addrMode = addrCounter++;
+		assert addrMode == MODE_VALUE_OFFSET : String.format("addrMode %d does not match MODE_VALUE_OFFSET %d", addrMode, MODE_VALUE_OFFSET);
+
+		// Data segment
+		ByteBuffer dataByteBuffer = ByteBuffer.allocate(addrCounter * MachineState.VALUE_SIZE);
+
+		// AT creator's trade Qortal address, decoded from Base58
+		assert dataByteBuffer.position() == addrCreatorTradeAddress1 * MachineState.VALUE_SIZE : "addrCreatorTradeAddress1 incorrect";
+		byte[] creatorTradeAddressBytes = Base58.decode(creatorTradeAddress);
+		dataByteBuffer.put(Bytes.ensureCapacity(creatorTradeAddressBytes, 32, 0));
+
+		// Namecoin public key hash
+		assert dataByteBuffer.position() == addrNamecoinPublicKeyHash * MachineState.VALUE_SIZE : "addrNamecoinPublicKeyHash incorrect";
+		dataByteBuffer.put(Bytes.ensureCapacity(namecoinPublicKeyHash, 32, 0));
+
+		// Redeem Qort amount
+		assert dataByteBuffer.position() == addrQortAmount * MachineState.VALUE_SIZE : "addrQortAmount incorrect";
+		dataByteBuffer.putLong(qortAmount);
+
+		// Expected Namecoin amount
+		assert dataByteBuffer.position() == addrNamecoinAmount * MachineState.VALUE_SIZE : "addrNamecoinAmount incorrect";
+		dataByteBuffer.putLong(namecoinAmount);
+
+		// Suggested trade timeout (minutes)
+		assert dataByteBuffer.position() == addrTradeTimeout * MachineState.VALUE_SIZE : "addrTradeTimeout incorrect";
+		dataByteBuffer.putLong(tradeTimeout);
+
+		// We're only interested in MESSAGE transactions
+		assert dataByteBuffer.position() == addrMessageTxnType * MachineState.VALUE_SIZE : "addrMessageTxnType incorrect";
+		dataByteBuffer.putLong(API.ATTransactionType.MESSAGE.value);
+
+		// Expected length of 'trade' MESSAGE data from AT creator
+		assert dataByteBuffer.position() == addrExpectedTradeMessageLength * MachineState.VALUE_SIZE : "addrExpectedTradeMessageLength incorrect";
+		dataByteBuffer.putLong(TRADE_MESSAGE_LENGTH);
+
+		// Expected length of 'redeem' MESSAGE data from trade partner
+		assert dataByteBuffer.position() == addrExpectedRedeemMessageLength * MachineState.VALUE_SIZE : "addrExpectedRedeemMessageLength incorrect";
+		dataByteBuffer.putLong(REDEEM_MESSAGE_LENGTH);
+
+		// Index into data segment of AT creator's address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrCreatorAddressPointer * MachineState.VALUE_SIZE : "addrCreatorAddressPointer incorrect";
+		dataByteBuffer.putLong(addrCreatorAddress1);
+
+		// Index into data segment of partner's Qortal address, used by SET_B_IND
+		assert dataByteBuffer.position() == addrQortalPartnerAddressPointer * MachineState.VALUE_SIZE : "addrQortalPartnerAddressPointer incorrect";
+		dataByteBuffer.putLong(addrQortalPartnerAddress1);
+
+		// Index into data segment of (temporary) transaction's sender's address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrMessageSenderPointer * MachineState.VALUE_SIZE : "addrMessageSenderPointer incorrect";
+		dataByteBuffer.putLong(addrMessageSender1);
+
+		// Offset into 'trade' MESSAGE data payload for extracting partner's Namecoin PKH
+		assert dataByteBuffer.position() == addrTradeMessagePartnerNamecoinPKHOffset * MachineState.VALUE_SIZE : "addrTradeMessagePartnerNamecoinPKHOffset incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Index into data segment of partner's Namecoin PKH, used by GET_B_IND
+		assert dataByteBuffer.position() == addrPartnerNamecoinPKHPointer * MachineState.VALUE_SIZE : "addrPartnerNamecoinPKHPointer incorrect";
+		dataByteBuffer.putLong(addrPartnerNamecoinPKH);
+
+		// Offset into 'trade' MESSAGE data payload for extracting hash-of-secret-A
+		assert dataByteBuffer.position() == addrTradeMessageHashOfSecretAOffset * MachineState.VALUE_SIZE : "addrTradeMessageHashOfSecretAOffset incorrect";
+		dataByteBuffer.putLong(64L);
+
+		// Index into data segment to hash of secret A, used by GET_B_IND
+		assert dataByteBuffer.position() == addrHashOfSecretAPointer * MachineState.VALUE_SIZE : "addrHashOfSecretAPointer incorrect";
+		dataByteBuffer.putLong(addrHashOfSecretA);
+
+		// Offset into 'redeem' MESSAGE data payload for extracting Qortal receiving address
+		assert dataByteBuffer.position() == addrRedeemMessageReceivingAddressOffset * MachineState.VALUE_SIZE : "addrRedeemMessageReceivingAddressOffset incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Source location and length for hashing any passed secret
+		assert dataByteBuffer.position() == addrMessageDataPointer * MachineState.VALUE_SIZE : "addrMessageDataPointer incorrect";
+		dataByteBuffer.putLong(addrMessageData);
+		assert dataByteBuffer.position() == addrMessageDataLength * MachineState.VALUE_SIZE : "addrMessageDataLength incorrect";
+		dataByteBuffer.putLong(32L);
+
+		// Pointer into data segment of where to save partner's receiving Qortal address, used by GET_B_IND
+		assert dataByteBuffer.position() == addrPartnerReceivingAddressPointer * MachineState.VALUE_SIZE : "addrPartnerReceivingAddressPointer incorrect";
+		dataByteBuffer.putLong(addrPartnerReceivingAddress);
+
+		assert dataByteBuffer.position() == addrEndOfConstants * MachineState.VALUE_SIZE : "dataByteBuffer position not at end of constants";
+
+		// Code labels
+		Integer labelRefund = null;
+
+		Integer labelTradeTxnLoop = null;
+		Integer labelCheckTradeTxn = null;
+		Integer labelCheckCancelTxn = null;
+		Integer labelNotTradeNorCancelTxn = null;
+		Integer labelCheckNonRefundTradeTxn = null;
+		Integer labelTradeTxnExtract = null;
+		Integer labelRedeemTxnLoop = null;
+		Integer labelCheckRedeemTxn = null;
+		Integer labelCheckRedeemTxnSender = null;
+		Integer labelPayout = null;
+
+		ByteBuffer codeByteBuffer = ByteBuffer.allocate(768);
+
+		// Two-pass version
+		for (int pass = 0; pass < 2; ++pass) {
+			codeByteBuffer.clear();
+
+			try {
+				/* Initialization */
+
+				// Use AT creation 'timestamp' as starting point for finding transactions sent to AT
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_CREATION_TIMESTAMP, addrLastTxnTimestamp));
+
+				// Load B register with AT creator's address so we can save it into addrCreatorAddress1-4
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_CREATOR_INTO_B));
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrCreatorAddressPointer));
+
+				// Set restart position to after this opcode
+				codeByteBuffer.put(OpCode.SET_PCS.compile());
+
+				/* NOP - to ensure NAMECOIN ACCT is unique */
+				codeByteBuffer.put(OpCode.NOP.compile());
+
+				/* Loop, waiting for message from AT creator's trade address containing trade partner details, or AT owner's address to cancel offer */
+
+				/* Transaction processing loop */
+				labelTradeTxnLoop = codeByteBuffer.position();
+
+				/* Sleep until message arrives */
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.SLEEP_UNTIL_MESSAGE.value, addrLastTxnTimestamp));
+
+				// Find next transaction (if any) to this AT since the last one (referenced by addrLastTxnTimestamp)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PUT_TX_AFTER_TIMESTAMP_INTO_A, addrLastTxnTimestamp));
+				// If no transaction found, A will be zero. If A is zero, set addrResult to 1, otherwise 0.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.CHECK_A_IS_ZERO, addrResult));
+				// If addrResult is zero (i.e. A is non-zero, transaction was found) then go check transaction
+				codeByteBuffer.put(OpCode.BZR_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelCheckTradeTxn)));
+				// Stop and wait for next block
+				codeByteBuffer.put(OpCode.STP_IMD.compile());
+
+				/* Check transaction */
+				labelCheckTradeTxn = codeByteBuffer.position();
+
+				// Update our 'last found transaction's timestamp' using 'timestamp' from transaction
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TIMESTAMP_FROM_TX_IN_A, addrLastTxnTimestamp));
+				// Extract transaction type (message/payment) from transaction and save type in addrTxnType
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TYPE_FROM_TX_IN_A, addrTxnType));
+				// If transaction type is not MESSAGE type then go look for another transaction
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrTxnType, addrMessageTxnType, calcOffset(codeByteBuffer, labelTradeTxnLoop)));
+
+				/* Check transaction's sender. We're expecting AT creator's trade address for 'trade' message, or AT creator's own address for 'cancel' message. */
+
+				// Extract sender address from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_ADDRESS_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageSender1 (as pointed to by addrMessageSenderPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageSenderPointer));
+				// Compare each part of message sender's address with AT creator's trade address. If they don't match, check for cancel situation.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrCreatorTradeAddress1, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrCreatorTradeAddress2, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrCreatorTradeAddress3, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrCreatorTradeAddress4, calcOffset(codeByteBuffer, labelCheckCancelTxn)));
+				// Message sender's address matches AT creator's trade address so go process 'trade' message
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelCheckNonRefundTradeTxn == null ? 0 : labelCheckNonRefundTradeTxn));
+
+				/* Checking message sender for possible cancel message */
+				labelCheckCancelTxn = codeByteBuffer.position();
+
+				// Compare each part of message sender's address with AT creator's address. If they don't match, look for another transaction.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrCreatorAddress1, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrCreatorAddress2, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrCreatorAddress3, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrCreatorAddress4, calcOffset(codeByteBuffer, labelNotTradeNorCancelTxn)));
+				// Partner address is AT creator's address, so cancel offer and finish.
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.CANCELLED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+
+				/* Not trade nor cancel message */
+				labelNotTradeNorCancelTxn = codeByteBuffer.position();
+
+				// Loop to find another transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelTradeTxnLoop == null ? 0 : labelTradeTxnLoop));
+
+				/* Possible switch-to-trade-mode message */
+				labelCheckNonRefundTradeTxn = codeByteBuffer.position();
+
+				// Check 'trade' message we received has expected number of message bytes
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(QortalFunctionCode.GET_MESSAGE_LENGTH_FROM_TX_IN_A.value, addrMessageLength));
+				// If message length matches, branch to info extraction code
+				codeByteBuffer.put(OpCode.BEQ_DAT.compile(addrMessageLength, addrExpectedTradeMessageLength, calcOffset(codeByteBuffer, labelTradeTxnExtract)));
+				// Message length didn't match - go back to finding another 'trade' MESSAGE transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelTradeTxnLoop == null ? 0 : labelTradeTxnLoop));
+
+				/* Extracting info from 'trade' MESSAGE transaction */
+				labelTradeTxnExtract = codeByteBuffer.position();
+
+				// Extract message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_MESSAGE_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrQortalPartnerAddress1 (as pointed to by addrQortalPartnerAddressPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrQortalPartnerAddressPointer));
+
+				// Extract trade partner's Namecoin public key hash (PKH) from message into B
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrTradeMessagePartnerNamecoinPKHOffset));
+				// Store partner's Namecoin PKH (we only really use values from B1-B3)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrPartnerNamecoinPKHPointer));
+				// Extract AT trade timeout (minutes) (from B4)
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_B4, addrRefundTimeout));
+
+				// Grab next 32 bytes
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrTradeMessageHashOfSecretAOffset));
+
+				// Extract hash-of-secret-A (we only really use values from B1-B3)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrHashOfSecretAPointer));
+				// Extract lockTime-A (from B4)
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_B4, addrLockTimeA));
+
+				// Calculate trade timeout refund 'timestamp' by adding addrRefundTimeout minutes to this transaction's 'timestamp', then save into addrRefundTimestamp
+				codeByteBuffer.put(OpCode.EXT_FUN_RET_DAT_2.compile(FunctionCode.ADD_MINUTES_TO_TIMESTAMP, addrRefundTimestamp, addrLastTxnTimestamp, addrRefundTimeout));
+
+				/* We are in 'trade mode' */
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.TRADING.value));
+
+				// Set restart position to after this opcode
+				codeByteBuffer.put(OpCode.SET_PCS.compile());
+
+				/* Loop, waiting for trade timeout or 'redeem' MESSAGE from Qortal trade partner */
+
+				// Fetch current block 'timestamp'
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_BLOCK_TIMESTAMP, addrBlockTimestamp));
+				// If we're not past refund 'timestamp' then look for next transaction
+				codeByteBuffer.put(OpCode.BLT_DAT.compile(addrBlockTimestamp, addrRefundTimestamp, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				// We're past refund 'timestamp' so go refund everything back to AT creator
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRefund == null ? 0 : labelRefund));
+
+				/* Transaction processing loop */
+				labelRedeemTxnLoop = codeByteBuffer.position();
+
+				// Find next transaction to this AT since the last one (if any)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PUT_TX_AFTER_TIMESTAMP_INTO_A, addrLastTxnTimestamp));
+				// If no transaction found, A will be zero. If A is zero, set addrComparator to 1, otherwise 0.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.CHECK_A_IS_ZERO, addrResult));
+				// If addrResult is zero (i.e. A is non-zero, transaction was found) then go check transaction
+				codeByteBuffer.put(OpCode.BZR_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelCheckRedeemTxn)));
+				// Stop and wait for next block
+				codeByteBuffer.put(OpCode.STP_IMD.compile());
+
+				/* Check transaction */
+				labelCheckRedeemTxn = codeByteBuffer.position();
+
+				// Update our 'last found transaction's timestamp' using 'timestamp' from transaction
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TIMESTAMP_FROM_TX_IN_A, addrLastTxnTimestamp));
+				// Extract transaction type (message/payment) from transaction and save type in addrTxnType
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(FunctionCode.GET_TYPE_FROM_TX_IN_A, addrTxnType));
+				// If transaction type is not MESSAGE type then go look for another transaction
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrTxnType, addrMessageTxnType, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+
+				/* Check message payload length */
+				codeByteBuffer.put(OpCode.EXT_FUN_RET.compile(QortalFunctionCode.GET_MESSAGE_LENGTH_FROM_TX_IN_A.value, addrMessageLength));
+				// If message length matches, branch to sender checking code
+				codeByteBuffer.put(OpCode.BEQ_DAT.compile(addrMessageLength, addrExpectedRedeemMessageLength, calcOffset(codeByteBuffer, labelCheckRedeemTxnSender)));
+				// Message length didn't match - go back to finding another 'redeem' MESSAGE transaction
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRedeemTxnLoop == null ? 0 : labelRedeemTxnLoop));
+
+				/* Check transaction's sender */
+				labelCheckRedeemTxnSender = codeByteBuffer.position();
+
+				// Extract sender address from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_ADDRESS_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageSender1 (as pointed to by addrMessageSenderPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageSenderPointer));
+				// Compare each part of transaction's sender's address with expected address. If they don't match, look for another transaction.
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender1, addrQortalPartnerAddress1, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender2, addrQortalPartnerAddress2, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender3, addrQortalPartnerAddress3, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+				codeByteBuffer.put(OpCode.BNE_DAT.compile(addrMessageSender4, addrQortalPartnerAddress4, calcOffset(codeByteBuffer, labelRedeemTxnLoop)));
+
+				/* Check 'secret-A' in transaction's message */
+
+				// Extract secret-A from first 32 bytes of message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN.compile(FunctionCode.PUT_MESSAGE_FROM_TX_IN_A_INTO_B));
+				// Save B register into data segment starting at addrMessageData (as pointed to by addrMessageDataPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrMessageDataPointer));
+				// Load B register with expected hash result (as pointed to by addrHashOfSecretAPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.SET_B_IND, addrHashOfSecretAPointer));
+				// Perform HASH160 using source data at addrMessageData. (Location and length specified via addrMessageDataPointer and addrMessageDataLength).
+				// Save the equality result (1 if they match, 0 otherwise) into addrResult.
+				codeByteBuffer.put(OpCode.EXT_FUN_RET_DAT_2.compile(FunctionCode.CHECK_HASH160_WITH_B, addrResult, addrMessageDataPointer, addrMessageDataLength));
+				// If hashes don't match, addrResult will be zero so go find another transaction
+				codeByteBuffer.put(OpCode.BNZ_DAT.compile(addrResult, calcOffset(codeByteBuffer, labelPayout)));
+				codeByteBuffer.put(OpCode.JMP_ADR.compile(labelRedeemTxnLoop == null ? 0 : labelRedeemTxnLoop));
+
+				/* Success! Pay arranged amount to receiving address */
+				labelPayout = codeByteBuffer.position();
+
+				// Extract Qortal receiving address from next 32 bytes of message from transaction into B register
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(QortalFunctionCode.PUT_PARTIAL_MESSAGE_FROM_TX_IN_A_INTO_B.value, addrRedeemMessageReceivingAddressOffset));
+				// Save B register into data segment starting at addrPartnerReceivingAddress (as pointed to by addrPartnerReceivingAddressPointer)
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.GET_B_IND, addrPartnerReceivingAddressPointer));
+				// Pay AT's balance to receiving address
+				codeByteBuffer.put(OpCode.EXT_FUN_DAT.compile(FunctionCode.PAY_TO_ADDRESS_IN_B, addrQortAmount));
+				// Set redeemed mode
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.REDEEMED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+
+				// Fall-through to refunding any remaining balance back to AT creator
+
+				/* Refund balance back to AT creator */
+				labelRefund = codeByteBuffer.position();
+
+				// Set refunded mode
+				codeByteBuffer.put(OpCode.SET_VAL.compile(addrMode, AcctMode.REFUNDED.value));
+				// We're finished forever (finishing auto-refunds remaining balance to AT creator)
+				codeByteBuffer.put(OpCode.FIN_IMD.compile());
+			} catch (CompilationException e) {
+				throw new IllegalStateException("Unable to compile NMC-QORT ACCT?", e);
+			}
+		}
+
+		codeByteBuffer.flip();
+
+		byte[] codeBytes = new byte[codeByteBuffer.limit()];
+		codeByteBuffer.get(codeBytes);
+
+		assert Arrays.equals(Crypto.digest(codeBytes), NamecoinACCTv3.CODE_BYTES_HASH)
+			: String.format("BTCACCT.CODE_BYTES_HASH mismatch: expected %s, actual %s", HashCode.fromBytes(CODE_BYTES_HASH), HashCode.fromBytes(Crypto.digest(codeBytes)));
+
+		final short ciyamAtVersion = 2;
+		final short numCallStackPages = 0;
+		final short numUserStackPages = 0;
+		final long minActivationAmount = 0L;
+
+		return MachineState.toCreationBytes(ciyamAtVersion, codeBytes, dataByteBuffer.array(), numCallStackPages, numUserStackPages, minActivationAmount);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	@Override
+	public CrossChainTradeData populateTradeData(Repository repository, ATData atData) throws DataException {
+		ATStateData atStateData = repository.getATRepository().getLatestATState(atData.getATAddress());
+		return populateTradeData(repository, atData.getCreatorPublicKey(), atData.getCreation(), atStateData);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	@Override
+	public CrossChainTradeData populateTradeData(Repository repository, ATStateData atStateData) throws DataException {
+		ATData atData = repository.getATRepository().fromATAddress(atStateData.getATAddress());
+		return populateTradeData(repository, atData.getCreatorPublicKey(), atData.getCreation(), atStateData);
+	}
+
+	/**
+	 * Returns CrossChainTradeData with useful info extracted from AT.
+	 */
+	public CrossChainTradeData populateTradeData(Repository repository, byte[] creatorPublicKey, long creationTimestamp, ATStateData atStateData) throws DataException {
+		byte[] addressBytes = new byte[25]; // for general use
+		String atAddress = atStateData.getATAddress();
+
+		CrossChainTradeData tradeData = new CrossChainTradeData();
+
+		tradeData.foreignBlockchain = SupportedBlockchain.NAMECOIN.name();
+		tradeData.acctName = NAME;
+
+		tradeData.qortalAtAddress = atAddress;
+		tradeData.qortalCreator = Crypto.toAddress(creatorPublicKey);
+		tradeData.creationTimestamp = creationTimestamp;
+
+		Account atAccount = new Account(repository, atAddress);
+		tradeData.qortBalance = atAccount.getConfirmedBalance(Asset.QORT);
+
+		byte[] stateData = atStateData.getStateData();
+		ByteBuffer dataByteBuffer = ByteBuffer.wrap(stateData);
+		dataByteBuffer.position(MachineState.HEADER_LENGTH);
+
+		/* Constants */
+
+		// Skip creator's trade address
+		dataByteBuffer.get(addressBytes);
+		tradeData.qortalCreatorTradeAddress = Base58.encode(addressBytes);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - addressBytes.length);
+
+		// Creator's Namecoin/foreign public key hash
+		tradeData.creatorForeignPKH = new byte[20];
+		dataByteBuffer.get(tradeData.creatorForeignPKH);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - tradeData.creatorForeignPKH.length); // skip to 32 bytes
+
+		// We don't use secret-B
+		tradeData.hashOfSecretB = null;
+
+		// Redeem payout
+		tradeData.qortAmount = dataByteBuffer.getLong();
+
+		// Expected NMC amount
+		tradeData.expectedForeignAmount = dataByteBuffer.getLong();
+
+		// Trade timeout
+		tradeData.tradeTimeout = (int) dataByteBuffer.getLong();
+
+		// Skip MESSAGE transaction type
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip expected 'trade' message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip expected 'redeem' message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to creator's address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's Qortal trade address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to message sender
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'trade' message data offset for partner's Namecoin PKH
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's Namecoin PKH
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'trade' message data offset for hash-of-secret-A
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to hash-of-secret-A
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip 'redeem' message data offset for partner's Qortal receiving address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to message data
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip message data length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip pointer to partner's receiving address
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		/* End of constants / begin variables */
+
+		// Skip AT creator's address
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Partner's trade address (if present)
+		dataByteBuffer.get(addressBytes);
+		String qortalRecipient = Base58.encode(addressBytes);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - addressBytes.length);
+
+		// Potential lockTimeA (if in trade mode)
+		int lockTimeA = (int) dataByteBuffer.getLong();
+
+		// AT refund timeout (probably only useful for debugging)
+		int refundTimeout = (int) dataByteBuffer.getLong();
+
+		// Trade-mode refund timestamp (AT 'timestamp' converted to Qortal block height)
+		long tradeRefundTimestamp = dataByteBuffer.getLong();
+
+		// Skip last transaction timestamp
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip block timestamp
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip transaction type
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary result
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary message sender
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Skip message length
+		dataByteBuffer.position(dataByteBuffer.position() + 8);
+
+		// Skip temporary message data
+		dataByteBuffer.position(dataByteBuffer.position() + 8 * 4);
+
+		// Potential hash160 of secret A
+		byte[] hashOfSecretA = new byte[20];
+		dataByteBuffer.get(hashOfSecretA);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - hashOfSecretA.length); // skip to 32 bytes
+
+		// Potential partner's Namecoin PKH
+		byte[] partnerNamecoinPKH = new byte[20];
+		dataByteBuffer.get(partnerNamecoinPKH);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - partnerNamecoinPKH.length); // skip to 32 bytes
+
+		// Partner's receiving address (if present)
+		byte[] partnerReceivingAddress = new byte[25];
+		dataByteBuffer.get(partnerReceivingAddress);
+		dataByteBuffer.position(dataByteBuffer.position() + 32 - partnerReceivingAddress.length); // skip to 32 bytes
+
+		// Trade AT's 'mode'
+		long modeValue = dataByteBuffer.getLong();
+		AcctMode mode = AcctMode.valueOf((int) (modeValue & 0xffL));
+
+		/* End of variables */
+
+		if (mode != null && mode != AcctMode.OFFERING) {
+			tradeData.mode = mode;
+			tradeData.refundTimeout = refundTimeout;
+			tradeData.tradeRefundHeight = new Timestamp(tradeRefundTimestamp).blockHeight;
+			tradeData.qortalPartnerAddress = qortalRecipient;
+			tradeData.hashOfSecretA = hashOfSecretA;
+			tradeData.partnerForeignPKH = partnerNamecoinPKH;
+			tradeData.lockTimeA = lockTimeA;
+
+			if (mode == AcctMode.REDEEMED)
+				tradeData.qortalPartnerReceivingAddress = Base58.encode(partnerReceivingAddress);
+		} else {
+			tradeData.mode = AcctMode.OFFERING;
+		}
+
+		tradeData.duplicateDeprecated();
+
+		return tradeData;
+	}
+
+	/** Returns 'offer' MESSAGE payload for trade partner to send to AT creator's trade address. */
+	public static byte[] buildOfferMessage(byte[] partnerBitcoinPKH, byte[] hashOfSecretA, int lockTimeA) {
+		byte[] lockTimeABytes = BitTwiddling.toBEByteArray((long) lockTimeA);
+		return Bytes.concat(partnerBitcoinPKH, hashOfSecretA, lockTimeABytes);
+	}
+
+	/** Returns info extracted from 'offer' MESSAGE payload sent by trade partner to AT creator's trade address, or null if not valid. */
+	public static OfferMessageData extractOfferMessageData(byte[] messageData) {
+		if (messageData == null || messageData.length != OFFER_MESSAGE_LENGTH)
+			return null;
+
+		OfferMessageData offerMessageData = new OfferMessageData();
+		offerMessageData.partnerNamecoinPKH = Arrays.copyOfRange(messageData, 0, 20);
+		offerMessageData.hashOfSecretA = Arrays.copyOfRange(messageData, 20, 40);
+		offerMessageData.lockTimeA = BitTwiddling.longFromBEBytes(messageData, 40);
+
+		return offerMessageData;
+	}
+
+	/** Returns 'trade' MESSAGE payload for AT creator to send to AT. */
+	public static byte[] buildTradeMessage(String partnerQortalTradeAddress, byte[] partnerBitcoinPKH, byte[] hashOfSecretA, int lockTimeA, int refundTimeout) {
+		byte[] data = new byte[TRADE_MESSAGE_LENGTH];
+		byte[] partnerQortalAddressBytes = Base58.decode(partnerQortalTradeAddress);
+		byte[] lockTimeABytes = BitTwiddling.toBEByteArray((long) lockTimeA);
+		byte[] refundTimeoutBytes = BitTwiddling.toBEByteArray((long) refundTimeout);
+
+		System.arraycopy(partnerQortalAddressBytes, 0, data, 0, partnerQortalAddressBytes.length);
+		System.arraycopy(partnerBitcoinPKH, 0, data, 32, partnerBitcoinPKH.length);
+		System.arraycopy(refundTimeoutBytes, 0, data, 56, refundTimeoutBytes.length);
+		System.arraycopy(hashOfSecretA, 0, data, 64, hashOfSecretA.length);
+		System.arraycopy(lockTimeABytes, 0, data, 88, lockTimeABytes.length);
+
+		return data;
+	}
+
+	/** Returns 'cancel' MESSAGE payload for AT creator to cancel trade AT. */
+	@Override
+	public byte[] buildCancelMessage(String creatorQortalAddress) {
+		byte[] data = new byte[CANCEL_MESSAGE_LENGTH];
+		byte[] creatorQortalAddressBytes = Base58.decode(creatorQortalAddress);
+
+		System.arraycopy(creatorQortalAddressBytes, 0, data, 0, creatorQortalAddressBytes.length);
+
+		return data;
+	}
+
+	/** Returns 'redeem' MESSAGE payload for trade partner to send to AT. */
+	public static byte[] buildRedeemMessage(byte[] secretA, String qortalReceivingAddress) {
+		byte[] data = new byte[REDEEM_MESSAGE_LENGTH];
+		byte[] qortalReceivingAddressBytes = Base58.decode(qortalReceivingAddress);
+
+		System.arraycopy(secretA, 0, data, 0, secretA.length);
+		System.arraycopy(qortalReceivingAddressBytes, 0, data, 32, qortalReceivingAddressBytes.length);
+
+		return data;
+	}
+
+	/** Returns refund timeout (minutes) based on trade partner's 'offer' MESSAGE timestamp and P2SH-A locktime. */
+	public static int calcRefundTimeout(long offerMessageTimestamp, int lockTimeA) {
+		// refund should be triggered halfway between offerMessageTimestamp and lockTimeA
+		return (int) ((lockTimeA - (offerMessageTimestamp / 1000L)) / 2L / 60L);
+	}
+
+	@Override
+	public byte[] findSecretA(Repository repository, CrossChainTradeData crossChainTradeData) throws DataException {
+		String atAddress = crossChainTradeData.qortalAtAddress;
+		String redeemerAddress = crossChainTradeData.qortalPartnerAddress;
+
+		// We don't have partner's public key so we check every message to AT
+		List<MessageTransactionData> messageTransactionsData = repository.getMessageRepository().getMessagesByParticipants(null, atAddress, null, null, null);
+		if (messageTransactionsData == null)
+			return null;
+
+		// Find 'redeem' message
+		for (MessageTransactionData messageTransactionData : messageTransactionsData) {
+			// Check message payload type/encryption
+			if (messageTransactionData.isText() || messageTransactionData.isEncrypted())
+				continue;
+
+			// Check message payload size
+			byte[] messageData = messageTransactionData.getData();
+			if (messageData.length != REDEEM_MESSAGE_LENGTH)
+				// Wrong payload length
+				continue;
+
+			// Check sender
+			if (!Crypto.toAddress(messageTransactionData.getSenderPublicKey()).equals(redeemerAddress))
+				// Wrong sender;
+				continue;
+
+			// Extract secretA
+			byte[] secretA = new byte[32];
+			System.arraycopy(messageData, 0, secretA, 0, secretA.length);
+
+			byte[] hashOfSecretA = Crypto.hash160(secretA);
+			if (!Arrays.equals(hashOfSecretA, crossChainTradeData.hashOfSecretA))
+				continue;
+
+			return secretA;
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/org/qortal/crosschain/SupportedBlockchain.java
+++ b/src/main/java/org/qortal/crosschain/SupportedBlockchain.java
@@ -97,6 +97,48 @@ public enum SupportedBlockchain {
 		public ACCT getLatestAcct() {
 			return PirateChainACCTv3.getInstance();
 		}
+	},
+
+	NAMECOIN(Arrays.asList(
+			Triple.valueOf(NamecoinACCTv3.NAME, NamecoinACCTv3.CODE_BYTES_HASH, NamecoinACCTv3::getInstance)
+		)) {
+		@Override
+		public ForeignBlockchain getInstance() {
+			return Namecoin.getInstance();
+		}
+
+		@Override
+		public ACCT getLatestAcct() {
+			return NamecoinACCTv3.getInstance();
+		}
+	},
+
+	DASH(Arrays.asList(
+			Triple.valueOf(DashACCTv3.NAME, DashACCTv3.CODE_BYTES_HASH, DashACCTv3::getInstance)
+		)) {
+		@Override
+		public ForeignBlockchain getInstance() {
+			return Dash.getInstance();
+		}
+
+		@Override
+		public ACCT getLatestAcct() {
+			return DashACCTv3.getInstance();
+		}
+	},
+
+	FIRO(Arrays.asList(
+			Triple.valueOf(FiroACCTv3.NAME, FiroACCTv3.CODE_BYTES_HASH, FiroACCTv3::getInstance)
+		)) {
+		@Override
+		public ForeignBlockchain getInstance() {
+			return Firo.getInstance();
+		}
+
+		@Override
+		public ACCT getLatestAcct() {
+			return FiroACCTv3.getInstance();
+		}
 	};
 
 	private static final Map<ByteArray, Supplier<ACCT>> supportedAcctsByCodeHash = Arrays.stream(SupportedBlockchain.values())

--- a/src/main/java/org/qortal/settings/Settings.java
+++ b/src/main/java/org/qortal/settings/Settings.java
@@ -13,6 +13,9 @@ import org.qortal.crosschain.Dogecoin.DogecoinNet;
 import org.qortal.crosschain.Litecoin.LitecoinNet;
 import org.qortal.crosschain.PirateChain.PirateChainNet;
 import org.qortal.crosschain.Ravencoin.RavencoinNet;
+import org.qortal.crosschain.Namecoin.NamecoinNet;
+import org.qortal.crosschain.Dash.DashNet;
+import org.qortal.crosschain.Firo.FiroNet;
 import org.qortal.network.message.MessageType;
 import org.qortal.utils.EnumUtils;
 
@@ -241,6 +244,9 @@ public class Settings {
 	private DigibyteNet digibyteNet = DigibyteNet.MAIN;
 	private RavencoinNet ravencoinNet = RavencoinNet.MAIN;
 	private PirateChainNet pirateChainNet = PirateChainNet.MAIN;
+	private NamecoinNet namecoinNet = NamecoinNet.MAIN;
+	private DashNet dashNet = DashNet.MAIN;
+	private FiroNet firoNet = FiroNet.MAIN;
 	// Also crosschain-related:
 	/** Whether to show SysTray pop-up notifications when trade-bot entries change state */
 	private boolean tradebotSystrayEnabled = false;
@@ -855,6 +861,18 @@ public class Settings {
 
 	public PirateChainNet getPirateChainNet() {
 		return this.pirateChainNet;
+	}
+
+	public NamecoinNet getNamecoinNet() {
+		return this.namecoinNet;
+	}
+
+	public DashNet getDashNet() {
+		return this.dashNet;
+	}
+
+	public FiroNet getFiroNet() {
+		return this.firoNet;
 	}
 
 	public int getMaxTradeOfferAttempts() {


### PR DESCRIPTION
Introduction:
Since one of Qortal's goals is to allow anyone to build onto the platform, it's understood that some people in the community will want to run customized or personalized versions of the software.  As this is a fully open source codebase, there should be no problem for someone to do that, as long as the blockchain consensus is still unchanged.  One of the important features of Qortal is the Trade Portal, which allows anyone to trade supported coins without needing to rely on centralized services or provide KYC.  Qortal's ACCT system is generalized for compatibility with many different blockchains, so a community could add their preferred coins to be traded and distribute a custom version of Core and UI which includes those.  Currently there are discussions with developers from several other blockchain projects, who may be able to assist with relevant code.

Problem:
Within the Qortal UI, there is a filter for available trades, which removes them from display if they were created by a node which is currently offline.  This is to prevent someone from accepting that trade, and not getting a response, causing their coins to be temporarily locked until they are refunded.  Previously, nodes submitted a "presence" transaction to the blockchain, to indicate they are available for trading, but this was later changed to a separate off-chain peer-to-peer protocol within the Core.  This protocol now checks the trade to see if the AT hash matches the known supported coins.  What this means for someone who wants to trade other coins, is that only nodes which are running the custom Core will allow the presence for those trades to propagate across the network.  If two people who don't know each other wanted to make a secure trade, they would need to be directly connected as network peers, which may not be possible or desirable, otherwise the UI does not show the trades.

Request:
This pull request does not add any new functionality to the Core, except the ability for all nodes within the network to recognize presence for some new coins.  This not does add any features involving sending, trading, or checking balances on these blockchains.  The majority of the code is just placeholder, with the only important value being the AT hash.  Everything else is simply added to ensure that the code compiles properly, and much of it could probably be set to null or empty values.  With these trades recognized, people will be able to test their own additions more properly.  The changes have passed all unit tests, and manual testing with various types of platform usage.

Alternatives:
This seems like the simplest and fastest way to solve the problem encountered when testing out trades on a new chain, however there may be other options that are more effective.  If there is a way to recognize whether an AT is a trade, or some other type of AT, then any custom trade presence could be passed on by non-custom peers.  With more changes, this could even be something that each node owner allows or blocks in their settings, similar to the options for QDN relay mode.

Rationale:
It's been decided that adding any new coins to the Wallet and Trade Portal must be approved by an on-chain vote from the community.  As this is effectively a set of constants, rather than full support for the new coins, it may not be something that would require a vote.  Additionally, by setting the AT hash for these specific coins in the main release, it prevents others from accidentally using the same hash for two different custom coins, which would result in those unrelated tradebooks being merged.  It is worth mentioning that there is a preliminary vote running, which currently shows that a majority of respondents would support adding each of these three coins.  Before the last Core update, they were around 65% in favor, and currently they stand at about 55%.  Even considering that we'll need to wait for another few updates to get more accurate results, and the low number of voters, that indicates there is not a strong consensus either way.  Adding these coins for "custom support only" would be a great way to allow people to test and become aware of the proposal, and encourage more people to vote, giving a better idea of what the community wants.
- Additional votes can still be posted, and the results can be reviewed at: `qortal://app/VotingTest`