### PR TITLE
Search group name / description

### DIFF
--- a/src/main/java/org/qortal/repository/GroupRepository.java
+++ b/src/main/java/org/qortal/repository/GroupRepository.java
@@ -36,6 +36,8 @@ public interface GroupRepository {
 		return getGroupsWithMember(member, null, null, null);
 	}
 
+	public List<GroupData> searchGroups(String query, Integer limit, Integer offset, Boolean reverse) throws DataException;
+
 	public void save(GroupData groupData) throws DataException;
 
 	public void delete(int groupId) throws DataException;


### PR DESCRIPTION
This completes the following item on the Qortal Core task list:
https://github.com/orgs/Qortal/projects/3/views/1?pane=issue&itemId=40151209

This adds an API call that returns any groups that have the given query string included within the group name or description.  This will allow users to find groups relating to a given topic, without knowing the exact name or group id.