### PR TITLE
fixed typo in EPC test message

### DIFF
--- a/src/test/java/org/qortal/test/EPCTests.java
+++ b/src/test/java/org/qortal/test/EPCTests.java
@@ -173,7 +173,7 @@ public class EPCTests {
 			}
 		}
 
-		System.out.println(String.format("Pings should start after %s seconds", PING_INTERVAL));
+		System.out.println(String.format("Pings should start after %s milliseconds", PING_INTERVAL));
 
 		testEPC(new PingEPC());
 	}


### PR DESCRIPTION
When running the unit tests, one of the messages said "Pings should start after 8000 seconds" but it only took 8 seconds.  This is because the value is returned in milliseconds.  To avoid any data type conversion problems, or other issues with math functions, the simplest fix seems to be editing the text to match the value.