### PR TITLE
Add debug logging when invalid timestamp is encountered

### DIFF
--- a/src/main/java/org/qortal/block/Block.java
+++ b/src/main/java/org/qortal/block/Block.java
@@ -1061,8 +1061,10 @@ public class Block {
 			return ValidationResult.MINTER_NOT_ACCEPTED;
 
 		long expectedTimestamp = calcTimestamp(parentBlockData, this.blockData.getMinterPublicKey(), minterLevel);
-		if (this.blockData.getTimestamp() != expectedTimestamp)
-			return ValidationResult.TIMESTAMP_INCORRECT;
+		if (this.blockData.getTimestamp() != expectedTimestamp) {
+                    LOGGER.debug(String.format("timestamp mismatch! block had %s but we expected %s", this.blockData.getTimestamp(), expectedTimestamp));
+                    return ValidationResult.TIMESTAMP_INCORRECT;
+                }
 
 		return ValidationResult.OK;
 	}


### PR DESCRIPTION
I'm not familiar with Java so this PR may need some tweaks before it would do what I want.  (I didn't test the changes.)

Twice in the last month I've encountered the "stuck block" issue on my laptop node.  Both times appear to have been close to the reward share payout block, IIUC.  I've documented what I know about it so far at:

https://qortal.link/APP/qwiki/edbob/qortal/StuckBlock

Thankfully the logged errors for TIMESTAMP_INCORRECT pointed to only one place in the code, but I'm not clear still what is going wrong per se.  I am suggesting we add a bit more logging at that point, so next time this happens we'll at least have a more solid clue as to why the timestamp is not considered valid.

Or with any luck someone can decipher my notes and deduce the problem..?  I'm happy to provide more info if needed, let me know.