### PR TITLE
Update online accounts API calls

### DIFF
--- a/src/main/java/org/qortal/account/Account.java
+++ b/src/main/java/org/qortal/account/Account.java
@@ -295,6 +295,26 @@ public class Account {
 	}
 
 	/**
+	 * Returns 'effective' minting level, or zero if account does not exist/cannot mint.
+	 * <p>
+	 * For founder accounts with no penalty, this returns 11, in order to list them separately.
+	 * 
+	 * @return 0+
+	 * @throws DataException
+	 */
+	public int getEffectiveMintingLevelWithFounders() throws DataException {
+		AccountData accountData = this.repository.getAccountRepository().getAccount(this.address);
+		if (accountData == null)
+			return 0;
+
+		// Founders are listed as level 11, as long as they have no penalty
+		if (Account.isFounder(accountData.getFlags()) && accountData.getBlocksMintedPenalty() == 0)
+			return 11;
+
+		return accountData.getLevel();
+	}
+
+	/**
 	 * Returns 'effective' minting level, or zero if reward-share does not exist.
 	 * 
 	 * @param repository
@@ -314,7 +334,7 @@ public class Account {
 	/**
 	 * Returns 'effective' minting level, with a fix for the zero level.
 	 * <p>
-	 * For founder accounts with no penalty, this returns "founderEffectiveMintingLevel" from blockchain config.
+	 * For founder accounts with no penalty, this returns 11, in order to list them separately.
 	 *
 	 * @param repository
 	 * @param rewardSharePublicKey
@@ -331,6 +351,6 @@ public class Account {
 			return 0;
 
 		Account rewardShareMinter = new Account(repository, rewardShareData.getMinter());
-		return rewardShareMinter.getEffectiveMintingLevel();
+		return rewardShareMinter.getEffectiveMintingLevelWithFounders();
 	}
 }

--- a/src/main/java/org/qortal/api/model/ApiOnlineAccount.java
+++ b/src/main/java/org/qortal/api/model/ApiOnlineAccount.java
@@ -12,6 +12,7 @@ public class ApiOnlineAccount {
 	protected byte[] rewardSharePublicKey;
 	protected String minterAddress;
 	protected String recipientAddress;
+	protected int minterLevel;
 
 	// Constructors
 
@@ -19,12 +20,13 @@ public class ApiOnlineAccount {
 	protected ApiOnlineAccount() {
 	}
 
-	public ApiOnlineAccount(long timestamp, byte[] signature, byte[] rewardSharePublicKey, String minterAddress, String recipientAddress) {
+	public ApiOnlineAccount(long timestamp, byte[] signature, byte[] rewardSharePublicKey, String minterAddress, String recipientAddress, int minterLevel) {
 		this.timestamp = timestamp;
 		this.signature = signature;
 		this.rewardSharePublicKey = rewardSharePublicKey;
 		this.minterAddress = minterAddress;
 		this.recipientAddress = recipientAddress;
+		this.minterLevel = minterLevel;
 	}
 
 	public long getTimestamp() {
@@ -45,6 +47,10 @@ public class ApiOnlineAccount {
 
 	public String getRecipientAddress() {
 		return this.recipientAddress;
+	}
+
+	public int getMinterLevel() {
+		return this.minterLevel;
 	}
 
 }

--- a/src/main/java/org/qortal/api/resource/AddressesResource.java
+++ b/src/main/java/org/qortal/api/resource/AddressesResource.java
@@ -172,9 +172,10 @@ public class AddressesResource {
 				if (rewardShareData == null)
 					// This shouldn't happen?
 					throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.PUBLIC_KEY_NOT_FOUND);
+				final int minterLevel = Account.getRewardShareEffectiveMintingLevelIncludingLevelZero(repository, onlineAccountData.getPublicKey());
 
 				apiOnlineAccounts.add(new ApiOnlineAccount(onlineAccountData.getTimestamp(), onlineAccountData.getSignature(), onlineAccountData.getPublicKey(),
-						rewardShareData.getMintingAccount(), rewardShareData.getRecipient()));
+						rewardShareData.getMintingAccount(), rewardShareData.getRecipient(), minterLevel));
 			}
 
 			return apiOnlineAccounts;

--- a/src/main/java/org/qortal/api/resource/AddressesResource.java
+++ b/src/main/java/org/qortal/api/resource/AddressesResource.java
@@ -203,7 +203,7 @@ public class AddressesResource {
 			List<OnlineAccountLevel> onlineAccountLevels = new ArrayList<>();
 
 			// Prepopulate all levels
-			for (int i=0; i<=10; i++)
+			for (int i=0; i<=11; i++)
 				onlineAccountLevels.add(new OnlineAccountLevel(i, 0));
 
 			for (OnlineAccountData onlineAccountData : onlineAccounts) {


### PR DESCRIPTION
These changes add minter level to the `/addresses/online` API call, and separates the Founder count from Level 10 in the `/addresses/online/levels` API call.  The changes do not affect any other functions or consensus, and have been successfully tested by direct usage, as well as passing the unit tests.