### PR TITLE
Update actions to v4

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -8,16 +8,16 @@ jobs:
   mavenTesting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Cache local Maven repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up the Java JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'adopt'


### PR DESCRIPTION
The error message given in the "Actions" menu when it tries to run the unit tests after a pull request (for example [here](https://github.com/Qortal/qortal/actions/runs/8824312810)) says:

`Node.js 16 actions are deprecated.`
`Please update the following actions to use Node.js 20:`
`actions/checkout@v3, actions/cache@v3, actions/setup-java@v3.`
For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

These three dependencies have updated to v4 to support Node.js 20:
https://github.com/actions/checkout
https://github.com/actions/cache
https://github.com/actions/setup-java

The results of this change being tested successfully, and the unit tests being run can be seen here:
https://github.com/QuickMythril/qortal/actions/runs/8827322769?pr=65
**Edit**: This pull request has itself triggered the tests to run successfully here:
https://github.com/Qortal/qortal/actions/runs/8827431061?pr=191