### PR TITLE
Add API call to fetch all lists

### DIFF
--- a/src/main/java/org/qortal/api/resource/ListsResource.java
+++ b/src/main/java/org/qortal/api/resource/ListsResource.java
@@ -19,6 +19,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
+import org.json.JSONArray;
 
 
 @Path("/lists")
@@ -28,6 +30,22 @@ public class ListsResource {
 	@Context
 	HttpServletRequest request;
 
+	@GET
+	@Operation(
+		summary = "Fetch all lists",
+		responses = {
+            @ApiResponse(
+                description = "A JSON array of list names",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON, array = @ArraySchema(schema = @Schema(implementation = String.class)))
+            )
+        }
+	)
+	@SecurityRequirement(name = "apiKey")
+	public String getAllLists(@HeaderParam(Security.API_KEY_HEADER) String apiKey) {
+    	Security.checkApiCallAllowed(request);
+    	List<String> listNames = ResourceListManager.getInstance().getAllListNames();
+    	return new JSONArray(listNames).toString();
+	}
 
 	@POST
 	@Path("/{listName}")

--- a/src/main/java/org/qortal/list/ResourceListManager.java
+++ b/src/main/java/org/qortal/list/ResourceListManager.java
@@ -208,4 +208,12 @@ public class ResourceListManager {
         return list.getList().size();
     }
 
+    public List<String> getAllListNames() {
+        List<String> listNames = new ArrayList<>();
+        for (ResourceList list : this.lists) {
+            listNames.add(list.getName());
+        }
+        return listNames;
+    }
+
 }


### PR DESCRIPTION
Currently the API only allows to add to, remove from, or display the contents of a list, however the name of the list must already be known.  This API call will allow all existing list names to be returned.