### PR TITLE
Reticulum updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -783,11 +783,13 @@
 		</dependency>
 		-->
 		<!-- BouncyCastle for crypto, including TLS secure networking -->
+    <!--
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15to18</artifactId>
 			<version>${bouncycastle.version}</version>
 		</dependency>
+    -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bctls-jdk15to18</artifactId>
@@ -963,12 +965,7 @@
       <version>${jinjava.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-      <version>3.1.0</version> 
-      </dependency>
-		<dependency>
+<dependency>
 <groupId>org.apache.tika</groupId>
 <artifactId>tika-core</artifactId>
 <version>3.1.0</version> 

--- a/src/main/java/org/qortal/network/RNSCommon.java
+++ b/src/main/java/org/qortal/network/RNSCommon.java
@@ -31,12 +31,12 @@ public class RNSCommon {
      */
     public static String jinjaConfigTemplateName = "reticulum_config_template.jinja";
 
-    ///**
-    // * Qortal RNS Destinations
-    // */
-    //public enum RNSDestinations {
-    //    BASE,
-    //    QDN;
-    //}
+    /**
+     * Qortal RNS Destination types
+     */
+    public enum RNSDestinationType {
+        BASE,
+        DATA;
+    }
     
 }

--- a/src/main/java/org/qortal/network/RNSCommon.java
+++ b/src/main/java/org/qortal/network/RNSCommon.java
@@ -24,7 +24,7 @@ public class RNSCommon {
      * Reticulum port for TCP Client interfaces
      */
     public static Integer MAINNET_IF_TCP_PORT = 4242;
-    public static Integer TESTNET_IF_TCP_PORT = 4243;
+    public static Integer TESTNET_IF_TCP_PORT = 4240;
 
     /**
      * Reticulum Jinjava configuration template name

--- a/src/main/java/org/qortal/network/RNSNetwork.java
+++ b/src/main/java/org/qortal/network/RNSNetwork.java
@@ -277,6 +277,8 @@ public class RNSNetwork {
                 //                         at least one Gateway interface
                 // * is_test_net: String "true" or "false" (from isTestNet)
                 // * target_port: target port for TCPServerInterface (only)
+                // * use_python_rns: use local shared python rnsd (has to provide a gateway interface)
+                // * python_rns_if_port: rnsd TCPServerInterface port (if rnsd gateway is a TCPServerInterface)
                 var jnj = new Jinjava();
                 var reticulumGateways = StringUtils.join(reticulumTcpGatewayServers, " ");
                 log.info("reticulumGateways: {}", reticulumGateways);
@@ -286,10 +288,9 @@ public class RNSNetwork {
                 context.put("qortal_network_name",  APP_NAME);
                 context.put("target_port", TARGET_PORT);
                 context.put("is_reticulum_gateway", isReticulumGateway ? "true" : "false");
-                context.put("is_testnet", Settings.getInstance().isTestNet() ? "true" : "false");
+                //context.put("is_test_net", Settings.getInstance().isTestNet() ? "true" : "false");
                 context.put("use_python_rns", Settings.getInstance().getReticulumUsePythonRNS() ? "true" : "false");
                 context.put("python_rns_if_port", Settings.getInstance().getReticulumPythonRNSGatewayPort());
-                //log.info("context populated");
 
                 // render config.yml from template
                 log.info("Rendering new Reticulum configuration file from resource {}", RNSCommon.jinjaConfigTemplateName  );

--- a/src/main/java/org/qortal/network/RNSNetwork.java
+++ b/src/main/java/org/qortal/network/RNSNetwork.java
@@ -231,13 +231,19 @@ public class RNSNetwork {
    
         baseDestination.setProofStrategy(ProofStrategy.PROVE_ALL);
         baseDestination.setAcceptLinkRequests(true);
+        //dataDestination.setProofStrategy(ProofStrategy.PROVE_APP);
+        //dataDestination.setAcceptLinkRequests(true);
         
-        baseDestination.setLinkEstablishedCallback(this::clientConnected);
+        baseDestination.setLinkEstablishedCallback(this::baseClientConnected);
+        //dataDestination.setLinkEstablishedCallback(this::dataClientConnected);
         Transport.getInstance().registerAnnounceHandler(new QAnnounceHandler());
+        //Transport.getInstance().registerAnnounceHandler(new QAnnounceHandler("qortal.qdn"));
         log.debug("announceHandlers: {}", Transport.getInstance().getAnnounceHandlers());
         // do a first announce
         baseDestination.announce();
         log.debug("Sent initial announce from {} ({})", encodeHexString(baseDestination.getHash()), baseDestination.getName());
+        // announce DFN destination
+        //dataDestination.announce();
 
         // Start up first networking thread (the "server loop", the "Tasks engine")
         rnsNetworkEPC.start();
@@ -281,11 +287,12 @@ public class RNSNetwork {
                 context.put("target_port", TARGET_PORT);
                 context.put("is_reticulum_gateway", isReticulumGateway ? "true" : "false");
                 context.put("is_testnet", Settings.getInstance().isTestNet() ? "true" : "false");
+                context.put("use_python_rns", Settings.getInstance().getReticulumUsePythonRNS() ? "true" : "false");
+                context.put("python_rns_if_port", Settings.getInstance().getReticulumPythonRNSGatewayPort());
                 //log.info("context populated");
 
                 // render config.yml from template
                 log.info("Rendering new Reticulum configuration file from resource {}", RNSCommon.jinjaConfigTemplateName  );
-                //var templateUrl = this.getClass().getClassLoader().getResource(RNSCommon.jinjaConfigTemplateName);
                 var templateResourceInpuSteam = this.getClass().getClassLoader().getResourceAsStream(RNSCommon.jinjaConfigTemplateName);
                 //var template = new Scanner(templateResourceInputSteam).useDelimiter("\n").next();
                 var template = new BufferedReader(new InputStreamReader(templateResourceInpuSteam)).lines().parallel().collect(Collectors.joining("\n"));
@@ -418,18 +425,34 @@ public class RNSNetwork {
         log.info("packet timed out, receipt status: {}", receipt.getStatus());
     }
 
-    public void clientConnected(Link link) {
+    public void baseClientConnected(Link link) {
         //link.setLinkClosedCallback(this::clientDisconnected);
         //link.setPacketCallback(this::serverPacketReceived);
-        log.info("clientConnected - link hash: {}, {}", link.getHash(), encodeHexString(link.getHash()));
+        log.info("baseClientConnected - link hash: {}, {}", link.getHash(), encodeHexString(link.getHash()));
         RNSPeer newPeer = new RNSPeer(link);
         newPeer.setPeerLinkHash(link.getHash());
+        newPeer.setDestinationType(RNSCommon.RNSDestinationType.BASE);
         newPeer.setMessageMagic(getMessageMagic());
         // make sure the peer has a channel and buffer
         newPeer.getOrInitPeerBuffer();
         addIncomingPeer(newPeer);
-        log.info("***> Client connected, link: {}", encodeHexString(link.getLinkId()));
+        log.info("***> Client connected, base link: {}", encodeHexString(link.getLinkId()));
     }
+
+    //public void dataClientConnected(Link link) {
+    //    //link.setLinkClosedCallback(this::clientDisconnected);
+    //    //link.setPacketCallback(this::serverPacketReceived);
+    //    log.info("dataClientConnected - link hash: {}, {}", link.getHash(), encodeHexString(link.getHash()));
+    //    RNSPeer newPeer = new RNSPeer(link);
+    //    newPeer.setPeerLinkHash(link.getHash());
+    //    newPeer.setDestinationType(RNSCommon.RNSDestinationType.DATA);
+    //    newPeer.setType(...)
+    //    newPeer.setMessageMagic(getMessageMagic());
+    //    // make sure the peer has a channel and buffer
+    //    newPeer.getOrInitPeerBuffer();
+    //    addIncomingPeer(newPeer);
+    //    log.info("***> Client connected, data link: {}", encodeHexString(link.getLinkId()));
+    //}
 
     public void clientDisconnected(Link link) {
         log.info("***> Client disconnected");
@@ -445,9 +468,20 @@ public class RNSNetwork {
     //}
 
     private class QAnnounceHandler implements AnnounceHandler {
+        String aspectFilter;
+
+        QAnnounceHandler(String aspectFilter) {
+            this.aspectFilter = aspectFilter;
+        }
+
+        QAnnounceHandler() {
+            this.aspectFilter = "qortal.core";
+        }
+
         @Override
         public String getAspectFilter() {
-            return "qortal.core";
+            //return "qortal.core";
+            return this.aspectFilter;
         }
 
         @Override
@@ -501,6 +535,14 @@ public class RNSNetwork {
                     RNSPeer newPeer = new RNSPeer(destinationHash);
                     newPeer.setServerIdentity(announcedIdentity);
                     newPeer.setIsInitiator(true);
+                    newPeer.setDestinationType(RNSCommon.RNSDestinationType.BASE);
+                    //if (aspectFilter == "qortal.qdn") {
+                    //    // data peer
+                    //    newPeer.setDestinationType(RNSCommon.RNSDestinationType.DATA);
+                    //} else {
+                    //    // core peer
+                    //    newPeer.setDestinationType(RNSCommon.RNSDestinationType.BASE);
+                    //}
                     newPeer.setMessageMagic(getMessageMagic());
                     addLinkedPeer(newPeer);
                     log.info("added new RNSPeer, destinationHash: {}", encodeHexString(destinationHash));

--- a/src/main/java/org/qortal/network/RNSPeer.java
+++ b/src/main/java/org/qortal/network/RNSPeer.java
@@ -402,7 +402,7 @@ public class RNSPeer {
 
                     case PONG:
                         log.trace("PONG received");
-                        addToQueue(message);  // as response in blocking queue for ping getResponse
+                        //addToQueue(message);  // as response in blocking queue for ping getResponse
                         break;
 
                     // Do we need this ? (no need to relay peer list...)

--- a/src/main/java/org/qortal/network/RNSPeer.java
+++ b/src/main/java/org/qortal/network/RNSPeer.java
@@ -86,6 +86,7 @@ public class RNSPeer {
 
     private byte[] destinationHash;   // remote destination hash
     Destination peerDestination;      // OUT destination created for this
+    RNSCommon.RNSDestinationType destinationType;
     private Identity serverIdentity;
     @Setter(AccessLevel.PACKAGE) private Instant creationTimestamp;
     @Setter(AccessLevel.PACKAGE) private Instant lastAccessTimestamp;
@@ -235,6 +236,11 @@ public class RNSPeer {
         }
         else {
             log.info("creating buffer - peerLink status: {}, channel: {}", this.peerLink.getStatus(), channel);
+            //// multi-destination: we might need to use different stream IDs from other destination (default is 0) (?)
+            //if (destinationType == RNSCommon.RNSDestinationType.DATA) {
+            //    this.receiveStreamId = 1;
+            //    this.sendStreamId = 1;
+            //}
             this.peerBuffer = Buffer.createBidirectionalBuffer(receiveStreamId, sendStreamId, channel, this::peerBufferReady);
         }
         return getPeerBuffer();

--- a/src/main/java/org/qortal/network/task/RNSPingTask.java
+++ b/src/main/java/org/qortal/network/task/RNSPingTask.java
@@ -35,8 +35,9 @@ public class RNSPingTask implements Task {
         // Note: Even though getResponse would work, we can use
         //       peer.sendMessage(pingMessage) using Reticulum buffer instead.
         //       More efficient and saves room for other request/response tasks.
-        peer.getResponse(pingMessage);
-        //peer.sendMessage(pingMessage);
+        //peer.getResponse(pingMessage);
+        // Note: We chose asynchronous for ping, no need to block queues for this.
+        peer.sendMessage(pingMessage);
 
         //// task is not over here (Reticulum is asynchronous)
         //peer.setLastPing(NTP.getTime() - now);

--- a/src/main/java/org/qortal/settings/Settings.java
+++ b/src/main/java/org/qortal/settings/Settings.java
@@ -633,6 +633,10 @@ public class Settings {
 			"phantom.mobilefabrik.com",
 			"phantom.tuergass.net"
 	};
+	/** There is a Python rnsd running on the node with a gateway inteface to use */
+	private boolean reticulumUsePythonRNS = false;
+	/** Specify the port if reticulumUsePythonRNS=true and rnsd has a TCPServerInterface */
+	private int reticulumPythonRNSGatewayPort = 4242;
 
 	// Constructors
 
@@ -1414,6 +1418,10 @@ public class Settings {
 	public String[] getReticulumTcpGatewayServers() {
 		return this.reticulumTcpGatewayServers;
 	}
+
+	public boolean getReticulumUsePythonRNS() { return this.reticulumUsePythonRNS; }
+
+	public int getReticulumPythonRNSGatewayPort() { return this.reticulumPythonRNSGatewayPort; }
 
 	public int getBuildArbitraryResourcesBatchSize() {
 		return buildArbitraryResourcesBatchSize;

--- a/src/main/resources/reticulum_config_template.jinja
+++ b/src/main/resources/reticulum_config_template.jinja
@@ -51,7 +51,6 @@ interfaces:
 {%- set gateway_servers = tcp_gateway_servers|split(' ')|shuffle -%}
 {%- for item in gateway_servers -%}
   {%- set fqdn_port_list = item|split(':') -%}
-  {# fqdn_port_list #}
   {%- if fqdn_port_list|length > 1 -%}
     {%- set item_fqdn = fqdn_port_list[0] -%}
     {%- set item_target_port = fqdn_port_list[1] -%}

--- a/src/main/resources/reticulum_config_template.jinja
+++ b/src/main/resources/reticulum_config_template.jinja
@@ -5,7 +5,11 @@
 # "reticulumHasServerInterface": node has gateway interface [boolean]
 # "reticulumDesiredClientInterfaces": how many TCP server interfaces
 #                                      to generate [integer] (deafault: 1)
-# "reticulumTcpGatewayServers": list of TCP Gateway nodes [json list]
+# "reticulumTcpGatewayServers": list of TCP Gateway node fqdn[:port] strings
+#                               (port optional) [json list]
+# "reticulumUsePythonRNS": there is a Python shared rnsd on on the node [boolean]
+#                          Note: the rnsd instance must have a gateway interface
+# "reticulumPythonRNSGatewayPort": the port to the desired PythonRNS interface [int]
 
 reticulum:
 
@@ -35,23 +39,32 @@ interfaces:
     # disabled by default
     enabled: false
 
-{% if is_reticulum_gateway %}
+{% if use_python_rns %}
   # gateway node: client to local Python RNS instance
   "TCP Client Interface qortal local":
     type: TCPClientInterface
     enabled: true
     target_host: localhost
-    target_port: 4242
+    target_port: {{ python_rns_if_port }}
     network_name: {{ qortal_network_name }}
 {% endif %}
 {%- set gateway_servers = tcp_gateway_servers|split(' ')|shuffle -%}
 {%- for item in gateway_servers -%}
-  {% if (loop.index <= num_client_interfaces) and (item != host_fqdn) %}
-  "TCP Client Interface qortal {{ item }}":
+  {%- set fqdn_port_list = item|split(':') -%}
+  {# fqdn_port_list #}
+  {%- if fqdn_port_list|length > 1 -%}
+    {%- set item_fqdn = fqdn_port_list[0] -%}
+    {%- set item_target_port = fqdn_port_list[1] -%}
+  {%- else -%}
+    {%- set item_fqdn = item -%}
+    {%- set item_target_port = target_port -%}
+  {%- endif -%}
+  {% if (loop.index <= num_client_interfaces) and (item_fqdn != host_fqdn) %}
+  "TCP Client Interface qortal {{ item_fqdn }}":
     type: TCPClientInterface
     enabled: true
-    target_host: {{ item }}
-    target_port: {{ target_port }}
+    target_host: {{ item_fqdn }}
+    target_port: {{ item_target_port }}
     network_name: {{ qortal_network_name }}
   {% endif %}
 {%- endfor -%}


### PR DESCRIPTION
Some updates:

* fix config.yml template: allow for fqdn[:port] entries in core server list.
* confg.yml template: allow to specify port for local rnsd client interface.
* remove some pom.xml duplicates.
* change RNSPingTask back to async mode, no need for blocking queue.
* prepared additional 2nd Destination to separate QDN and core traffic. Separates RNSPeer(s) by destinationType (CORE, DATA).