### PR TITLE
Add ElectrumX server settings

### DIFF
--- a/src/main/java/org/qortal/crosschain/Bitcoin.java
+++ b/src/main/java/org/qortal/crosschain/Bitcoin.java
@@ -10,9 +10,11 @@ import org.qortal.crosschain.ElectrumX.Server;
 import org.qortal.crosschain.ChainableServer.ConnectionType;
 import org.qortal.settings.Settings;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 public class Bitcoin extends Bitcoiny {
@@ -43,7 +45,7 @@ public class Bitcoin extends Bitcoiny {
 
 			@Override
 			public Collection<ElectrumX.Server> getServers() {
-				return Arrays.asList(
+				List<ElectrumX.Server> defaultServers = Arrays.asList(
 					// Servers chosen on NO BASIS WHATSOEVER from various sources!
 					// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=btc
 					new Server("104.198.149.61", Server.ConnectionType.SSL, 50002),
@@ -104,6 +106,35 @@ public class Bitcoin extends Bitcoiny {
 					new Server("vmd63185.contaboserver.net", Server.ConnectionType.SSL, 50002),
 					new Server("xtrum.com", Server.ConnectionType.SSL, 50002)
 				);
+
+				List<ElectrumX.Server> availableServers = new ArrayList<>();
+				Boolean useDefault = Settings.getInstance().getUseBitcoinDefaults();
+				if (useDefault == true) {
+					availableServers.addAll(defaultServers);
+				}
+
+				String[] settingsList = Settings.getInstance().getBitcoinServers();
+				if (settingsList != null) {
+					List<ElectrumX.Server> customServers = new ArrayList<>();
+					for (String setting : settingsList) {
+						String[] colonParts = setting.split(":");
+						if (colonParts.length == 2) {
+							String[] commaParts = colonParts[1].split(",");
+							if (commaParts.length == 2) {
+								String hostname = colonParts[0];
+								int port = Integer.parseInt(commaParts[0].trim());
+								String typeString = commaParts[1].trim().toUpperCase();
+								Server.ConnectionType type = Server.ConnectionType.SSL;
+								if (typeString.equals("TCP")) {
+									type = Server.ConnectionType.TCP;
+								}
+								customServers.add(new Server(hostname, type, port));
+							}
+						}
+					}
+					availableServers.addAll(customServers);
+				}
+				return availableServers;
 			}
 
 			@Override

--- a/src/main/java/org/qortal/crosschain/Digibyte.java
+++ b/src/main/java/org/qortal/crosschain/Digibyte.java
@@ -10,9 +10,11 @@ import org.qortal.crosschain.ElectrumX.Server;
 import org.qortal.crosschain.ChainableServer.ConnectionType;
 import org.qortal.settings.Settings;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 public class Digibyte extends Bitcoiny {
@@ -42,7 +44,7 @@ public class Digibyte extends Bitcoiny {
 
 			@Override
 			public Collection<Server> getServers() {
-				return Arrays.asList(
+				List<ElectrumX.Server> defaultServers = Arrays.asList(
 					// Servers chosen on NO BASIS WHATSOEVER from various sources!
 					// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=dgb
 					new Server("electrum.qortal.link", Server.ConnectionType.SSL, 55002),
@@ -50,6 +52,35 @@ public class Digibyte extends Bitcoiny {
 					new Server("electrum2.cipig.net", Server.ConnectionType.SSL, 20059),
 					new Server("electrum3.cipig.net", Server.ConnectionType.SSL, 20059)
 				);
+
+				List<ElectrumX.Server> availableServers = new ArrayList<>();
+				Boolean useDefault = Settings.getInstance().getUseDigibyteDefaults();
+				if (useDefault == true) {
+					availableServers.addAll(defaultServers);
+				}
+
+				String[] settingsList = Settings.getInstance().getDigibyteServers();
+				if (settingsList != null) {
+					List<ElectrumX.Server> customServers = new ArrayList<>();
+					for (String setting : settingsList) {
+						String[] colonParts = setting.split(":");
+						if (colonParts.length == 2) {
+							String[] commaParts = colonParts[1].split(",");
+							if (commaParts.length == 2) {
+								String hostname = colonParts[0];
+								int port = Integer.parseInt(commaParts[0].trim());
+								String typeString = commaParts[1].trim().toUpperCase();
+								Server.ConnectionType type = Server.ConnectionType.SSL;
+								if (typeString.equals("TCP")) {
+									type = Server.ConnectionType.TCP;
+								}
+								customServers.add(new Server(hostname, type, port));
+							}
+						}
+					}
+					availableServers.addAll(customServers);
+				}
+				return availableServers;
 			}
 
 			@Override

--- a/src/main/java/org/qortal/crosschain/Dogecoin.java
+++ b/src/main/java/org/qortal/crosschain/Dogecoin.java
@@ -9,9 +9,11 @@ import org.qortal.crosschain.ElectrumX.Server;
 import org.qortal.crosschain.ChainableServer.ConnectionType;
 import org.qortal.settings.Settings;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 public class Dogecoin extends Bitcoiny {
@@ -42,7 +44,7 @@ public class Dogecoin extends Bitcoiny {
 
 			@Override
 			public Collection<Server> getServers() {
-				return Arrays.asList(
+				List<ElectrumX.Server> defaultServers = Arrays.asList(
 					// Servers chosen on NO BASIS WHATSOEVER from various sources!
 					// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=doge
 					new Server("dogecoin.stackwallet.com", Server.ConnectionType.SSL, 50022),
@@ -51,6 +53,35 @@ public class Dogecoin extends Bitcoiny {
 					new Server("electrum2.cipig.net", Server.ConnectionType.SSL, 20060),
 					new Server("electrum3.cipig.net", Server.ConnectionType.SSL, 20060)
 				);
+
+				List<ElectrumX.Server> availableServers = new ArrayList<>();
+				Boolean useDefault = Settings.getInstance().getUseDogecoinDefaults();
+				if (useDefault == true) {
+					availableServers.addAll(defaultServers);
+				}
+
+				String[] settingsList = Settings.getInstance().getDogecoinServers();
+				if (settingsList != null) {
+					List<ElectrumX.Server> customServers = new ArrayList<>();
+					for (String setting : settingsList) {
+						String[] colonParts = setting.split(":");
+						if (colonParts.length == 2) {
+							String[] commaParts = colonParts[1].split(",");
+							if (commaParts.length == 2) {
+								String hostname = colonParts[0];
+								int port = Integer.parseInt(commaParts[0].trim());
+								String typeString = commaParts[1].trim().toUpperCase();
+								Server.ConnectionType type = Server.ConnectionType.SSL;
+								if (typeString.equals("TCP")) {
+									type = Server.ConnectionType.TCP;
+								}
+								customServers.add(new Server(hostname, type, port));
+							}
+						}
+					}
+					availableServers.addAll(customServers);
+				}
+				return availableServers;
 			}
 
 			@Override

--- a/src/main/java/org/qortal/crosschain/PirateChain.java
+++ b/src/main/java/org/qortal/crosschain/PirateChain.java
@@ -49,10 +49,39 @@ public class PirateChain extends Bitcoiny {
 
 			@Override
 			public Collection<Server> getServers() {
-				return Arrays.asList(
+				List<Server> defaultServers = Arrays.asList(
 					// Servers chosen on NO BASIS WHATSOEVER from various sources!
 					new Server("lightd.pirate.black", Server.ConnectionType.SSL, 443)
 				);
+
+				List<Server> availableServers = new ArrayList<>();
+				Boolean useDefault = Settings.getInstance().getUsePirateChainDefaults();
+				if (useDefault == true) {
+					availableServers.addAll(defaultServers);
+				}
+
+				String[] settingsList = Settings.getInstance().getPirateChainServers();
+				if (settingsList != null) {
+					List<Server> customServers = new ArrayList<>();
+					for (String setting : settingsList) {
+						String[] colonParts = setting.split(":");
+						if (colonParts.length == 2) {
+							String[] commaParts = colonParts[1].split(",");
+							if (commaParts.length == 2) {
+								String hostname = colonParts[0];
+								int port = Integer.parseInt(commaParts[0].trim());
+								String typeString = commaParts[1].trim().toUpperCase();
+								Server.ConnectionType type = Server.ConnectionType.SSL;
+								if (typeString.equals("TCP")) {
+									type = Server.ConnectionType.TCP;
+								}
+								customServers.add(new Server(hostname, type, port));
+							}
+						}
+					}
+					availableServers.addAll(customServers);
+				}
+				return availableServers;
 			}
 
 			@Override

--- a/src/main/java/org/qortal/crosschain/Ravencoin.java
+++ b/src/main/java/org/qortal/crosschain/Ravencoin.java
@@ -10,9 +10,11 @@ import org.qortal.crosschain.ElectrumX.Server;
 import org.qortal.crosschain.ChainableServer.ConnectionType;
 import org.qortal.settings.Settings;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 public class Ravencoin extends Bitcoiny {
@@ -42,7 +44,7 @@ public class Ravencoin extends Bitcoiny {
 
 			@Override
 			public Collection<Server> getServers() {
-				return Arrays.asList(
+				List<ElectrumX.Server> defaultServers = Arrays.asList(
 					// Servers chosen on NO BASIS WHATSOEVER from various sources!
 					// Status verified at https://1209k.com/bitcoin-eye/ele.php?chain=rvn
 					new Server("electrum.qortal.link", Server.ConnectionType.SSL, 56002),
@@ -52,6 +54,35 @@ public class Ravencoin extends Bitcoiny {
 					new Server("rvn-dashboard.com", Server.ConnectionType.SSL, 50002),
 					new Server("rvn4lyfe.com", Server.ConnectionType.SSL, 50002)
 				);
+
+				List<ElectrumX.Server> availableServers = new ArrayList<>();
+				Boolean useDefault = Settings.getInstance().getUseRavencoinDefaults();
+				if (useDefault == true) {
+					availableServers.addAll(defaultServers);
+				}
+
+				String[] settingsList = Settings.getInstance().getRavencoinServers();
+				if (settingsList != null) {
+					List<ElectrumX.Server> customServers = new ArrayList<>();
+					for (String setting : settingsList) {
+						String[] colonParts = setting.split(":");
+						if (colonParts.length == 2) {
+							String[] commaParts = colonParts[1].split(",");
+							if (commaParts.length == 2) {
+								String hostname = colonParts[0];
+								int port = Integer.parseInt(commaParts[0].trim());
+								String typeString = commaParts[1].trim().toUpperCase();
+								Server.ConnectionType type = Server.ConnectionType.SSL;
+								if (typeString.equals("TCP")) {
+									type = Server.ConnectionType.TCP;
+								}
+								customServers.add(new Server(hostname, type, port));
+							}
+						}
+					}
+					availableServers.addAll(customServers);
+				}
+				return availableServers;
 			}
 
 			@Override

--- a/src/main/java/org/qortal/settings/Settings.java
+++ b/src/main/java/org/qortal/settings/Settings.java
@@ -241,6 +241,23 @@ public class Settings {
 	private DigibyteNet digibyteNet = DigibyteNet.MAIN;
 	private RavencoinNet ravencoinNet = RavencoinNet.MAIN;
 	private PirateChainNet pirateChainNet = PirateChainNet.MAIN;
+
+	// List of ElectrumX servers to attempt connections with
+	private String[] bitcoinServers = null;
+	private String[] litecoinServers = null;
+	private String[] dogecoinServers = null;
+	private String[] digibyteServers = null;
+	private String[] ravencoinServers = null;
+	private String[] pirateChainServers = null;
+
+	// Whether to connect with the default ElectrumX servers
+	private Boolean useBitcoinDefaults = true;
+	private Boolean useLitecoinDefaults = true;
+	private Boolean useDogecoinDefaults = true;
+	private Boolean useDigibyteDefaults = true;
+	private Boolean useRavencoinDefaults = true;
+	private Boolean usePirateChainDefaults = true;
+
 	// Also crosschain-related:
 	/** Whether to show SysTray pop-up notifications when trade-bot entries change state */
 	private boolean tradebotSystrayEnabled = false;
@@ -855,6 +872,44 @@ public class Settings {
 
 	public PirateChainNet getPirateChainNet() {
 		return this.pirateChainNet;
+	}
+
+	public String[] getBitcoinServers() {
+		return this.bitcoinServers;
+	}
+	public String[] getLitecoinServers() {
+		return this.litecoinServers;
+	}
+	public String[] getDogecoinServers() {
+		return this.dogecoinServers;
+	}
+	public String[] getDigibyteServers() {
+		return this.digibyteServers;
+	}
+	public String[] getRavencoinServers() {
+		return this.ravencoinServers;
+	}
+	public String[] getPirateChainServers() {
+		return this.pirateChainServers;
+	}
+
+	public Boolean getUseBitcoinDefaults() {
+		return this.useBitcoinDefaults;
+	}
+	public Boolean getUseLitecoinDefaults() {
+		return this.useLitecoinDefaults;
+	}
+	public Boolean getUseDogecoinDefaults() {
+		return this.useDogecoinDefaults;
+	}
+	public Boolean getUseDigibyteDefaults() {
+		return this.useDigibyteDefaults;
+	}
+	public Boolean getUseRavencoinDefaults() {
+		return this.useRavencoinDefaults;
+	}
+	public Boolean getUsePirateChainDefaults() {
+		return this.usePirateChainDefaults;
 	}
 
 	public int getMaxTradeOfferAttempts() {


### PR DESCRIPTION
This adds two new settings for each of the supported foreign coins.  These settings allow users to specify ElectrumX servers to use (or wallet servers for Piratechain), and whether or not to use the default servers provided by the Core.  This gives users more control over their node, and allows easier testing for issues with specific wallets or servers.  As an example, the following lines could be added to settings.json to disable default servers and connect only to qortal.link:
`"useDogecoinDefaults": false, "dogecoinServers": ["electrum.qortal.link:54002,SSL"]`