### PR TITLE
Fix for most unit tests fails

### DIFF
--- a/src/test/resources/test-chain-v2.json
+++ b/src/test/resources/test-chain-v2.json
@@ -96,7 +96,12 @@
 		"arbitraryOptionalFeeTimestamp": 0,
 		"unconfirmableRewardSharesHeight": 99999999,
 		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999999,
+		"groupMemberCheckHeight": 9999999999999
 	},
 	"genesisInfo": {
 		"version": 4,


### PR DESCRIPTION
The newer feature triggers are missing from the testchain json files, which causes a very large amount of the unit tests to fail immediately.  This pull request adds the missing feature triggers to the `test-chain-v2.json` file only.  Here are the results of the unit tests before and after this change:

Before
![tests-before-fix](https://github.com/user-attachments/assets/c7a29658-0ead-40bf-a525-8253d8f88a97)

After
![tests-after-fix](https://github.com/user-attachments/assets/cd146d16-d0c1-4fc2-8ca2-2980781a23c4)

Only 38 tests passed before, but 558 passed after the change.  Some of the remaining failed tests are also caused by missing feature triggers within other testchain files which I can fix later, if this is approved.