### PR TITLE
Add private name sales to consensus

### DIFF
--- a/src/main/java/org/qortal/data/naming/NameData.java
+++ b/src/main/java/org/qortal/data/naming/NameData.java
@@ -30,6 +30,10 @@ public class NameData {
 	@XmlJavaTypeAdapter(value = org.qortal.api.AmountTypeAdapter.class)
 	private Long salePrice;
 
+	private boolean isPrivateSale;
+
+	private String saleRecipient; // Not always present
+
 	// For internal use - no need to expose this via API
 	@XmlTransient
 	@Schema(hidden = true)
@@ -49,6 +53,7 @@ public class NameData {
 	// Typically used when fetching from repository
 	public NameData(String name, String reducedName, String owner, String data, long registered,
 			Long updated, boolean isForSale, Long salePrice,
+			boolean isPrivateSale, String saleRecipient,
 			byte[] reference, int creationGroupId) {
 		this.name = name;
 		this.reducedName = reducedName;
@@ -59,12 +64,14 @@ public class NameData {
 		this.reference = reference;
 		this.isForSale = isForSale;
 		this.salePrice = salePrice;
+		this.isPrivateSale = isPrivateSale;
+		this.saleRecipient = saleRecipient;
 		this.creationGroupId = creationGroupId;
 	}
 
 	// Typically used when registering a new name
 	public NameData(String name, String reducedName, String owner, String data, long registered, byte[] reference, int creationGroupId) {
-		this(name, reducedName, owner, data, registered, null, false, null, reference, creationGroupId);
+		this(name, reducedName, owner, data, registered, null, false, null, false, null, reference, creationGroupId);
 	}
 
 	// Getters / setters
@@ -127,6 +134,22 @@ public class NameData {
 
 	public void setSalePrice(Long salePrice) {
 		this.salePrice = salePrice;
+	}
+
+	public boolean getIsPrivateSale() {
+		return this.isPrivateSale;
+	}
+
+	public void setIsPrivateSale(boolean isPrivateSale) {
+		this.isPrivateSale = isPrivateSale;
+	}
+
+	public String getSaleRecipient() {
+		return this.saleRecipient;
+	}
+
+	public void setSaleRecipient(String saleRecipient) {
+		this.saleRecipient = saleRecipient;
 	}
 
 	public byte[] getReference() {

--- a/src/main/java/org/qortal/data/transaction/BuyNameTransactionData.java
+++ b/src/main/java/org/qortal/data/transaction/BuyNameTransactionData.java
@@ -32,6 +32,9 @@ public class BuyNameTransactionData extends TransactionData {
 	// For internal use when orphaning
 	@XmlTransient
 	@Schema(hidden = true)
+	private boolean isPrivateSale;
+	@XmlTransient
+	@Schema(hidden = true)
 	private byte[] nameReference;
 
 	// Constructors
@@ -47,19 +50,23 @@ public class BuyNameTransactionData extends TransactionData {
 
 	/** From repository */
 	public BuyNameTransactionData(BaseTransactionData baseTransactionData,
-			String name, long amount, String seller, byte[] nameReference) {
+			String name, long amount, String seller, boolean isPrivateSale, byte[] nameReference) {
 		super(TransactionType.BUY_NAME, baseTransactionData);
 
 		this.buyerPublicKey = baseTransactionData.creatorPublicKey;
 		this.name = name;
 		this.amount = amount;
 		this.seller = seller;
+		this.isPrivateSale = isPrivateSale;
 		this.nameReference = nameReference;
 	}
 
 	/** From network/API */
+	public BuyNameTransactionData(BaseTransactionData baseTransactionData, String name, long amount, String seller, boolean isPrivateSale) {
+		this(baseTransactionData, name, amount, seller, isPrivateSale, null);
+	}
 	public BuyNameTransactionData(BaseTransactionData baseTransactionData, String name, long amount, String seller) {
-		this(baseTransactionData, name, amount, seller, null);
+		this(baseTransactionData, name, amount, seller, false, null);
 	}
 
 	// Getters / setters
@@ -78,6 +85,14 @@ public class BuyNameTransactionData extends TransactionData {
 
 	public String getSeller() {
 		return this.seller;
+	}
+
+	public boolean getIsPrivateSale() {
+		return this.isPrivateSale;
+	}
+
+	public void setIsPrivateSale(boolean isPrivateSale) {
+		this.isPrivateSale = isPrivateSale;
 	}
 
 	public byte[] getNameReference() {

--- a/src/main/java/org/qortal/data/transaction/CancelSellNameTransactionData.java
+++ b/src/main/java/org/qortal/data/transaction/CancelSellNameTransactionData.java
@@ -23,6 +23,12 @@ public class CancelSellNameTransactionData extends TransactionData {
 	@XmlTransient
 	@Schema(hidden = true)
 	private Long salePrice;
+	@XmlTransient
+	@Schema(hidden = true)
+	private boolean isPrivateSale;
+	@XmlTransient
+	@Schema(hidden = true)
+	private String saleRecipient;
 
 	// Constructors
 
@@ -35,17 +41,19 @@ public class CancelSellNameTransactionData extends TransactionData {
 		this.creatorPublicKey = this.ownerPublicKey;
 	}
 
-	public CancelSellNameTransactionData(BaseTransactionData baseTransactionData, String name, Long salePrice) {
+	public CancelSellNameTransactionData(BaseTransactionData baseTransactionData, String name, Long salePrice, boolean isPrivateSale, String saleRecipient) {
 		super(TransactionType.CANCEL_SELL_NAME, baseTransactionData);
 
 		this.ownerPublicKey = baseTransactionData.creatorPublicKey;
 		this.name = name;
 		this.salePrice = salePrice;
+		this.isPrivateSale = isPrivateSale;
+		this.saleRecipient = saleRecipient;
 	}
 
 	/** From network/API */
 	public CancelSellNameTransactionData(BaseTransactionData baseTransactionData, String name) {
-		this(baseTransactionData, name, null);
+		this(baseTransactionData, name, null, false, null);
 	}
 
 	// Getters / setters
@@ -64,6 +72,22 @@ public class CancelSellNameTransactionData extends TransactionData {
 
 	public void setSalePrice(Long salePrice) {
 		this.salePrice = salePrice;
+	}
+
+	public boolean getIsPrivateSale() {
+		return this.isPrivateSale;
+	}
+
+	public void setIsPrivateSale(boolean isPrivateSale) {
+		this.isPrivateSale = isPrivateSale;
+	}
+
+	public String getSaleRecipient() {
+		return this.saleRecipient;
+	}
+
+	public void setSaleRecipient(String saleRecipient) {
+		this.saleRecipient = saleRecipient;
 	}
 
 }

--- a/src/main/java/org/qortal/data/transaction/SellNameTransactionData.java
+++ b/src/main/java/org/qortal/data/transaction/SellNameTransactionData.java
@@ -25,6 +25,12 @@ public class SellNameTransactionData extends TransactionData {
 	@XmlJavaTypeAdapter(value = org.qortal.api.AmountTypeAdapter.class)
 	private long amount;
 
+	@Schema(description = "if sale is for a specific buyer", example = "true")
+	private boolean isPrivateSale;
+
+	@Schema(description = "intended buyer's address", example = "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v")
+	private String saleRecipient;
+
 	// Constructors
 
 	// For JAXB
@@ -42,6 +48,18 @@ public class SellNameTransactionData extends TransactionData {
 		this.ownerPublicKey = baseTransactionData.creatorPublicKey;
 		this.name = name;
 		this.amount = amount;
+		this.isPrivateSale = false;
+		this.saleRecipient = null;
+	}
+
+	public SellNameTransactionData(BaseTransactionData baseTransactionData, String name, long amount, boolean isPrivateSale, String saleRecipient) {
+		super(TransactionType.SELL_NAME, baseTransactionData);
+
+		this.ownerPublicKey = baseTransactionData.creatorPublicKey;
+		this.name = name;
+		this.amount = amount;
+		this.isPrivateSale = isPrivateSale;
+		this.saleRecipient = saleRecipient;
 	}
 
 	// Getters / setters
@@ -56,6 +74,14 @@ public class SellNameTransactionData extends TransactionData {
 
 	public long getAmount() {
 		return this.amount;
+	}
+
+	public boolean getIsPrivateSale() {
+		return this.isPrivateSale;
+	}
+
+	public String getSaleRecipient() {
+		return this.isPrivateSale ? this.saleRecipient : null;
 	}
 
 }

--- a/src/main/java/org/qortal/naming/Name.java
+++ b/src/main/java/org/qortal/naming/Name.java
@@ -162,6 +162,9 @@ public class Name {
 		// Mark as for-sale and set price
 		this.nameData.setIsForSale(true);
 		this.nameData.setSalePrice(sellNameTransactionData.getAmount());
+		this.nameData.setIsPrivateSale(sellNameTransactionData.getIsPrivateSale());
+		if (sellNameTransactionData.getIsPrivateSale())
+			this.nameData.setSaleRecipient(sellNameTransactionData.getSaleRecipient());
 
 		// Save sale info into repository
 		this.repository.getNameRepository().save(this.nameData);
@@ -171,6 +174,8 @@ public class Name {
 		// Mark not for-sale and unset price
 		this.nameData.setIsForSale(false);
 		this.nameData.setSalePrice(null);
+		this.nameData.setIsPrivateSale(false);
+		this.nameData.setSaleRecipient(null);
 
 		// Save no-sale info into repository
 		this.repository.getNameRepository().save(this.nameData);
@@ -183,6 +188,8 @@ public class Name {
 		// Mark not for-sale
 		this.nameData.setIsForSale(false);
 		this.nameData.setSalePrice(null);
+		this.nameData.setIsPrivateSale(false);
+		this.nameData.setSaleRecipient(null);
 
 		// Save sale info into repository
 		this.repository.getNameRepository().save(this.nameData);
@@ -192,6 +199,9 @@ public class Name {
 		// Mark as for-sale using existing price
 		this.nameData.setIsForSale(true);
 		this.nameData.setSalePrice(cancelSellNameTransactionData.getSalePrice());
+		this.nameData.setIsPrivateSale(cancelSellNameTransactionData.getIsPrivateSale());
+		if (cancelSellNameTransactionData.getIsPrivateSale())
+			this.nameData.setSaleRecipient(cancelSellNameTransactionData.getSaleRecipient());
 
 		// Save no-sale info into repository
 		this.repository.getNameRepository().save(this.nameData);
@@ -234,6 +244,9 @@ public class Name {
 		// Mark as for-sale using existing price
 		this.nameData.setIsForSale(true);
 		this.nameData.setSalePrice(buyNameTransactionData.getAmount());
+		this.nameData.setIsPrivateSale(buyNameTransactionData.getIsPrivateSale());
+		if (buyNameTransactionData.getIsPrivateSale())
+			this.nameData.setSaleRecipient(Crypto.toAddress(buyNameTransactionData.getCreatorPublicKey()));
 
 		// Previous name-changing reference is taken from this transaction's cached copy
 		this.nameData.setReference(buyNameTransactionData.getNameReference());

--- a/src/main/java/org/qortal/network/message/NamesMessage.java
+++ b/src/main/java/org/qortal/network/message/NamesMessage.java
@@ -57,6 +57,13 @@ public class NamesMessage extends Message {
 					bytes.write(Longs.toByteArray(nameData.getSalePrice()));
 				}
 
+				int isPrivateSale = nameData.getIsPrivateSale() ? 1 : 0;
+				bytes.write(Ints.toByteArray(isPrivateSale));
+
+				if (nameData.getIsPrivateSale()) {
+					Serialization.serializeAddress(bytes, nameData.getSaleRecipient());
+				}
+
 				bytes.write(nameData.getReference());
 
 				bytes.write(Ints.toByteArray(nameData.getCreationGroupId()));
@@ -112,13 +119,20 @@ public class NamesMessage extends Message {
 					salePrice = bytes.getLong();
 				}
 
+				boolean isPrivateSale = (bytes.getInt() == 1);
+
+				String saleRecipient = null;
+				if (isPrivateSale) {
+					saleRecipient = Serialization.deserializeAddress(bytes);
+				}
+
 				byte[] reference = new byte[SIGNATURE_LENGTH];
 				bytes.get(reference);
 
 				int creationGroupId = bytes.getInt();
 
 				NameData nameData = new NameData(name, reducedName, owner, data, registered, updated,
-						isForSale, salePrice, reference, creationGroupId);
+						isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId);
 				nameDataList.add(nameData);
 			}
 

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBDatabaseUpdates.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBDatabaseUpdates.java
@@ -1052,6 +1052,20 @@ public class HSQLDBDatabaseUpdates {
 					stmt.execute("UPDATE Accounts SET blocks_minted_penalty = -5000000 WHERE blocks_minted_penalty < 0");
 					break;
 
+				case 50:
+					// For private name sales
+					stmt.execute("ALTER TABLE Names ADD is_private_sale BOOLEAN NOT NULL DEFAULT FALSE");
+					stmt.execute("ALTER TABLE Names ADD sale_recipient QortalAddress");
+
+					stmt.execute("ALTER TABLE SellNameTransactions ADD is_private_sale BOOLEAN NOT NULL DEFAULT FALSE");
+					stmt.execute("ALTER TABLE SellNameTransactions ADD sale_recipient QortalAddress");
+
+					stmt.execute("ALTER TABLE CancelSellNameTransactions ADD is_private_sale BOOLEAN NOT NULL DEFAULT FALSE");
+					stmt.execute("ALTER TABLE CancelSellNameTransactions ADD sale_recipient QortalAddress");
+
+					stmt.execute("ALTER TABLE BuyNameTransactions ADD is_private_sale BOOLEAN NOT NULL DEFAULT FALSE");
+					break;
+
 				default:
 					// nothing to do
 					return false;

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBNameRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBNameRepository.java
@@ -20,7 +20,7 @@ public class HSQLDBNameRepository implements NameRepository {
 	@Override
 	public NameData fromName(String name) throws DataException {
 		String sql = "SELECT reduced_name, owner, data, registered_when, updated_when, "
-				+ "is_for_sale, sale_price, reference, creation_group_id FROM Names WHERE name = ?";
+				+ "is_for_sale, sale_price, is_private_sale, sale_recipient, reference, creation_group_id FROM Names WHERE name = ?";
 
 		try (ResultSet resultSet = this.repository.checkedExecute(sql, name)) {
 			if (resultSet == null)
@@ -42,10 +42,16 @@ public class HSQLDBNameRepository implements NameRepository {
 			if (salePrice == 0 && resultSet.wasNull())
 				salePrice = null;
 
-			byte[] reference = resultSet.getBytes(8);
-			int creationGroupId = resultSet.getInt(9);
+			boolean isPrivateSale = resultSet.getBoolean(8);
 
-			return new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, reference, creationGroupId);
+			String saleRecipient = resultSet.getString(9);
+			if (!isPrivateSale)
+				saleRecipient = null;
+
+			byte[] reference = resultSet.getBytes(10);
+			int creationGroupId = resultSet.getInt(11);
+
+			return new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId);
 		} catch (SQLException e) {
 			throw new DataException("Unable to fetch name info from repository", e);
 		}
@@ -63,7 +69,7 @@ public class HSQLDBNameRepository implements NameRepository {
 	@Override
 	public NameData fromReducedName(String reducedName) throws DataException {
 		String sql = "SELECT name, owner, data, registered_when, updated_when, "
-				+ "is_for_sale, sale_price, reference, creation_group_id FROM Names WHERE reduced_name = ?";
+				+ "is_for_sale, sale_price, is_private_sale, sale_recipient, reference, creation_group_id FROM Names WHERE reduced_name = ?";
 
 		try (ResultSet resultSet = this.repository.checkedExecute(sql, reducedName)) {
 			if (resultSet == null)
@@ -85,10 +91,16 @@ public class HSQLDBNameRepository implements NameRepository {
 			if (salePrice == 0 && resultSet.wasNull())
 				salePrice = null;
 
-			byte[] reference = resultSet.getBytes(8);
-			int creationGroupId = resultSet.getInt(9);
+			boolean isPrivateSale = resultSet.getBoolean(8);
 
-			return new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, reference, creationGroupId);
+			String saleRecipient = resultSet.getString(9);
+			if (!isPrivateSale)
+				saleRecipient = null;
+
+			byte[] reference = resultSet.getBytes(10);
+			int creationGroupId = resultSet.getInt(11);
+
+			return new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId);
 		} catch (SQLException e) {
 			throw new DataException("Unable to fetch name info from repository", e);
 		}
@@ -108,7 +120,7 @@ public class HSQLDBNameRepository implements NameRepository {
 		List<Object> bindParams = new ArrayList<>();
 
 		sql.append("SELECT name, reduced_name, owner, data, registered_when, updated_when, "
-				+ "is_for_sale, sale_price, reference, creation_group_id FROM Names "
+				+ "is_for_sale, sale_price, is_private_sale, sale_recipient, reference, creation_group_id FROM Names "
 				+ "WHERE LCASE(name) LIKE ? ORDER BY name");
 
 		// Search anywhere in the name, unless "prefixOnly" has been requested
@@ -145,10 +157,16 @@ public class HSQLDBNameRepository implements NameRepository {
 				if (salePrice == 0 && resultSet.wasNull())
 					salePrice = null;
 
-				byte[] reference = resultSet.getBytes(9);
-				int creationGroupId = resultSet.getInt(10);
+				boolean isPrivateSale = resultSet.getBoolean(9);
 
-				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, reference, creationGroupId));
+				String saleRecipient = resultSet.getString(10);
+				if (!isPrivateSale)
+					saleRecipient = null;
+
+				byte[] reference = resultSet.getBytes(11);
+				int creationGroupId = resultSet.getInt(12);
+
+				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId));
 			} while (resultSet.next());
 
 			return names;
@@ -163,7 +181,7 @@ public class HSQLDBNameRepository implements NameRepository {
 		List<Object> bindParams = new ArrayList<>();
 
 		sql.append("SELECT name, reduced_name, owner, data, registered_when, updated_when, "
-				+ "is_for_sale, sale_price, reference, creation_group_id FROM Names");
+				+ "is_for_sale, sale_price, is_private_sale, sale_recipient, reference, creation_group_id FROM Names");
 
 		if (after != null) {
 			sql.append(" WHERE registered_when > ? OR updated_when > ?");
@@ -202,10 +220,16 @@ public class HSQLDBNameRepository implements NameRepository {
 				if (salePrice == 0 && resultSet.wasNull())
 					salePrice = null;
 
-				byte[] reference = resultSet.getBytes(9);
-				int creationGroupId = resultSet.getInt(10);
+				boolean isPrivateSale = resultSet.getBoolean(9);
 
-				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, reference, creationGroupId));
+				String saleRecipient = resultSet.getString(10);
+				if (!isPrivateSale)
+					saleRecipient = null;
+
+				byte[] reference = resultSet.getBytes(11);
+				int creationGroupId = resultSet.getInt(12);
+
+				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId));
 			} while (resultSet.next());
 
 			return names;
@@ -219,7 +243,7 @@ public class HSQLDBNameRepository implements NameRepository {
 		StringBuilder sql = new StringBuilder(512);
 
 		sql.append("SELECT name, reduced_name, owner, data, registered_when, updated_when, "
-				+ "sale_price, reference, creation_group_id  FROM Names WHERE is_for_sale = TRUE ORDER BY name");
+				+ "sale_price, is_private_sale, sale_recipient, reference, creation_group_id  FROM Names WHERE is_for_sale = TRUE ORDER BY name");
 
 		if (reverse != null && reverse)
 			sql.append(" DESC");
@@ -250,10 +274,16 @@ public class HSQLDBNameRepository implements NameRepository {
 				if (salePrice == 0 && resultSet.wasNull())
 					salePrice = null;
 
-				byte[] reference = resultSet.getBytes(8);
-				int creationGroupId = resultSet.getInt(9);
+				boolean isPrivateSale = resultSet.getBoolean(8);
 
-				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, reference, creationGroupId));
+				String saleRecipient = resultSet.getString(9);
+				if (!isPrivateSale)
+					saleRecipient = null;
+
+				byte[] reference = resultSet.getBytes(10);
+				int creationGroupId = resultSet.getInt(11);
+
+				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId));
 			} while (resultSet.next());
 
 			return names;
@@ -267,7 +297,7 @@ public class HSQLDBNameRepository implements NameRepository {
 		StringBuilder sql = new StringBuilder(512);
 
 		sql.append("SELECT name, reduced_name, data, registered_when, updated_when, "
-				+ "is_for_sale, sale_price, reference, creation_group_id FROM Names WHERE owner = ? ORDER BY name");
+				+ "is_for_sale, sale_price, is_private_sale, sale_recipient, reference, creation_group_id FROM Names WHERE owner = ? ORDER BY name");
 
 		if (reverse != null && reverse)
 			sql.append(" DESC");
@@ -297,10 +327,16 @@ public class HSQLDBNameRepository implements NameRepository {
 				if (salePrice == 0 && resultSet.wasNull())
 					salePrice = null;
 
-				byte[] reference = resultSet.getBytes(8);
-				int creationGroupId = resultSet.getInt(9);
+				boolean isPrivateSale = resultSet.getBoolean(8);
 
-				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, reference, creationGroupId));
+				String saleRecipient = resultSet.getString(9);
+				if (!isPrivateSale)
+					saleRecipient = null;
+
+				byte[] reference = resultSet.getBytes(10);
+				int creationGroupId = resultSet.getInt(11);
+
+				names.add(new NameData(name, reducedName, owner, data, registered, updated, isForSale, salePrice, isPrivateSale, saleRecipient, reference, creationGroupId));
 			} while (resultSet.next());
 
 			return names;
@@ -341,6 +377,7 @@ public class HSQLDBNameRepository implements NameRepository {
 				.bind("owner", nameData.getOwner()).bind("data", nameData.getData())
 				.bind("registered_when", nameData.getRegistered()).bind("updated_when", nameData.getUpdated())
 				.bind("is_for_sale", nameData.isForSale()).bind("sale_price", nameData.getSalePrice())
+				.bind("is_private_sale", nameData.getIsPrivateSale()).bind("sale_recipient", nameData.getSaleRecipient())
 				.bind("reference", nameData.getReference()).bind("creation_group_id", nameData.getCreationGroupId());
 
 		try {

--- a/src/main/java/org/qortal/repository/hsqldb/transaction/HSQLDBBuyNameTransactionRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/transaction/HSQLDBBuyNameTransactionRepository.java
@@ -17,7 +17,7 @@ public class HSQLDBBuyNameTransactionRepository extends HSQLDBTransactionReposit
 	}
 
 	TransactionData fromBase(BaseTransactionData baseTransactionData) throws DataException {
-		String sql = "SELECT name, amount, seller, name_reference FROM BuyNameTransactions WHERE signature = ?";
+		String sql = "SELECT name, amount, seller, is_private_sale, name_reference FROM BuyNameTransactions WHERE signature = ?";
 
 		try (ResultSet resultSet = this.repository.checkedExecute(sql, baseTransactionData.getSignature())) {
 			if (resultSet == null)
@@ -26,9 +26,10 @@ public class HSQLDBBuyNameTransactionRepository extends HSQLDBTransactionReposit
 			String name = resultSet.getString(1);
 			long amount = resultSet.getLong(2);
 			String seller = resultSet.getString(3);
-			byte[] nameReference = resultSet.getBytes(4);
+			boolean isPrivateSale = resultSet.getBoolean(4);
+			byte[] nameReference = resultSet.getBytes(5);
 
-			return new BuyNameTransactionData(baseTransactionData, name, amount, seller, nameReference);
+			return new BuyNameTransactionData(baseTransactionData, name, amount, seller, isPrivateSale, nameReference);
 		} catch (SQLException e) {
 			throw new DataException("Unable to fetch buy name transaction from repository", e);
 		}
@@ -42,7 +43,7 @@ public class HSQLDBBuyNameTransactionRepository extends HSQLDBTransactionReposit
 
 		saveHelper.bind("signature", buyNameTransactionData.getSignature()).bind("buyer", buyNameTransactionData.getBuyerPublicKey())
 				.bind("name", buyNameTransactionData.getName()).bind("amount", buyNameTransactionData.getAmount())
-				.bind("seller", buyNameTransactionData.getSeller()).bind("name_reference", buyNameTransactionData.getNameReference());
+				.bind("seller", buyNameTransactionData.getSeller()).bind("is_private_sale", buyNameTransactionData.getIsPrivateSale()).bind("name_reference", buyNameTransactionData.getNameReference());
 
 		try {
 			saveHelper.execute(this.repository);

--- a/src/main/java/org/qortal/repository/hsqldb/transaction/HSQLDBCancelSellNameTransactionRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/transaction/HSQLDBCancelSellNameTransactionRepository.java
@@ -17,7 +17,7 @@ public class HSQLDBCancelSellNameTransactionRepository extends HSQLDBTransaction
 	}
 
 	TransactionData fromBase(BaseTransactionData baseTransactionData) throws DataException {
-		String sql = "SELECT name, sale_price FROM CancelSellNameTransactions WHERE signature = ?";
+		String sql = "SELECT name, sale_price, is_private_sale, sale_recipient FROM CancelSellNameTransactions WHERE signature = ?";
 
 		try (ResultSet resultSet = this.repository.checkedExecute(sql, baseTransactionData.getSignature())) {
 			if (resultSet == null)
@@ -25,8 +25,12 @@ public class HSQLDBCancelSellNameTransactionRepository extends HSQLDBTransaction
 
 			String name = resultSet.getString(1);
 			Long salePrice = resultSet.getLong(2);
+			boolean isPrivateSale = resultSet.getBoolean(3);
+			String saleRecipient = resultSet.getString(4);
+			if (!isPrivateSale)
+				saleRecipient = null;
 
-			return new CancelSellNameTransactionData(baseTransactionData, name, salePrice);
+			return new CancelSellNameTransactionData(baseTransactionData, name, salePrice, isPrivateSale, saleRecipient);
 		} catch (SQLException e) {
 			throw new DataException("Unable to fetch cancel sell name transaction from repository", e);
 		}
@@ -39,7 +43,7 @@ public class HSQLDBCancelSellNameTransactionRepository extends HSQLDBTransaction
 		HSQLDBSaver saveHelper = new HSQLDBSaver("CancelSellNameTransactions");
 
 		saveHelper.bind("signature", cancelSellNameTransactionData.getSignature()).bind("owner", cancelSellNameTransactionData.getOwnerPublicKey()).bind("name",
-				cancelSellNameTransactionData.getName()).bind("sale_price", cancelSellNameTransactionData.getSalePrice());
+				cancelSellNameTransactionData.getName()).bind("sale_price", cancelSellNameTransactionData.getSalePrice()).bind("is_private_sale", cancelSellNameTransactionData.getIsPrivateSale()).bind("sale_recipient", cancelSellNameTransactionData.getSaleRecipient());
 
 		try {
 			saveHelper.execute(this.repository);

--- a/src/main/java/org/qortal/transaction/BuyNameTransaction.java
+++ b/src/main/java/org/qortal/transaction/BuyNameTransaction.java
@@ -91,6 +91,23 @@ public class BuyNameTransaction extends Transaction {
 		if (this.buyNameTransactionData.getAmount() != nameData.getSalePrice())
 			return ValidationResult.INVALID_AMOUNT;
 
+		// Check for private sale
+		if (nameData.getIsPrivateSale()) {
+
+			// Check buyer address matches expected recipient
+			if (!buyer.getAddress().equals(nameData.getSaleRecipient()))
+				return ValidationResult.INVALID_NAME_OWNER;
+
+			// Check buyer transaction is set to private
+			if (!this.buyNameTransactionData.getIsPrivateSale())
+				return ValidationResult.INVALID_RETURN;
+		} else {
+
+			// Check buyer transaction matches if not private
+			if (this.buyNameTransactionData.getIsPrivateSale())
+				return ValidationResult.INVALID_RETURN;
+		}
+
 		// Check buyer has enough funds
 		if (buyer.getConfirmedBalance(Asset.QORT) < this.buyNameTransactionData.getFee())
 			return ValidationResult.NO_BALANCE;

--- a/src/main/java/org/qortal/transform/transaction/BuyNameTransactionTransformer.java
+++ b/src/main/java/org/qortal/transform/transaction/BuyNameTransactionTransformer.java
@@ -20,7 +20,7 @@ public class BuyNameTransactionTransformer extends TransactionTransformer {
 	private static final int NAME_SIZE_LENGTH = INT_LENGTH;
 	private static final int SELLER_LENGTH = ADDRESS_LENGTH;
 
-	private static final int EXTRAS_LENGTH = NAME_SIZE_LENGTH + AMOUNT_LENGTH + SELLER_LENGTH;
+	private static final int EXTRAS_LENGTH = NAME_SIZE_LENGTH + AMOUNT_LENGTH + SELLER_LENGTH + BOOLEAN_LENGTH;
 
 	protected static final TransactionLayout layout;
 
@@ -35,6 +35,7 @@ public class BuyNameTransactionTransformer extends TransactionTransformer {
 		layout.add("name", TransformationType.STRING);
 		layout.add("buy price", TransformationType.AMOUNT);
 		layout.add("seller", TransformationType.ADDRESS);
+		layout.add("is private sale", TransformationType.BOOLEAN);
 		layout.add("fee", TransformationType.AMOUNT);
 		layout.add("signature", TransformationType.SIGNATURE);
 	}
@@ -55,6 +56,8 @@ public class BuyNameTransactionTransformer extends TransactionTransformer {
 
 		String seller = Serialization.deserializeAddress(byteBuffer);
 
+		boolean isPrivateSale = byteBuffer.get() != 0;
+
 		long fee = byteBuffer.getLong();
 
 		byte[] signature = new byte[SIGNATURE_LENGTH];
@@ -62,7 +65,7 @@ public class BuyNameTransactionTransformer extends TransactionTransformer {
 
 		BaseTransactionData baseTransactionData = new BaseTransactionData(timestamp, txGroupId, reference, buyerPublicKey, fee, signature);
 
-		return new BuyNameTransactionData(baseTransactionData, name, amount, seller);
+		return new BuyNameTransactionData(baseTransactionData, name, amount, seller, isPrivateSale);
 	}
 
 	public static int getDataLength(TransactionData transactionData) throws TransformationException {
@@ -84,6 +87,8 @@ public class BuyNameTransactionTransformer extends TransactionTransformer {
 			bytes.write(Longs.toByteArray(buyNameTransactionData.getAmount()));
 
 			Serialization.serializeAddress(bytes, buyNameTransactionData.getSeller());
+
+			bytes.write((byte) (buyNameTransactionData.getIsPrivateSale() ? 1 : 0));
 
 			bytes.write(Longs.toByteArray(buyNameTransactionData.getFee()));
 


### PR DESCRIPTION
This branch adds the functionality for private name sales, allowing someone to specify which address can buy, when selling a name.  This would also allow them to set the cost to 0 (for private sales only), effectively "giving" someone a name, though it would still require the recipient to "accept" (purchase for 0).  This implementation is complete, however it should be tested network-wide on a testnet.  Also before mainnet release, it should probably set to trigger at a specific block in the future, to ensure that all nodes will be updated before any changes to consensus.  This code has been reviewed and planned very carefully and deliberately, and even some of the variable names were chosen specifically to avoid issues or further complicating things.  However, if there are any questions or suggestions for alternatives, any responses here are greatly encouraged.