### PR TITLE
Fixed vote weight results API call

### DIFF
--- a/src/main/java/org/qortal/api/resource/PollsResource.java
+++ b/src/main/java/org/qortal/api/resource/PollsResource.java
@@ -142,7 +142,7 @@ public class PollsResource {
                     for (VoteOnPollData vote : votes) {
                             String voter = Crypto.toAddress(vote.getVoterPublicKey());
                             AccountData voterData = repository.getAccountRepository().getAccount(voter);
-                            int voteWeight = voterData.getBlocksMinted() - voterData.getBlocksMintedPenalty();
+                            int voteWeight = voterData.getBlocksMinted() + voterData.getBlocksMintedPenalty();
                             if (voteWeight < 0) voteWeight = 0;
                             totalWeight += voteWeight;
 


### PR DESCRIPTION
blocksMintedPenalty is a negative value, so it should be added to blocksMinted, not subtracted.