### PR TITLE
removed API restriction from pubkey conversion

### DIFF
--- a/src/main/java/org/qortal/api/resource/AddressesResource.java
+++ b/src/main/java/org/qortal/api/resource/AddressesResource.java
@@ -327,11 +327,8 @@ public class AddressesResource {
 			)
 		}
 	)
-	@ApiErrors({ApiError.INVALID_PUBLIC_KEY, ApiError.NON_PRODUCTION, ApiError.REPOSITORY_ISSUE})
+	@ApiErrors({ApiError.INVALID_PUBLIC_KEY, ApiError.REPOSITORY_ISSUE})
 	public String fromPublicKey(@PathParam("publickey") String publicKey58) {
-		if (Settings.getInstance().isApiRestricted())
-			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.NON_PRODUCTION);
-
 		// Decode public key
 		byte[] publicKey;
 		try {


### PR DESCRIPTION
As polls have started to be used more, and votes are returned by the API as pubkeys, Q-Apps would need to make an additional API call to convert the pubkey to an address.  This is currently set as restricted, requiring people to change "apiRestricted" to false in their Core settings, to be able to use this function locally.  As this seems to be a very standard and common API call, which has little to no risk of being abused, I have submitted the change to remove that restriction.  All relevant unit tests have passed successfully with this changed code.