### PR TITLE
Add chatAuthBypassEnabled setting

### DIFF
--- a/src/main/java/org/qortal/api/resource/ChatResource.java
+++ b/src/main/java/org/qortal/api/resource/ChatResource.java
@@ -22,6 +22,7 @@ import org.qortal.data.transaction.TransactionData;
 import org.qortal.repository.DataException;
 import org.qortal.repository.Repository;
 import org.qortal.repository.RepositoryManager;
+import org.qortal.settings.Settings;
 import org.qortal.transaction.ChatTransaction;
 import org.qortal.transaction.Transaction;
 import org.qortal.transaction.Transaction.TransactionType;
@@ -273,7 +274,8 @@ public class ChatResource {
 	@ApiErrors({ApiError.TRANSACTION_INVALID, ApiError.TRANSFORMATION_ERROR, ApiError.REPOSITORY_ISSUE})
 	@SecurityRequirement(name = "apiKey")
 	public String buildChat(@HeaderParam(Security.API_KEY_HEADER) String apiKey, ChatTransactionData transactionData) {
-		Security.checkApiCallAllowed(request);
+		if (!Settings.getInstance().isChatAuthBypassEnabled())
+			Security.checkApiCallAllowed(request);
 
 		try (final Repository repository = RepositoryManager.getRepository()) {
 			ChatTransaction chatTransaction = (ChatTransaction) Transaction.fromData(repository, transactionData);

--- a/src/main/java/org/qortal/settings/Settings.java
+++ b/src/main/java/org/qortal/settings/Settings.java
@@ -367,6 +367,9 @@ public class Settings {
 	/** Whether to serve QDN data without authentication */
 	private boolean qdnAuthBypassEnabled = true;
 
+	/** Whether to accept CHAT transactions without authentication */
+	private boolean chatAuthBypassEnabled = false;
+
 	/** Limit threads per message type */
 	private Set<ThreadLimit> maxThreadsPerMessageType = new HashSet<>();
 
@@ -1108,6 +1111,10 @@ public class Settings {
 			return true;
 		}
 		return this.qdnAuthBypassEnabled;
+	}
+
+	public boolean isChatAuthBypassEnabled() {
+		return this.chatAuthBypassEnabled;
 	}
 
 	public Integer getMaxThreadsForMessageType(MessageType messageType) {


### PR DESCRIPTION
This adds a new `chatAuthBypassEnabled` setting that can be used by any public nodes, or others who want to allow CHAT transactions to be processed by their node, without requiring an API key check.  The setting is set to `false` by default, as there was previously some discussion about removing this API key requirement entirely, and the decision was made to not do so.  This appears to be a reasonable compromise, and would effectively change nothing at all for most users, unless they manually chose to apply this new setting.  Allowing this option will give other applications, such as SYNQ, a way to provide more functionality for those who are not able to access their own private node at all times, but still would like to interact with the Qortal community while they are travelling, away from home, etc.  If this change is not acceptable or there are any other issues, considerations, or questions, please let me know.  This could be a good step towards creating a more versatile mobile Qortal application that gains wide usage, and helps to expand the community.