### PR TITLE
Remove eclipse config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,49 +402,7 @@
 					<skipTests>${skipTests}</skipTests>
 				</configuration>
 			</plugin>
-		</plugins>
-		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>${lifecycle-mapping.version}</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-dependency-plugin</artifactId>
-										<version>${maven-dependency-plugin.version}</version>
-										<goals>
-											<goal>unpack</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<execute/>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>com.google.code.maven-replacer-plugin</groupId>
-										<artifactId>replacer</artifactId>
-										<version>${replacer.version}</version>
-										<goals>
-											<goal>replace</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<execute/>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
+		</plugins>		
 	</build>
 	<repositories>
 		<repository>


### PR DESCRIPTION
Remove eclipse config, because it causes a conflict in VScode and output the error:
`
"Cannot parse lifecycle mapping metadata... Unrecognized tag: 'version'"`

The underlying cause is:
`The lifecycle-mapping plugin is Eclipse-specific metadata used by M2E (Maven Integration for Eclipse). It has no effect on Maven builds, and is not recognized by other Maven tools — including the one used by VS Code's Java Language Server.`

This PR replaces #273 
