### PR TITLE
Bugfix/group invite expiry

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -45,3 +45,8 @@ Template for entries:
 - Files: (inspection only; no file changes)
 - What: Verified all chain configs with featureTriggers already include `groupInviteExpiryHeight`; no additional files needed updates.
 - Why: Ensures startup validation won’t fail on overlooked configs before proceeding to code changes.
+
+## Gate invite-first expiry by trigger
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Introduced trigger-gated invite expiry handling in `Group.join(...)`, using next block height to decide when to apply invite expiry logic.
+- Why: Ensures invite expiry enforcement is only evaluated after the `groupInviteExpiryHeight` activation point.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -25,3 +25,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/block/BlockChain.java
 - What: Documented the `getGroupInviteExpiryHeight` convenience method with the intended activation scope (invite-first expiry enforcement).
 - Why: Clarifies the purpose of the getter so future invite-expiry logic and reviews have an explicit reference to its role.
+
+## Wire mainnet config placeholder
+- Files: src/main/resources/blockchain.json
+- What: Added a placeholder `groupInviteExpiryHeight` entry (set to 99999999) to the mainnet featureTriggers map.
+- Why: Ensures mainnet config recognizes the new invite-expiry trigger while keeping activation far in the future until a rollout height is chosen.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -20,3 +20,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/block/BlockChain.java
 - What: Added `groupInviteExpiryHeight` to the `FeatureTrigger` enum and exposed a getter to read it from chain configs.
 - Why: This prepares the blockchain config/validation to recognize the new invite-expiration trigger and makes it accessible to invite-handling code.
+
+## Expose feature trigger getter
+- Files: src/main/java/org/qortal/block/BlockChain.java
+- What: Documented the `getGroupInviteExpiryHeight` convenience method with the intended activation scope (invite-first expiry enforcement).
+- Why: Clarifies the purpose of the getter so future invite-expiry logic and reviews have an explicit reference to its role.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -145,7 +145,7 @@ Template for entries:
 - Why: Verifies the success path of invite-first expiry enforcement.
 - Output:
   - [testInviteFirstValidBeforeExpiryAddsMember] START
-  - Join timestamp 1764912209573 before expiry 1764912211073
+  - Join timestamp 1764917672854 before expiry 1764917674354
   - Membership? true
   - Invite should be consumed -> null
   - Join request should be absent -> null
@@ -157,7 +157,7 @@ Template for entries:
 - Why: Confirms expired invites are treated as absent and fall back to request handling.
 - Output:
   - [testInviteFirstExpiredCreatesRequest] START
-  - Join timestamp 1764912211191 after expiry 1764912211190
+  - Join timestamp 1764917674379 after expiry 1764917674378
   - Membership? false
   - Join request stored? true
   - Expired invite retained? true
@@ -169,7 +169,7 @@ Template for entries:
 - Why: Documents the transaction-timestamp window behavior for invite consumption.
 - Output:
   - [testInviteFirstBackdatedJoinWithinExpiry] START
-  - Join timestamp 1764912212559 relative to expiry 1764912213059
+  - Join timestamp 1764917675587 relative to expiry 1764917676087
   - Membership? true
   - PASS
 
@@ -209,7 +209,7 @@ Template for entries:
 - Why: Confirms chain-tip-based filtering behavior exposed via API.
 - Output:
   - [testApiFiltersExpiredInvites] START
-  - Minting expired invite at 1764912207663 for bob
+  - Minting expired invite at 1764917670601 for bob
   - Minting TTL=0 invite for chloe
   - Group invites returned: 1
   - Invites for Chloe: 1
@@ -222,12 +222,28 @@ Template for entries:
 - Why: Validates trigger-gated activation of invite expiry enforcement.
 - Output:
   - [testPrePostTriggerActivation] START
-  - Pre-trigger join timestamp 1764912213759 relative to expiry 1764912212759
+  - Pre-trigger join timestamp 1764917676864 relative to expiry 1764917675864
   - Pre-trigger membership? true
-  - Post-trigger join timestamp 1764912213894 relative to expiry 1764912212894
+  - Post-trigger join timestamp 1764917676945 relative to expiry 1764917675945
   - Post-trigger membership? false
   - Post-trigger request stored and invite retained
   - PASS
+
+## testInviteFilteringByChainTip
+- What: API invite filtering hides expired invites and retains TTL=0/unexpired invites using chain-tip timestamp.
+- How: Mint an expired invite, a non-expiring invite, and an unexpired invite; call invitee and group endpoints; assert expired invite filtered out and others returned.
+- Why: Verifies chain-tip-based filtering behavior exposed via API.
+- Output:
+  - TEST START: testInviteFilteringByChainTip - expired invites filtered, TTL=0/unexpired retained.
+  - TEST PASS: testInviteFilteringByChainTip - expected bobInvites size=1, actual=1; expected groupInvites size=2, actual=2
+
+## testInviteFilteringSkippedWhenNoChainTip
+- What: API invite filtering is skipped when no chain tip is available, so expired invites are returned.
+- How: Mint an expired invite, swap repository factory to return null chain tip, call invitee endpoint, and assert expired invite is present.
+- Why: Confirms documented no-tip fallback for API filtering.
+- Output:
+  - TEST START: testInviteFilteringSkippedWhenNoChainTip - filtering is skipped without a chain tip.
+  - TEST PASS: testInviteFilteringSkippedWhenNoChainTip - expired invite present=true
 
 # Test Logging Notes
 - Added descriptive stdout logging (`log(testName, message)`) to new invite-expiry tests to show start, key state, and outcomes when run via CLI.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -70,3 +70,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Confirmed invite expiry logic treats `expiry == null` as non-expiring and uses an inclusive `timestamp <= expiry` boundary with an explanatory comment.
 - Why: Ensures invite validation semantics are explicit and deterministic, matching the intended TTL sentinel and boundary behavior.
+
+## Document join-first time basis
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Added a code comment clarifying that TTL/expiry is intentionally ignored when an invite approves a pending join request (join-first path), pre- and post-trigger.
+- Why: Documents the deliberate legacy-preserving behavior so reviewers know this path remains TTL-agnostic.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,22 @@
+# Commits Log
+
+This document tracks each commit made for the invite-expiration work. For every TODO sub-item we complete, add a new entry before committing:
+
+- Use the sub-item title as the commit message.
+- List the files changed.
+- Describe what the changes do.
+- Explain why the changes are needed.
+
+Template for entries:
+
+```
+## <commit message / TODO sub-item title>
+- Files: <comma-separated paths>
+- What: <concise description of the changes>
+- Why: <reasoning/intent>
+```
+
+## Add feature trigger enum entry
+- Files: src/main/java/org/qortal/block/BlockChain.java
+- What: Added `groupInviteExpiryHeight` to the `FeatureTrigger` enum and exposed a getter to read it from chain configs.
+- Why: This prepares the blockchain config/validation to recognize the new invite-expiration trigger and makes it accessible to invite-handling code.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -75,3 +75,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Added a code comment clarifying that TTL/expiry is intentionally ignored when an invite approves a pending join request (join-first path), pre- and post-trigger.
 - Why: Documents the deliberate legacy-preserving behavior so reviewers know this path remains TTL-agnostic.
+
+## Auto-approve pending request
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Clarified in code that a matching invite auto-approves and consumes a pending join request in the join-first path, maintaining legacy behavior.
+- Why: Documents the intended behavior for reviewers and affirms no trigger/TTL gating is applied when approving stored requests.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -85,3 +85,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Noted that TTL=0 invites remain valid in the join-first auto-approval path.
 - Why: Documents that the non-expiring sentinel applies consistently even when approving stored join requests.
+
+## Filter invites-by-invitee API
+- Files: src/main/java/org/qortal/api/resource/GroupsResource.java
+- What: Added chain-tip-based filtering for `/groups/invites/{address}` invites, treating `expiry == null` as non-expiring, using inclusive `expiry >= tip`, and skipping filtering when no chain tip is present; introduced a helper to reuse for other invite listings.
+- Why: Hides expired invites from the API without relying on local time and prepares for consistent invite filtering across endpoints.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -60,3 +60,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: When the invite is expired post-trigger, `Group.join` now treats it as missing, falling back to a join request for closed groups without deleting the stale invite.
 - Why: Prevents expired invites from granting membership while preserving the stored invite for deterministic replay/orphan handling.
+
+## Preserve pre-trigger join behavior
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Clarified the trigger gate in `Group.join` to note legacy behavior remains unchanged before activation.
+- Why: Documents that expiry enforcement is strictly post-trigger, reassuring reviewers about pre-trigger compatibility.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -126,6 +126,17 @@ Template for entries:
 - What: Added coverage showing expired invites auto-add pre-trigger but fall back to join requests post-trigger, using a temporary feature trigger override via reflection.
 - Why: Validates trigger-gated behavior for invite expiry enforcement across activation boundaries.
 
+
+## Update docs with final semantics
+- Files: docs/INVITE_EXPIRATION.md, docs/IMPLEMENTATION.md
+- What: Documented finalized invite-expiry semantics (trigger, invite-first enforcement with join timestamp, join-first TTL-agnostic behavior, transaction-timestamp dating windows, and API chain-tip filtering divergence).
+- Why: Keeps design docs aligned with implemented behavior and test coverage.
+
+## Document activation plan
+- Files: docs/CONSENSUS_CHANGE.md
+- What: Added activation plan guidance (placeholder trigger on mainnet, low heights on testnet/fixtures, follow-up release to set real height after coverage).
+- Why: Clarifies rollout steps for the consensus change.
+
 # Added Tests (details)
 
 ## testInviteFirstValidBeforeExpiryAddsMember
@@ -134,7 +145,7 @@ Template for entries:
 - Why: Verifies the success path of invite-first expiry enforcement.
 - Output:
   - [testInviteFirstValidBeforeExpiryAddsMember] START
-  - Join timestamp 1764911654474 before expiry 1764911655974
+  - Join timestamp 1764912209573 before expiry 1764912211073
   - Membership? true
   - Invite should be consumed -> null
   - Join request should be absent -> null
@@ -146,7 +157,7 @@ Template for entries:
 - Why: Confirms expired invites are treated as absent and fall back to request handling.
 - Output:
   - [testInviteFirstExpiredCreatesRequest] START
-  - Join timestamp 1764911657753 after expiry 1764911657752
+  - Join timestamp 1764912211191 after expiry 1764912211190
   - Membership? false
   - Join request stored? true
   - Expired invite retained? true
@@ -158,7 +169,7 @@ Template for entries:
 - Why: Documents the transaction-timestamp window behavior for invite consumption.
 - Output:
   - [testInviteFirstBackdatedJoinWithinExpiry] START
-  - Join timestamp 1764911658928 relative to expiry 1764911659428
+  - Join timestamp 1764912212559 relative to expiry 1764912213059
   - Membership? true
   - PASS
 
@@ -198,7 +209,7 @@ Template for entries:
 - Why: Confirms chain-tip-based filtering behavior exposed via API.
 - Output:
   - [testApiFiltersExpiredInvites] START
-  - Minting expired invite at 1764911653566 for bob
+  - Minting expired invite at 1764912207663 for bob
   - Minting TTL=0 invite for chloe
   - Group invites returned: 1
   - Invites for Chloe: 1
@@ -211,9 +222,9 @@ Template for entries:
 - Why: Validates trigger-gated activation of invite expiry enforcement.
 - Output:
   - [testPrePostTriggerActivation] START
-  - Pre-trigger join timestamp 1764911659966 relative to expiry 1764911658966
+  - Pre-trigger join timestamp 1764912213759 relative to expiry 1764912212759
   - Pre-trigger membership? true
-  - Post-trigger join timestamp 1764911660059 relative to expiry 1764911659059
+  - Post-trigger join timestamp 1764912213894 relative to expiry 1764912212894
   - Post-trigger membership? false
   - Post-trigger request stored and invite retained
   - PASS

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -90,3 +90,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/api/resource/GroupsResource.java
 - What: Added chain-tip-based filtering for `/groups/invites/{address}` invites, treating `expiry == null` as non-expiring, using inclusive `expiry >= tip`, and skipping filtering when no chain tip is present; introduced a helper to reuse for other invite listings.
 - Why: Hides expired invites from the API without relying on local time and prepares for consistent invite filtering across endpoints.
+
+## Filter invites-by-group API
+- Files: src/main/java/org/qortal/api/resource/GroupsResource.java
+- What: Applied the same chain-tip-based invite filtering to `/groups/invites/group/{groupid}` via the shared helper, respecting `expiry == null`, inclusive boundary, and no-tip passthrough.
+- Why: Ensures group-level invite listings also hide expired entries without depending on local time.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -40,3 +40,8 @@ Template for entries:
 - Files: src/test/resources/test-chain-v2.json, src/test/resources/test-chain-v2-block-timestamps.json, src/test/resources/test-chain-v2-disable-reference.json, src/test/resources/test-chain-v2-founder-rewards.json, src/test/resources/test-chain-v2-leftover-reward.json, src/test/resources/test-chain-v2-minting.json, src/test/resources/test-chain-v2-penalty-fix.json, src/test/resources/test-chain-v2-qora-holder-extremes.json, src/test/resources/test-chain-v2-qora-holder-reduction.json, src/test/resources/test-chain-v2-qora-holder.json, src/test/resources/test-chain-v2-reward-levels.json, src/test/resources/test-chain-v2-reward-scaling.json, src/test/resources/test-chain-v2-reward-shares.json, src/test/resources/test-chain-v2-self-sponsorship-algo-v1.json, src/test/resources/test-chain-v2-self-sponsorship-algo-v2.json, src/test/resources/test-chain-v2-self-sponsorship-algo-v3.json
 - What: Added `groupInviteExpiryHeight` with low activation (0) across all test-chain fixture configs.
 - Why: Keeps all test fixtures aligned with startup validation and allows tests to exercise invite-expiry logic immediately.
+
+## (No commit) Sanity-check trigger coverage
+- Files: (inspection only; no file changes)
+- What: Verified all chain configs with featureTriggers already include `groupInviteExpiryHeight`; no additional files needed updates.
+- Why: Ensures startup validation won’t fail on overlooked configs before proceeding to code changes.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -120,3 +120,8 @@ Template for entries:
 - Files: src/test/java/org/qortal/test/group/MiscTests.java
 - What: Added an API-level test verifying chain-tip-based filtering hides expired invites while retaining non-expiring ones for both invitee and group endpoints.
 - Why: Confirms the filtering helper and endpoints omit expired invites without local clock use.
+
+## Test pre/post trigger activation
+- Files: src/test/java/org/qortal/test/group/MiscTests.java
+- What: Added coverage showing expired invites auto-add pre-trigger but fall back to join requests post-trigger, using a temporary feature trigger override via reflection.
+- Why: Validates trigger-gated behavior for invite expiry enforcement across activation boundaries.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -95,3 +95,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/api/resource/GroupsResource.java
 - What: Applied the same chain-tip-based invite filtering to `/groups/invites/group/{groupid}` via the shared helper, respecting `expiry == null`, inclusive boundary, and no-tip passthrough.
 - Why: Ensures group-level invite listings also hide expired entries without depending on local time.
+
+## Document unconditional filtering
+- Files: src/main/java/org/qortal/api/resource/GroupsResource.java
+- What: Updated swagger summaries for invite endpoints to explicitly state chain-tip-based filtering (inclusive boundary, `expiry == null` sentinel) and left filtering unconditional (no feature trigger) with no local-clock fallback when tip is missing.
+- Why: Makes the filtering behavior clear to API consumers and documents the divergence from consensus time basis.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -110,3 +110,8 @@ Template for entries:
 - Files: src/test/java/org/qortal/test/group/MiscTests.java
 - What: Added join-first tests confirming invites auto-approve pending requests regardless of TTL/age (including TTL=0) and that backdated requests still auto-add when an invite arrives later.
 - Why: Documents and validates the TTL-agnostic join-first path and back/forward-dated request approval behavior.
+
+## Test backdated/forward-dated join window
+- Files: src/test/java/org/qortal/test/group/MiscTests.java
+- What: Added invite-first test showing a backdated join within the invite’s expiry window still adds a member (documenting tx-timestamp dating behavior).
+- Why: Captures the expected behavior of the transaction-timestamp window for invite consumption.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -100,3 +100,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/api/resource/GroupsResource.java
 - What: Updated swagger summaries for invite endpoints to explicitly state chain-tip-based filtering (inclusive boundary, `expiry == null` sentinel) and left filtering unconditional (no feature trigger) with no local-clock fallback when tip is missing.
 - Why: Makes the filtering behavior clear to API consumers and documents the divergence from consensus time basis.
+
+## Test invite-first expiry enforcement
+- Files: src/test/java/org/qortal/test/group/MiscTests.java
+- What: Added invite-first tests covering valid-before-expiry membership and expired-invite fallback to join request (invite retained), with helper builders for timestamped joins and TTL invites.
+- Why: Verifies post-trigger invite expiry enforcement matches intended behavior in invite-first flow.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -65,3 +65,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Clarified the trigger gate in `Group.join` to note legacy behavior remains unchanged before activation.
 - Why: Documents that expiry enforcement is strictly post-trigger, reassuring reviewers about pre-trigger compatibility.
+
+## Honor TTL=0 and inclusive boundary
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Confirmed invite expiry logic treats `expiry == null` as non-expiring and uses an inclusive `timestamp <= expiry` boundary with an explanatory comment.
+- Why: Ensures invite validation semantics are explicit and deterministic, matching the intended TTL sentinel and boundary behavior.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -50,3 +50,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Introduced trigger-gated invite expiry handling in `Group.join(...)`, using next block height to decide when to apply invite expiry logic.
 - Why: Ensures invite expiry enforcement is only evaluated after the `groupInviteExpiryHeight` activation point.
+
+## Use join tx timestamp for expiry check
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Added join-transaction-timestamp-based expiry evaluation, respecting TTL=0 as never expiring and an inclusive `<= expiry` boundary.
+- Why: Ensures invite validity checks rely on deterministic transaction timestamps instead of local time before applying invite consumption.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -115,3 +115,8 @@ Template for entries:
 - Files: src/test/java/org/qortal/test/group/MiscTests.java
 - What: Added invite-first test showing a backdated join within the invite’s expiry window still adds a member (documenting tx-timestamp dating behavior).
 - Why: Captures the expected behavior of the transaction-timestamp window for invite consumption.
+
+## Test API invite filtering
+- Files: src/test/java/org/qortal/test/group/MiscTests.java
+- What: Added an API-level test verifying chain-tip-based filtering hides expired invites while retaining non-expiring ones for both invitee and group endpoints.
+- Why: Confirms the filtering helper and endpoints omit expired invites without local clock use.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -55,3 +55,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Added join-transaction-timestamp-based expiry evaluation, respecting TTL=0 as never expiring and an inclusive `<= expiry` boundary.
 - Why: Ensures invite validity checks rely on deterministic transaction timestamps instead of local time before applying invite consumption.
+
+## Treat expired invite as absent in join
+- Files: src/main/java/org/qortal/group/Group.java
+- What: When the invite is expired post-trigger, `Group.join` now treats it as missing, falling back to a join request for closed groups without deleting the stale invite.
+- Why: Prevents expired invites from granting membership while preserving the stored invite for deterministic replay/orphan handling.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -35,3 +35,8 @@ Template for entries:
 - Files: testnet/testchain.json
 - What: Added `groupInviteExpiryHeight` with immediate activation (height 0) to the testnet featureTriggers map.
 - Why: Ensures testnet nodes recognize and activate invite-expiry logic right away for testing and validation.
+
+## Wire test fixtures
+- Files: src/test/resources/test-chain-v2.json, src/test/resources/test-chain-v2-block-timestamps.json, src/test/resources/test-chain-v2-disable-reference.json, src/test/resources/test-chain-v2-founder-rewards.json, src/test/resources/test-chain-v2-leftover-reward.json, src/test/resources/test-chain-v2-minting.json, src/test/resources/test-chain-v2-penalty-fix.json, src/test/resources/test-chain-v2-qora-holder-extremes.json, src/test/resources/test-chain-v2-qora-holder-reduction.json, src/test/resources/test-chain-v2-qora-holder.json, src/test/resources/test-chain-v2-reward-levels.json, src/test/resources/test-chain-v2-reward-scaling.json, src/test/resources/test-chain-v2-reward-shares.json, src/test/resources/test-chain-v2-self-sponsorship-algo-v1.json, src/test/resources/test-chain-v2-self-sponsorship-algo-v2.json, src/test/resources/test-chain-v2-self-sponsorship-algo-v3.json
+- What: Added `groupInviteExpiryHeight` with low activation (0) across all test-chain fixture configs.
+- Why: Keeps all test fixtures aligned with startup validation and allows tests to exercise invite-expiry logic immediately.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -80,3 +80,8 @@ Template for entries:
 - Files: src/main/java/org/qortal/group/Group.java
 - What: Clarified in code that a matching invite auto-approves and consumes a pending join request in the join-first path, maintaining legacy behavior.
 - Why: Documents the intended behavior for reviewers and affirms no trigger/TTL gating is applied when approving stored requests.
+
+## Honor TTL=0 sentinel (join-first)
+- Files: src/main/java/org/qortal/group/Group.java
+- What: Noted that TTL=0 invites remain valid in the join-first auto-approval path.
+- Why: Documents that the non-expiring sentinel applies consistently even when approving stored join requests.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -105,3 +105,8 @@ Template for entries:
 - Files: src/test/java/org/qortal/test/group/MiscTests.java
 - What: Added invite-first tests covering valid-before-expiry membership and expired-invite fallback to join request (invite retained), with helper builders for timestamped joins and TTL invites.
 - Why: Verifies post-trigger invite expiry enforcement matches intended behavior in invite-first flow.
+
+## Test join-first behavior
+- Files: src/test/java/org/qortal/test/group/MiscTests.java
+- What: Added join-first tests confirming invites auto-approve pending requests regardless of TTL/age (including TTL=0) and that backdated requests still auto-add when an invite arrives later.
+- Why: Documents and validates the TTL-agnostic join-first path and back/forward-dated request approval behavior.

--- a/COMMITS.md
+++ b/COMMITS.md
@@ -30,3 +30,8 @@ Template for entries:
 - Files: src/main/resources/blockchain.json
 - What: Added a placeholder `groupInviteExpiryHeight` entry (set to 99999999) to the mainnet featureTriggers map.
 - Why: Ensures mainnet config recognizes the new invite-expiry trigger while keeping activation far in the future until a rollout height is chosen.
+
+## Wire testnet config
+- Files: testnet/testchain.json
+- What: Added `groupInviteExpiryHeight` with immediate activation (height 0) to the testnet featureTriggers map.
+- Why: Ensures testnet nodes recognize and activate invite-expiry logic right away for testing and validation.

--- a/docs/CONSENSUS_CHANGE.md
+++ b/docs/CONSENSUS_CHANGE.md
@@ -139,6 +139,12 @@ These are the specific semantics I would explicitly codify (and test) before mer
 
 If you want, next step we can walk through the exact “post-trigger rule” you prefer (strict reject vs “request-only”), but the above is the low-risk option that matches existing closed-group behavior.
 
+## Activation plan (next release)
+
+- Keep `groupInviteExpiryHeight` in configs: mainnet placeholder (far future), testnet/fixtures low heights.
+- Ship the rule behind the placeholder height first; use on-chain auto-update.
+- Once coverage is sufficient, publish a follow-up release that sets a real activation height and communicates the fork date/height to operators.
+
 [1]: https://github.com/qortal/qortal/releases?utm_source=chatgpt.com "Releases · Qortal/qortal"
 [2]: https://wiki.qortal.org/doku.php?id=how_to_update_.jar_file "how_to_update_.jar_file [Qortal Project ]"
 [3]: https://wiki.qortal.org/doku.php?id=qortal_in_a_nutshell "qortal_in_a_nutshell [Qortal Project ]"

--- a/docs/CONSENSUS_CHANGE.md
+++ b/docs/CONSENSUS_CHANGE.md
@@ -1,0 +1,145 @@
+### TL;DR
+
+Yes — **enforcing invite expiration at the moment a closed-group join is finalized is a consensus change**, so you should ship it behind a **new `featureTrigger` block height** (`groupInviteExpiryHeight`, not local wall-clock time), release a new Core version, and **schedule the trigger far enough ahead that the on-chain auto-update can propagate**. Qortal already does exactly this style of rollout for other consensus-affecting changes via “featureTriggers” keyed by block height. ([GitHub][1]) Ship the first release with a far-future placeholder height (e.g., `99999999`) and flip it to a real activation height only after rollout coverage is high.
+
+---
+
+## Root cause → fix → how to verify (for this item)
+
+* **Root cause:** invite `expiration` exists as data, but is not enforced in the membership-finalization logic, so an old `GROUP_INVITE` can “approve” a `JOIN_GROUP` indefinitely.
+* **Fix:** after **`groupInviteExpiryHeight`**, a closed-group `JOIN_GROUP` finalizes membership **only if a matching `GROUP_INVITE` exists and is unexpired at the deterministic transaction timestamp used for finalization** (`expiry == null` means “never”, valid if `finalizingTxTimestamp <= inviteExpiry`). In the invite-first path, expired invites are ignored so the join remains a request; in the join-first path, TTL is ignored and any matching invite approves the pending request (documented exception). Use transaction timestamps for determinism, never local time.
+* **Verify:** before trigger height, behavior unchanged; after trigger height in the invite-first path, a `JOIN_GROUP` that would previously auto-add a member instead becomes only a request (no auto-add). Join-first remains exempt (any invite approves a stored request), so only invite-first flows show the delta post-trigger.
+
+---
+
+## Why this must be a hard-fork / consensus-triggered change
+
+Once you enforce expiry, two nodes will disagree on group membership for the same block if only one enforces it:
+
+* **Old nodes:** “Invite exists ⇒ join succeeds (member added)”
+* **Upgraded nodes:** “Invite exists but expired ⇒ join does *not* add member”
+
+That divergence affects the validity/effect of later group-dependent transactions, so it’s consensus-critical. Hence: **feature trigger + coordinated rollout**.
+
+---
+
+## Recommended trigger mechanism: block height (not timestamp)
+
+Qortal already uses **featureTriggers expressed as block heights** (e.g. `adminsReplaceFoundersHeight`, etc.), and has shipped releases where multiple triggers activate on the same height. ([GitHub][1])
+
+**Recommendation:** implement this as a new **feature trigger height**:
+
+* `groupInviteExpiryHeight: 99999999` (placeholder “all 9s”)
+* later replace with a real height once you’re ready to schedule the fork.
+
+Why height is the safer default:
+
+* Deterministic during reorg and replay.
+* Matches existing Qortal operational practice. ([GitHub][1])
+
+---
+
+## Exactly what rule should change at the trigger
+
+### Pre-trigger (legacy behavior)
+
+* Preserve current semantics 1:1 for replay compatibility.
+
+### Post-trigger (new behavior)
+
+Canonical rule: after `groupInviteExpiryHeight`, membership finalizes **only if a matching invite exists and the relevant transaction timestamp is <= inviteExpiry** (`expiry == null` = never). If the invite is expired, ignore it and let the join fall back to a pending request instead of rejecting the transaction (request path only). For join-first auto-approvals, TTL is intentionally ignored: any matching invite approves a pending request.
+
+When a closed-group membership is about to be finalized because both sides exist (`JOIN_GROUP` + `GROUP_INVITE`, regardless of order), the approval side must check:
+
+**Invite is valid iff (invite-first path)**
+
+* `expiry == null` (TTL = 0 “never expires”), **OR**
+* `timestamp_used_for_finalization <= inviteTx.timestamp + expiryPeriod`
+
+Key point: **do not use local time (`System.currentTimeMillis`/NTP) in consensus paths.** Use the transaction timestamp (join or invite, depending on ordering). This matches ban-expiry semantics but accepts the ~30m forward-dating window allowed by `maxTransactionTimestampFuture`. The boundary is inclusive (`<= expiry`). Small note on dating: transaction timestamps can be forward-dated (~30m) and backdated within the transaction-expiry window (~24h), so an invite can still be consumed by a JOIN whose timestamp lies inside the TTL even if the block is mined later. Join-first auto-approvals ignore TTL entirely (any invite approves).
+
+Residual window (intentional): sticking with transaction-timestamp semantics means a caller can use that forward/backdating window to consume an invite outside its wall-clock TTL. This is the accepted trade-off for determinism and parity with current ban handling; tighter expiry would require block-time or hybrid semantics (see docs/OTHER_ISSUES.md).
+
+### Practical semantics (minimizes breakage)
+
+* If invite is expired, **do not reject the `JOIN_GROUP` transaction outright**.
+* Instead: treat it like a normal closed-group **join request** (i.e., it stays pending until a valid invite arrives).
+
+This avoids turning “expired invite” into a new transaction validity rule (more disruptive), while still fixing the exploit/bug: **you can’t become a member using an expired invite**.
+
+---
+
+## Handling both possible orderings (important)
+
+You described that order doesn’t matter: join can be a request first, invite can be approval later.
+
+Post-trigger, you want *both* of these to remain true (same as pre-trigger):
+
+1. **Invite-first (common case):**
+
+   * `JOIN_GROUP` finalizes membership only if invite is unexpired **at joinTx.timestamp**.
+
+2. **Join-first (request), invite-second:**
+
+   * Auto-approves a pending join request when an invite appears, and **TTL is ignored** in this path (any matching invite approves), pre- and post-trigger. This preserves the “request + later approval” behavior even for aged invites.
+
+If you only implement (1), you’ll fix the user-visible “invites never expire” bug in the most common flow; (2) is intentionally permissive and documented. In all cases, expired invites are ignored in invite-first (no rejection); closed-group joins fall back to pending requests.
+
+---
+
+## Feature-trigger rollout plan (how I’d ship it)
+
+### 1) Add the trigger (placeholder)
+
+* Add a new entry in the chain config featureTriggers set at **all-9s** placeholder height (e.g. `99999999`).
+* Gate the new behavior behind `height >= groupInviteExpiryHeight`.
+
+### 2) Ship the Core release + on-chain auto-update
+
+Qortal’s model is: **auto updates exist to keep nodes synced and reduce forking risk**. ([Qortal Project][2])
+Auto-updates themselves require dev/admin governance (40% approval is mentioned in the project wiki). ([Qortal Project][3])
+
+So operationally:
+
+* Release a Core version that *contains* the new rule but with a “far future” placeholder trigger.
+* Get it distributed via auto-update.
+
+### 3) Pick a real activation height and ship a follow-up release
+
+Qortal has previously:
+
+* **Set featureTrigger block heights** in releases, and even called out estimated activation dates. ([GitHub][4])
+* **Pushed trigger heights back** to allow more time for auto-update preparation/propagation. ([GitHub][4])
+
+So the pattern is already established:
+
+* Once most of the network is on the “rule-ready” version, ship a follow-up that changes the trigger from `999...` to a concrete height.
+* Set the activation height with enough margin that even slower nodes pick up the update.
+
+---
+
+## What “expiration details” you must lock down (so the fix is unambiguous)
+
+These are the specific semantics I would explicitly codify (and test) before merging:
+
+* **Units:** is invite `expiration` seconds, minutes, blocks, or milliseconds? (Treat it consistently everywhere.)
+* **Sentinel value:** `expiry == null` means “never expires” (TTL = 0); enforce it explicitly.
+* **Boundary:** is `expiresAt` inclusive or exclusive?
+
+  * I’d recommend: valid if `finalizingTx.timestamp <= expiresAt` (inclusive), because it avoids “off-by-one millisecond” surprises.
+* **Timestamp basis:** use **transaction timestamp** (join/invite, matching ban expiry); note the allowed ~30m forward-dating window via `maxTransactionTimestampFuture` and backdating within the tx-expiry window (~24h). Never use local clock time.
+* **Both orderings:** invite-first enforces expiry; join-first auto-approvals intentionally ignore TTL (any matching invite approves a pending request).
+* **Orphan/reorg safety:** logic must replay identically during sync/reorg (feature-trigger gating by height ensures that).
+
+---
+
+## Minimal PR description text you can reuse
+
+> This change introduces consensus-enforced GROUP_INVITE expiration for closed-group membership finalization. After `groupInviteExpiryHeight` activates, a closed-group JOIN_GROUP finalizes membership only if a corresponding GROUP_INVITE exists and is unexpired at the deterministic on-chain transaction timestamp of finalization (with `expiry == null` meaning “never expires”); otherwise the join remains a request. Join-first auto-approvals intentionally ignore TTL (any matching invite approves a pending request). Prior to activation height, legacy behavior is preserved for chain compatibility.
+
+If you want, next step we can walk through the exact “post-trigger rule” you prefer (strict reject vs “request-only”), but the above is the low-risk option that matches existing closed-group behavior.
+
+[1]: https://github.com/qortal/qortal/releases?utm_source=chatgpt.com "Releases · Qortal/qortal"
+[2]: https://wiki.qortal.org/doku.php?id=how_to_update_.jar_file "how_to_update_.jar_file [Qortal Project ]"
+[3]: https://wiki.qortal.org/doku.php?id=qortal_in_a_nutshell "qortal_in_a_nutshell [Qortal Project ]"
+[4]: https://github.com/qortal/qortal/releases "Releases · Qortal/qortal · GitHub"

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -79,7 +79,12 @@ Note: Use the transaction timestamp (join/invite) for expiry checks to avoid loc
 
 ### Join-first auto-approval (invite arrives after join request)
 
-For pending join requests, TTL does **not** gate the approval: any matching invite (pre- and post-trigger) will approve the stored request, even if its TTL would have expired by wall-clock time. This keeps the “request + later approval” flow working regardless of invite age and avoids adding a new rejection path. Do not enforce expiry in this path; use the invite’s transaction timestamp only for deterministic bookkeeping, not for expiry checks.
+For pending join requests, TTL does **not** gate the approval (pre- and post-trigger). Any matching invite auto-approves the stored request, even if the invite’s TTL would be expired by wall-clock time. Notes:
+
+- Time basis: ignore TTL when approving a pending request; the invite’s transaction timestamp is used only for deterministic bookkeeping, not for expiry checks.
+- Flow: only auto-approve if a pending join request exists; consume that request when the invite confirms.
+- Trigger: no feature-trigger gating in this path; behavior is unchanged before/after activation.
+- TTL=0 sentinel: still means “never expires” (consistent with invite-first path).
 
 ### API filtering (client-facing, non-consensus)
 

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -81,6 +81,10 @@ Note: Use the transaction timestamp (join/invite) for expiry checks to avoid loc
 
 For pending join requests, TTL does **not** gate the approval: any matching invite (pre- and post-trigger) will approve the stored request, even if its TTL would have expired by wall-clock time. This keeps the “request + later approval” flow working regardless of invite age and avoids adding a new rejection path. Do not enforce expiry in this path; use the invite’s transaction timestamp only for deterministic bookkeeping, not for expiry checks.
 
+### API filtering (client-facing, non-consensus)
+
+Invite-list endpoints filter expired invites using the current chain-tip block timestamp with an inclusive boundary (`expiry >= tip`), treating `expiry == null` as never expiring, and skipping filtering if there is no chain tip (to avoid local clock). Filtering is unconditional (no feature trigger) and may hide invites that could still be consumed via back/forward-dated JOINs—this divergence is intentional as a UX safety layer.
+
 Residual window (intentional): because we keep transaction-timestamp semantics, the forward/backdating window (~30m / ~24h) remains usable to consume an invite outside its wall-clock TTL. Closing that would need a block-time or hybrid basis (see docs/OTHER_ISSUES.md); out of scope for this fix.
 
 ## API: Ignoring Expired Invites in Results

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -1,0 +1,151 @@
+# Implementing Invite Expiration in Qortal Groups
+
+Canonical rule (post-trigger, consensus path): after `groupInviteExpiryHeight`, a closed-group join only finalizes membership if a matching invite exists and the deterministic transaction timestamp used for finalization is **<= inviteExpiry** (`expiry == null` = never). If expired, ignore the invite and fall back to the join-request path; do not reject the transaction.
+
+## Feature Trigger: Invite Expiration Enforcement
+
+Gate the rule behind a blockchain feature trigger. Add a new enum entry to `BlockChain.FeatureTrigger` and a getter (e.g. `getGroupInviteExpiryHeight()`), and add the key to all chain configs (mainnet/testnet and every test fixture). Use a far-future placeholder on mainnet and low activation heights for tests. On startup, `BlockChain` validates that every enum entry exists in `featureTriggers`[1].
+
+## Enforcing Expiration on Group Join
+
+The core logic lives in Group.join(...) (file: org/qortal/group/Group.java). Currently, when a user attempts to join a closed group, the code checks for an existing invite but does not verify if it’s expired. Specifically, it retrieves any pending GroupInviteData for the joiner and, if none is found and the group is closed, converts the join to a pending request; otherwise, it uses the invite[3][4]:
+
+```
+GroupInviteData groupInviteData = this.getInvite(joiner.getAddress());
+
+if (groupInviteData == null && !groupData.isOpen()) {
+    // Closed group with no invite: create join request
+    this.addJoinRequest(joiner.getAddress(), joinTxData.getSignature());
+    joinTxData.setInviteReference(null);
+    return;
+}
+
+// If invite exists, use it (no expiration check yet)
+if (groupInviteData != null) {
+    joinTxData.setInviteReference(groupInviteData.getReference());
+    this.deleteInvite(joiner.getAddress());  // consume invite
+} else {
+    joinTxData.setInviteReference(null);
+}
+
+// Add new member to group
+this.addMember(joiner.getAddress(), joinTxData);
+...
+```
+
+We need to insert an expiration check after retrieving groupInviteData but before deciding how to proceed. The invite’s expiry timestamp is stored when the invite is created[5] (it’s set to inviteTimestamp + timeToLive*1000 if TTL > 0). Our plan (matching the canonical rule):
+
+1. Fetch the next block height (tip height + 1) and compare to the trigger height via `BlockChain.getGroupInviteExpiryHeight()`.
+2. If active (`nextHeight >= triggerHeight`) and the invite has an expiry (`expiry != null`), compare the **join transaction timestamp** (deterministic, matches ban semantics) against the expiry.
+3. If `joinTxTimestamp > expiry`, treat the invite as expired (inclusive boundary: `<= expiry` is valid). Set `groupInviteData = null` to force the “no invite” path; leave the expired invite stored and do not delete it.
+4. Pre-trigger: preserve legacy behavior unchanged.
+
+In code, it will look something like:
+
+```
+GroupInviteData groupInviteData = this.getInvite(joiner.getAddress());
+
+// If feature trigger active, check for expired invite
+long triggerHeight = BlockChain.getInstance().getGroupInviteExpiryHeight();
+int nextBlockHeight = this.repository.getBlockRepository().getBlockchainHeight() + 1;
+long now = joinGroupTransactionData.getTimestamp(); // transaction timestamp, deterministic, matches ban semantics
+if (nextBlockHeight >= triggerHeight
+        && groupInviteData != null
+        && groupInviteData.getExpiry() != null
+        && now > groupInviteData.getExpiry()) {
+    // Invite has expired – ignore it (leave stored)
+    groupInviteData = null;
+}
+
+if (groupInviteData == null && !groupData.isOpen()) {
+    // No valid invite for a closed group: create join request
+    this.addJoinRequest(joiner.getAddress(), joinTxData.getSignature());
+    joinTxData.setInviteReference(null);
+    return;
+}
+if (groupInviteData != null) {
+    // Valid invite present
+    joinTxData.setInviteReference(groupInviteData.getReference());
+    this.deleteInvite(joiner.getAddress());
+} else {
+    joinTxData.setInviteReference(null);
+}
+this.addMember(joiner.getAddress(), joinTxData);
+```
+
+This ensures that after the trigger height, an invite past its TTL will no longer grant immediate membership. Instead, the join will fall back to a join request (the expired invite remains in the database; we ignore it, consistent with ban handling). Before the trigger height, behavior remains unchanged for backward compatibility.
+
+Note: Use the transaction timestamp (join/invite) for expiry checks to avoid local-clock drift and to match ban expiry semantics. Do not use `NTP.getTime()` in consensus paths. Transaction timestamps can be forward-dated (~30m) and backdated within the transaction-expiry window (~24h), so an invite can still be consumed by a JOIN whose timestamp lies inside the TTL even if the containing block is later; that’s expected under tx-timestamp semantics.
+
+### Join-first auto-approval (invite arrives after join request)
+
+For pending join requests, TTL does **not** gate the approval: any matching invite (pre- and post-trigger) will approve the stored request, even if its TTL would have expired by wall-clock time. This keeps the “request + later approval” flow working regardless of invite age and avoids adding a new rejection path. Do not enforce expiry in this path; use the invite’s transaction timestamp only for deterministic bookkeeping, not for expiry checks.
+
+Residual window (intentional): because we keep transaction-timestamp semantics, the forward/backdating window (~30m / ~24h) remains usable to consume an invite outside its wall-clock TTL. Closing that would need a block-time or hybrid basis (see docs/OTHER_ISSUES.md); out of scope for this fix.
+
+## API: Ignoring Expired Invites in Results
+
+Update the API endpoints that list pending invites so that expired invites are filtered out. The relevant endpoints are in GroupsResource.java:
+
+- GET /groups/invites/{address} – returns invites where the given address is the invitee[6][7].
+- GET /groups/invites/group/{groupid} – returns invites for a given group[8][9].
+
+If the node has no chain tip yet (`getLastBlock() == null`, e.g., very early startup), skip filtering and return invites unfiltered to avoid using local time.
+
+Filter expired invites unconditionally (no feature trigger), using a deterministic basis such as the current chain tip’s block timestamp. Treat `expiry == null` (TTL=0) as never expires. For example:
+
+```
+List<GroupInviteData> invites = repository.getGroupRepository().getInvitesByInvitee(invitee);
+BlockData chainTip = repository.getBlockRepository().getLastBlock();
+if (chainTip == null)
+    return invites; // no tip yet; do not use local clock
+long chainTipTimestamp = chainTip.getTimestamp();
+return invites.stream()
+    .filter(inv -> inv.getExpiry() == null || inv.getExpiry() >= chainTipTimestamp) // inclusive boundary
+    .collect(Collectors.toList());
+```
+
+Apply the same filtering for getInvitesByGroupId. This hides expired invites from clients even before consensus enforcement and may hide invites that could still be used via back/forward-dated JOINs; this pre-trigger, chain-tip-based filtering is intentional as a soft mitigation/UX safety layer and should be documented as a divergence from consensus time basis (tx timestamp).
+
+Pagination note: limits/offsets are applied before filtering, so a page can return fewer items than the requested limit once expired invites are dropped, and filtered-out entries still count toward the offset (older invites can be skipped over). Sorting/reverse order is preserved because filtering happens after the repository query. This behavior is expected under the pre-trigger, client-facing filtering.
+
+## Unit Tests for Invite Expiration
+
+Extend the test suite (e.g., org.qortal.test.group.MiscTests) to cover:
+
+- Invite-first, valid before expiry → member added post-trigger.
+- Invite-first, expired → join becomes request, no membership; invite stored but ignored.
+- Join-first, invite later valid → auto-add member.
+- Join-first, invite later expired (by wall clock) still auto-adds because TTL is ignored for pending requests (documented behavior).
+- TTL=0 non-expiring invite → still works.
+- (Optional) Expired invite with backdated JOIN (tx timestamp ≤ expiry) still succeeds to document tx-timestamp window.
+
+Use `BlockChain.getGroupInviteExpiryHeight()` with `BlockUtils.mintBlocks(...)` to flip pre/post behavior; set test configs’ `groupInviteExpiryHeight` low (0/1). For API filtering, add tests (e.g., new GroupApiInviteTests) that use chain-tip block timestamp as “now,” skip filtering when there is no tip, and assert expired invites are omitted while TTL=0/unexpired remain. Document the divergence: API uses chain-tip time; consensus uses transaction timestamps and accepts the forward-dating window.
+
+[1] BlockChain.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/block/BlockChain.java
+
+[2] blockchain.json
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/resources/blockchain.json
+
+[3] [4] [5] Group.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/group/Group.java
+
+[6] [7] [8] [9] [14] GroupsResource.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/api/resource/GroupsResource.java
+
+[10] GroupInviteData.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/data/group/GroupInviteData.java
+
+[11] [12] [13] MiscTests.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/test/java/org/qortal/test/group/MiscTests.java
+
+[15] GroupInviteTransaction.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/transaction/GroupInviteTransaction.java

--- a/docs/INVITE_EXPIRATION.md
+++ b/docs/INVITE_EXPIRATION.md
@@ -1,0 +1,195 @@
+# Investigating Qortal’s Group Invite Expiration Issue
+
+## Overview of Qortal Group Invites and Joins
+
+Group Types: In Qortal, on-chain groups can be Open (public) or Closed (private). Membership in open groups is permissionless – anyone can join by broadcasting a JOIN_GROUP transaction. Closed groups, however, require an invitation and approval process:
+
+- Open Groups: A user joins by sending a JOIN_GROUP transaction. Once that transaction confirms, the user is immediately added as a group member.
+- Closed Groups: Joining is a two-step process:
+- A group admin sends a GROUP_INVITE transaction targeting the invitee’s address. This acts as an invitation (or an approval if a join request already exists).
+- The invitee accepts by sending their own JOIN_GROUP transaction for that group. This join will only succeed (result in membership) if a corresponding invite exists (or if the join came first and is later “approved” by an invite).
+
+The order of these two transactions doesn’t strictly matter. If the JOIN_GROUP comes before the invite (user requests to join before being invited), it is stored as a pending join request in the group’s data. When the admin later issues a GROUP_INVITE, the code detects the pending request and immediately adds the user to the group (consuming both the invite and the stored request). Conversely, if the GROUP_INVITE comes first for a closed group, it sits as a pending invite until the user eventually sends a matching JOIN_GROUP transaction to accept it[1][2]. In that case, the join transaction will find the pending invite and the user will be added to the group upon the join’s confirmation[3].
+
+Private Group Messaging: A closed group’s messages can technically be seen by anyone on-chain, but they are usually encrypted with a group key (derived from members’ public keys) to preserve privacy. Only group members possess the decryption key. Non-members cannot send messages to the group (attempts would be rejected), but they could see ciphertext of messages (hence the need for encryption for privacy).
+
+Cancelling Invites: The Qortal core does support a manual invite cancellation via a CANCEL_GROUP_INVITE transaction type (which can be used by an admin to revoke an outstanding invite)[4][5]. However, absent manual cancellation, an issued invite remains in effect indefinitely unless the intended expiration mechanism works. Currently, users are working around unwanted late acceptances by removing the member (kicking them) after they join, which is not ideal.
+
+## The Intended “Expiration” Mechanism
+
+When creating a GROUP_INVITE transaction, the inviter specifies a Time-To-Live (TTL) for the invite, in seconds. This is meant to define how long the invite remains valid. The core sets an expires_when timestamp by adding TTL to the invite’s creation time:
+
+- In the code, GroupInviteTransactionData includes a field timeToLive (TTL in seconds)[6]. When processing the invite, the core calculates the expiration time as invite_timestamp + TTL * 1000 (milliseconds) and stores it in the GroupInvites repository table[7]. If TTL is 0, they treat it as “no expiration” (the expiry is stored as NULL)[7].
+
+So, for example, an invite with timeToLive = 3600 seconds will have an expiry timestamp ~1 hour after the invite’s creation time. The invite and its expiry are saved in the node’s database (GroupInvites table) via the repository layer[7].
+
+Expectation: If the current time passes that expires_when timestamp before the invite is accepted, the invite should be considered expired/invalid. In practice, that would mean if the invitee tries to join after the expiry time, the join should not be auto-approved – effectively the invite should no longer count, and the join might instead be treated as a new request or be rejected.
+
+## What’s Happening in Practice (Bug)
+
+Invites Never Expire: In the current Qortal Core implementation, once an invite is issued, it can be accepted at any future time, even long after the supposed expiration. The TTL field and expires_when timestamp are being recorded but not actually enforced.
+
+Code Analysis: The code responsible for handling group joins and invites does not check the expiration at all when deciding whether a join can be approved by an invite:
+
+- When a user’s JOIN_GROUP transaction is processed for a closed group, the core simply checks if there is a pending invite for that user in the group via getInvite(groupId, userAddress). If an invite is found, the code proceeds to accept the join[3]; if no invite is found and the group is closed, the join is stored as a pending request[8]. Crucially, there is no check comparing current time to the invite’s expiry. The presence of an invite in the DB is enough to cause an auto-join, regardless of its age.
+- The GroupInviteData object does carry the expiry timestamp[9][10], and the invite is stored in the repository with that expires_when field. However, retrieval functions do not filter out or consider expiration. For example, GroupRepository.getInvite(groupId, invitee) simply selects the invite row by group and invitee, returning it if present[11]. It doesn’t check whether expires_when is in the past. Similarly, listing all pending invites for a group or invitee returns all entries unfiltered[12][13]. So an expired invite remains in the “pending invites” list returned by the API, and more importantly, remains available to satisfy a join.
+- The invite creation logic only validates that TTL is non-negative (it allows zero or positive values)[14], but beyond setting the expiry timestamp, there is no further logic making use of that timestamp. There is no scheduled task purging old invites, nor any validation in the JOIN_GROUP processing to reject or ignore an invite that has passed its expiry.
+
+Given this, any GROUP_INVITE entry persists indefinitely until one of three events: the invite is accepted (join happens), the invite is manually canceled by an admin (CANCEL_GROUP_INVITE tx), or the group is deleted entirely. If none of those occur, the invite sits in the DB forever, effectively never expiring on its own.
+
+Example Scenario: Suppose an admin invites Alice to a closed group with a TTL of 1 day. Internally, the invite’s expires_when is set to (invite_timestamp + 86,400,000 ms). If Alice waits a week and then sends a JOIN_GROUP, the core will still find the invite entry and treat it as valid, adding Alice to the group – even though a week is well past the intended 1-day validity. This matches the observed behavior that “invites never expire”.
+
+## Root Cause of the Issue
+
+The root cause is simply that the expiration feature was never fully implemented in the invite acceptance logic. The TTL and expiry are recorded, but no code checks or acts on the expiry timestamp when it should:
+
+- No expiration check on join: The group.join(...) method (called when processing a JOIN_GROUP tx) should ideally ignore or reject an invite if current_time > invite.expiry. Currently it does not – it unconditionally uses the invite if present[8][3]. There is no conditional like “if invite is expired, consider it not found.”
+- No automatic cleanup: There is no background process or trigger to remove expired invites from the GroupInvites table. The invite remains until explicitly removed (by acceptance or cancellation). The repository’s deleteInvite() is only called during normal invite consumption (on join) or when processing a CANCEL_GROUP_INVITE[15][16]. If an invite quietly expires, it stays in the table and continues to be returned as a pending invite.
+
+Essentially, the expiration is only a timestamp field with no logic attached. This appears to be an oversight in the implementation. The design clearly intended invites to have a limited lifetime (hence the TTL field), but the enforcement mechanism is missing or incomplete. The result is that “expired” invites are treated no differently than active invites by the core.
+
+## Confirming the Findings in Code
+
+To illustrate the above, let’s look at the relevant code snippets:
+
+- Setting the expiry when creating an invite: In the Group.invite(...) method, the code calculates the expiry as shown below. If timeToLive is non-zero, it adds that many seconds to the invite’s timestamp (note: timestamps are in milliseconds since epoch) and saves the invite with this expires_when value. Zero TTL yields expiry = null (meaning no expiration)[7]:
+```
+// In Group.java, handling a new invite
+int timeToLive = groupInviteTransactionData.getTimeToLive();
+Long expiry = null;
+if (timeToLive != 0)
+    expiry = groupInviteTransactionData.getTimestamp() + timeToLive * 1000;
+
+GroupInviteData groupInviteData = new GroupInviteData(groupId, inviterAddress, invitee, expiry, txSignature);
+groupRepository.save(groupInviteData);
+```
+
+This confirms TTL is stored correctly (in milliseconds). For example, a TTL of 300 seconds will produce an expires_when roughly 5 minutes after the invite’s timestamp.
+
+- No check at join time: When a JOIN_GROUP transaction is processed, the code simply does:
+```
+GroupInviteData inviteData = groupRepository.getInvite(groupId, joinerAddress);
+if (inviteData == null && !groupData.isOpen()) {
+    // No invite found for a closed group – treat this join as a pending request
+    this.addJoinRequest(joinerAddress, joinTxSignature);
+    // ... (set joinTx inviteReference to null, etc.)
+    return;
+}
+if (inviteData != null) {
+    // Invite found – proceed to use it
+    joinTxData.setInviteReference(inviteData.getReference());
+    groupRepository.deleteInvite(groupId, joinerAddress); // consume the invite
+}
+// Then addMember to group unconditionally...
+this.addMember(joinerAddress, joinGroupTransactionData);
+```
+
+In the actual Group.join() implementation, you can see that if an invite exists, they immediately delete the invite and add the member[3][17]. There is no conditional check on the invite’s expiry here – meaning even if the current time is well beyond inviteData.expiry, the code treats inviteData != null as sufficient for validity.
+
+- Invite retrieval doesn’t filter expiry: The repository call getInvite(groupId, invitee) simply fetches the row if it exists[11]. It does convert the SQL NULL to a null Long for expiry (lines not shown here), but it doesn’t ignore expired ones. In other words, even if expires_when is in the past, getInvite will still return a GroupInviteData object (with an expiry value set). Nothing in the service layer subsequently discards it.
+For reference, the SQL used is:
+
+```
+SELECT inviter, expires_when, reference 
+FROM GroupInvites 
+WHERE group_id = ? AND invitee = ?;
+```
+
+[11]
+
+If expires_when is past, that fact is not used – there’s no “…AND expires_when > currentTime” in the query or any post-query logic to drop it.
+
+These code findings confirm why, in practice, “group invites never expire”. The expiration timestamp is effectively inert.
+
+## Implications and Current Workaround
+
+Because of this bug, an invitee can join a closed group long after the invite was meant to lapse. This can be problematic if an admin intended the invite to be short-lived (for security or policy reasons). Admins currently have to monitor and manually remove any late joiners (by kicking them) if they no longer want that person in the group. As you pointed out, this is not how the feature should work – users shouldn’t have to manually enforce expiration.
+
+There is a manual cancellation transaction (CANCEL_GROUP_INVITE) that an admin can issue before the invite is accepted[5]. It will remove the pending invite from the repository, effectively rescinding it. However, this is a manual step and not tied to the TTL at all. It’s useful if an admin changes their mind or made a mistake, but it doesn’t solve the expired invite problem unless the admin preemptively cancels after the TTL passes. Relying on that is not practical.
+
+To answer your question: Yes, the core currently lacks any automatic expiry enforcement. The TTL is supposed to mean “this invite is only good for X time,” but due to the missing checks, any invite can be accepted at any time until explicitly canceled or consumed. This is clearly unintended behavior given the design.
+
+## Proposed Solution and Recommendations
+
+Post-trigger canonical rule (consensus path): after `groupInviteExpiryHeight`, closed-group membership finalizes only if a matching invite exists and the deterministic transaction timestamp used for finalization is **<= inviteExpiry** (`expiry == null` = never). If expired, ignore the invite and fall back to a join request; do not reject the transaction. Use transaction timestamps, never local time. Transaction timestamps can be forward-dated (~30m) and backdated within the transaction-expiry window (~24h), so a JOIN whose timestamp lies inside the TTL can still consume an invite even if the block is mined later; that’s expected with tx-timestamp semantics.
+
+To fix this issue, the Qortal Core needs to incorporate the invite expiration logic where appropriate. Based on our analysis, the following changes are recommended:
+
+- Enforce expiration on join: Modify the join processing logic to check the invite’s expiry before using it. If an invite exists but its expiry time has passed (relative to the join transaction’s timestamp), the code should treat it as if no valid invite exists. In practical terms, for a closed group, that would mean:
+- The joining user’s JOIN_GROUP transaction would no longer find a valid invite, so it would be handled as a join request instead of an immediate join. The expired invite stays stored but is ignored (no delete).
+- As a result, the user is not added to the group automatically. The on-chain effect is that their join transaction sits as a pending request, awaiting approval.
+- The group admin, seeing the join request, can then decide to issue a fresh GROUP_INVITE if they still want to let the user in.
+
+Implementing this would involve a small addition, gated by a feature trigger such as `groupInviteExpiryHeight` and using the next block height comparison (`nextHeight >= groupInviteExpiryHeight`):
+
+```
+// Group.join(...) uses the group-scoped helper that fetches by invitee
+GroupInviteData inviteData = this.getInvite(user);
+if (inviteData != null && inviteData.getExpiry() != null) {
+    int nextHeight = repository.getBlockRepository().getBlockchainHeight() + 1;
+    long now = joinTx.getTimestamp(); // deterministic, matches ban semantics
+    if (nextHeight >= BlockChain.getInstance().getGroupInviteExpiryHeight()
+            && now > inviteData.getExpiry()) {
+        // Invite is expired – ignore it (leave stored)
+        inviteData = null;
+    }
+}
+if (inviteData == null && !groupData.isOpen()) {
+    // handle as join request...
+}
+if (inviteData != null) {
+    // proceed with invite as before...
+}
+```
+
+This ensures expired invites can no longer approve joins once the trigger height is reached in the invite-first path, using transaction timestamps (not local clock) for determinism. Note the ~30m forward-dating and ~24h backdating (transaction expiry) windows.
+
+- Join-first auto-approval: when an invite arrives after a stored join request, TTL is **not** enforced; any matching invite approves the pending request. Use the invite’s transaction timestamp only for deterministic bookkeeping, not for expiry checks. This preserves the “request + later approval” flow regardless of invite age and is unchanged by the feature trigger.
+- No pruning: leave expired invites stored; enforce via expiry checks and API filtering only.
+- API filtering: list endpoints should filter expired invites using the chain-tip block timestamp (inclusive boundary: `expiry >= chainTipTimestamp`), treat `expiry == null` as never, and skip filtering if there is no chain tip yet (`getLastBlock() == null`) to avoid local-time drift. Filtering is unconditional (no feature trigger) and diverges from consensus time basis.
+- Timestamp basis and dating windows: consensus paths use transaction timestamps and accept the ~30-minute forward-dating window allowed by `maxTransactionTimestampFuture` and backdating within the transaction-expiry window (~24h); API filtering uses chain-tip block time. A backdated JOIN could still consume an invite the API hides—this divergence is expected and should be documented.
+- Testing the changes: After implementing, thorough testing is needed:
+- Issue an invite with a short TTL (e.g., 1 minute), wait for it to expire (by minting blocks so joinTx.timestamp > expiry), then attempt to join. The expected result is the join becomes a pending request (and the user is not added until a new invite is sent).
+- Conversely, test joining before expiry to ensure it still works normally.
+- Test TTL = 0 (no expiry) to ensure those invites continue to work indefinitely (they should, by design).
+- Ensure that manual cancellation (CANCEL_GROUP_INVITE) still works (cancelling an invite should trump everything regardless of TTL).
+- Join-first flow: verify that an aged/“expired by wall clock” invite still auto-approves a pending request, since TTL is ignored in that path pre- and post-trigger (documented behavior).
+
+With these fixes, the system will align with the intended behavior: invites will only be valid for the specified time window in the invite-first flow. The documented join-first exception still applies (any matching invite approves a pending request even if the TTL would have expired by wall clock), so expiry enforcement is one-sided by design. After the window, invite-first joins fall back to requests and cannot auto-join unless re-approved. This removes the burden on users to “manually fix” the situation by kicking unwanted late-joiners.
+
+## Conclusion
+
+The investigation confirms that the invite expiration issue is caused by a missing enforcement in the code. The Qortal Core defines an expiry for group invites but never uses it when it actually matters, i.e., during join validation. The solution is to introduce checks in the invite-first join path (and API filtering) to honor the expiration timestamp, while explicitly documenting that join-first auto-approvals ignore TTL. By making these changes, group admins can rely on invites expiring for the invite-first flow and understand the documented exception for pending requests.
+
+References:
+
+- Qortal Core source code showing invite TTL stored but not enforced[7][3].
+- Qortal Core source code showing join processing does not consider invite expiration[8][11].
+
+[1] [2] [3] [7] [8] [15] [17] Group.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/group/Group.java
+
+[4] [5] GroupsResource.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/api/resource/GroupsResource.java
+
+[6] GroupInviteTransactionData.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/data/transaction/GroupInviteTransactionData.java
+
+[9] [10] GroupInviteData.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/data/group/GroupInviteData.java
+
+[11] [12] [13] [16] HSQLDBGroupRepository.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/repository/hsqldb/HSQLDBGroupRepository.java
+
+[14] GroupInviteTransaction.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/transaction/GroupInviteTransaction.java
+
+[18] NTP.java
+
+https://github.com/QORT/qortal/blob/d81729d9f7cfef3060e15cbaf8563e89b8e72776/src/main/java/org/qortal/utils/NTP.java

--- a/docs/INVITE_EXPIRATION_CONSIDERATIONS.md
+++ b/docs/INVITE_EXPIRATION_CONSIDERATIONS.md
@@ -1,0 +1,40 @@
+# Invite Expiration – Implementation Considerations
+
+- **Deterministic time source:** In consensus paths use the transaction timestamp (matches ban semantics); never use `NTP.getTime()`/local clock. Accept the ~30-minute forward-dating window (`maxTransactionTimestampFuture`) and the ~24h backdating window (transaction expiry); switching to block time would change behavior and need a feature-triggered rollout.
+- **Feature trigger wiring:** Add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and every chain config (mainnet/test/regtest/fixtures); missing entries fail startup validation.
+- **“No expiry” sentinel:** TTL=0 is stored as `expiry = null`; keep this in code/tests/docs.
+- **Orderings:** Invite-first enforces expiry post-trigger; join-first auto-approval intentionally ignores TTL (any matching invite approves a pending request). Document this split.
+- **API filtering scope:** Filter expired invites unconditionally using chain-tip block timestamp with inclusive boundary (`expiry >= chainTipTimestamp`); treat `expiry == null` as never; skip filtering if there is no chain tip. Limits/offsets apply before filtering, so pages can be short. Document divergence: API uses chain-tip time while consensus uses transaction timestamps (with forward/backdating), so a backdated JOIN might still succeed even if the API hides the invite. This pre-trigger, chain-tip filtering is intentional as a soft mitigation to avoid surfacing invites that “should” be expired.
+- **Expired invite handling/retention:** Leave expired invites stored; validation ignores them, API filters them; no pruning so cancel flows continue to work and replay/orphan behavior stays deterministic.
+- **Testing matrix:** Cover invite-first valid/expired, join-first valid/“expired by wall clock” (still auto-approves because TTL is ignored), TTL=0, backdated JOIN success (documents tx-timestamp window), API filtering behavior (chain-tip basis, skip when no tip), and orphan/reorg safety via deterministic checks. Use `groupInviteExpiryHeight` with `BlockUtils.mintBlocks` for pre/post behavior.
+- **Current code gaps:** `Group.join(...)` lacks expiry checks/trigger gating (invite-first); API not filtering by tip; join-first TTL handling must be explicit (ignored) and consistently documented (no trigger gating).
+
+## Companion docs addressed
+
+- docs/CONSENSUS_CHANGE.md: deterministic time source, `expiry = null` sentinel, feature trigger wiring, both orderings (invite-first enforced, join-first documented).
+- docs/IMPLEMENTATION.md: trigger wiring, consensus-time basis, API filtering (tip-based, skip when no tip), invite-first enforcement, join-first TTL ignored, tests aligned.
+- docs/INVITE_EXPIRATION.md: tx-timestamp basis with forward/backdating windows, invite-first enforcement, join-first TTL ignored, API divergence documented.
+
+## Feature trigger wiring decisions
+
+- Trigger name: `groupInviteExpiryHeight` (lowerCamel with `Height`, matching `groupMemberCheckHeight` style).
+- Mainnet config (`src/main/resources/blockchain.json`): add the key with a far-future placeholder (e.g., `99999999`).
+- Testnet (`testnet/testchain.json`): add the key with a low height (e.g., `0` or `1`) so it is active immediately.
+- Test fixtures (`src/test/resources/test-chain-*.json`): add the key to every `featureTriggers` map with a low height (e.g., `0`) to avoid validation failures and keep tests exercising expiry logic.
+- Code: add the enum entry and a getter in `BlockChain`, and use the getter in invite-expiry code instead of raw map access.
+
+## Testing plan
+
+- Consensus-path tests (extend `src/test/java/org/qortal/test/group/MiscTests.java`):  
+  - Invite-first, valid before expiry → member added post-trigger.  
+  - Invite-first, expired → join becomes request, no membership; invite stored but ignored.  
+  - Join-first, invite later valid → auto-add member.  
+  - Join-first, invite later expired by wall clock → still auto-adds because TTL is ignored; request should not persist.  
+  - TTL=0 non-expiring invite → still works.  
+  - (Optional) Expired invite with backdated JOIN (tx timestamp ≤ expiry) still succeeds to document tx-timestamp window.  
+  - Use `BlockChain.getGroupInviteExpiryHeight()` with `BlockUtils.mintBlocks(...)` to flip pre/post behavior; set test configs’ `groupInviteExpiryHeight` low (0/1).
+- API filtering tests (new class, e.g., `GroupApiInviteTests`):  
+  - Invite with short TTL expires; chain-tip timestamp > expiry ⇒ `/groups/invites/...` omits it.  
+  - TTL=0 and unexpired invites remain visible.  
+  - Expiry exactly at chain-tip timestamp remains visible (inclusive boundary).  
+  - Use chain-tip block timestamp as “now”; skip filtering when no tip; no feature trigger gating.

--- a/docs/OTHER_ISSUES.md
+++ b/docs/OTHER_ISSUES.md
@@ -1,0 +1,23 @@
+# Other Issues (Non-invite-expiry)
+
+## Transaction-timestamp spoofing can bypass near-expiry bans
+
+- **What happens:** GROUP_JOIN and GROUP_INVITE validation checks whether an offender is banned by calling `banExists(groupId, address, txTimestamp)` (`src/main/java/org/qortal/transaction/JoinGroupTransaction.java`, `GroupInviteTransaction.java`). The repository considers a ban active if `expires_when > txTimestamp` (`src/main/java/org/qortal/repository/hsqldb/HSQLDBGroupRepository.java:790`).
+- **Spoof window:** Transaction timestamps are user-supplied and only constrained to be (a) not too far in the future (`now + maxTransactionTimestampFuture`, default 30 minutes; `Settings.java:108`) and (b) before the containing block timestamp (`Block.java:1335-1340`, `BlockMinter.java:468-476`). A user can forward-date their JOIN/INVITE by up to ~30 minutes. They can also backdate within the transaction-expiry window (~24h). If a ban expires inside those windows, the tx timestamp can be set just after ban expiry so validation treats the ban as expired even though the block is mined earlier.
+- **Scope of backdating:** Backdating is capped by `transactionExpiryPeriod` (24h in `src/main/resources/blockchain.json`), so the spoof window cannot extend beyond that expiry horizon.
+- **Impact on users:** Offenders can rejoin early by timestamp spoofing—up to ~30 minutes via forward-dating, or within the tx-expiry window via backdating—defeating the tail end of a ban’s lifetime.
+- **Underlying cause:** Validation uses the transaction’s timestamp (user-controlled) instead of a deterministic on-chain time (e.g., containing block timestamp) when evaluating ban expiry.
+- **Potential fixes:**  
+  - **Block timestamp check (consensus):** Switch ban expiry checks to use the containing block’s timestamp (or other deterministic on-chain time) instead of `txTimestamp`; gate via a new feature trigger. Closes the spoof window; requires rollout.  
+  - **Reduce forward-dating (non-consensus):** Tighten `maxTransactionTimestampFuture` (e.g., from ~30m down) to shrink the window while keeping tx-timestamp semantics. Partial mitigation; no fork.  
+  - **Hybrid check (consensus):** Keep tx timestamp but also require ban expiry at block time (e.g., treat ban as active if `blockTimestamp < banExpiry`); gate via trigger. More complex than a full switch.  
+  - **Block-count TTL (consensus + format change):** Introduce a block-count-based TTL for new bans/invites (deterministic, no clocks); would need new tx version/field and dual semantics because legacy data is time-based. Requires trigger and coordinated rollout.
+- **Consensus impact:** Any change to consensus-time basis (block timestamp, hybrid, or block-count TTL) is a consensus change and needs a feature trigger and rollout. Tightening `maxTransactionTimestampFuture` alone is non-consensus.
+
+## Stale group invites/bans accumulate in DB
+
+- **What happens:** Expired group invites (and expired bans) are not auto-pruned; they remain in `GroupInvites`/`GroupBans` tables. They are deleted only when explicitly consumed (join, cancel, ban lift) or manually removed. Expiry checks simply ignore stale rows (`banExists(..., txTimestamp)`, invite expiry validation).
+- **Impact on users:** DB grows with stale rows; API clients might see older entries unless filtered. Cancel transactions for invites/bans still succeed because the row exists, which can be surprising if UI hides them.
+- **Underlying cause:** No background cleanup or opportunistic delete-on-expiry; current logic favors idempotence and replay safety by leaving rows intact until acted upon.
+- **Risks of changing DB behavior:** Auto-deleting on expiry could break cancel flows (row no longer exists), change orphan/reorg replay expectations, and add write paths in validation. Background pruning must be carefully non-consensus or triggered consistently to avoid divergence across nodes.
+- **Why not included now:** For the invite-expiry fix we’re leaving expired entries stored but ignored (matching existing ban behavior) to avoid new DB mutation paths, reduce risk to orphaning/replay, and keep cancel transactions functional. Cleanup can be considered separately as a non-consensus maintenance task with proper safeguards.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -28,7 +28,7 @@
   - [x] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
   - [x] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).
   - [ ] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).
-  - [ ] "Test API invite filtering": expired omitted, TTL=0/unexpired visible, chain-tip time basis, skip filtering when no tip.
+  - [x] "Test API invite filtering": expired omitted, TTL=0/unexpired visible, chain-tip time basis, skip filtering when no tip.
 - [ ] Docs/status updates:
   - [ ] "Update docs with final semantics": reflect trigger heights, invite expiry semantics (both orderings), join-first TTL decision, transaction-timestamp dating windows (forward/backdating), and API filtering behavior.
   - [ ] "Document activation plan": note consensus impact and activation plan in release notes/changelog once trigger height is set.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,7 @@
 # TODO – Invite Expiration Work
 
 - [ ] Add `groupInviteExpiryHeight` feature trigger:
-  - [ ] "Add feature trigger enum entry": add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and ensure startup validation covers it.
+  - [x] "Add feature trigger enum entry": add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and ensure startup validation covers it.
   - [ ] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
   - [ ] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
   - [ ] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7,7 +7,7 @@
   - [x] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
   - [x] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
   - [x] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
-- [ ] Enforce invite expiry in invite-first flow:
+- [x] Enforce invite expiry in invite-first flow:
   - [x] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
   - [x] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
   - [x] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
@@ -15,7 +15,7 @@
   - [x] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
 - [ ] Document join-first TTL-agnostic auto-approval:
   - [x] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
-  - [ ] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.
+  - [x] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.
   - [ ] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
 - [ ] API invite filtering:
   - [ ] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -30,6 +30,6 @@
   - [x] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).
   - [x] "Test API invite filtering": expired omitted, TTL=0/unexpired visible, chain-tip time basis, skip filtering when no tip.
 - [ ] Docs/status updates:
-  - [ ] "Update docs with final semantics": reflect trigger heights, invite expiry semantics (both orderings), join-first TTL decision, transaction-timestamp dating windows (forward/backdating), and API filtering behavior.
-  - [ ] "Document activation plan": note consensus impact and activation plan in release notes/changelog once trigger height is set.
+  - [x] "Update docs with final semantics": reflect trigger heights, invite expiry semantics (both orderings), join-first TTL decision, transaction-timestamp dating windows (forward/backdating), and API filtering behavior.
+  - [x] "Document activation plan": note consensus impact and activation plan in release notes/changelog once trigger height is set.
   - [ ] (No commit): Clean up TODO/checklists when tasks are completed.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19,7 +19,7 @@
   - [x] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
 - [ ] API invite filtering:
   - [x] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
-  - [ ] "Filter invites-by-group API": filter `/groups/invites/group/{groupid}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
+  - [x] "Filter invites-by-group API": filter `/groups/invites/group/{groupid}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [ ] "Document unconditional filtering": keep filtering unconditional (no trigger) and document the intentional divergence from consensus (tx timestamp basis vs chain tip) as a pre-trigger soft mitigation that may hide invites still consumable via back/forward-dated joins.
   - [ ] "Avoid local clock in filtering": ensure repository/API layers avoid local clock use and handle null tip without NPE.
   - [ ] "Update API docs for filtering": update swagger annotations in `GroupsResource` invite endpoints (`/groups/invites/{address}`, `/groups/invites/group/{groupid}`) to note chain-tip-based filtering, inclusive boundary (`expiry >= tip`), `expiry == null` sentinel, skip-when-no-tip behavior, and the intentional pre-trigger UX/safety divergence.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,7 @@
   - [x] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
   - [x] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
   - [x] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
-  - [ ] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
+  - [x] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
 - [ ] Enforce invite expiry in invite-first flow:
   - [ ] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
   - [ ] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,7 +4,7 @@
   - [x] "Add feature trigger enum entry": add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and ensure startup validation covers it.
   - [x] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
   - [x] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
-  - [ ] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
+  - [x] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
   - [ ] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
   - [ ] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
 - [ ] Enforce invite expiry in invite-first flow:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,7 +2,7 @@
 
 - [ ] Add `groupInviteExpiryHeight` feature trigger:
   - [x] "Add feature trigger enum entry": add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and ensure startup validation covers it.
-  - [ ] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
+  - [x] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
   - [ ] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
   - [ ] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
   - [ ] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,9 +20,9 @@
 - [ ] API invite filtering:
   - [x] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [x] "Filter invites-by-group API": filter `/groups/invites/group/{groupid}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
-  - [ ] "Document unconditional filtering": keep filtering unconditional (no trigger) and document the intentional divergence from consensus (tx timestamp basis vs chain tip) as a pre-trigger soft mitigation that may hide invites still consumable via back/forward-dated joins.
-  - [ ] "Avoid local clock in filtering": ensure repository/API layers avoid local clock use and handle null tip without NPE.
-  - [ ] "Update API docs for filtering": update swagger annotations in `GroupsResource` invite endpoints (`/groups/invites/{address}`, `/groups/invites/group/{groupid}`) to note chain-tip-based filtering, inclusive boundary (`expiry >= tip`), `expiry == null` sentinel, skip-when-no-tip behavior, and the intentional pre-trigger UX/safety divergence.
+  - [x] "Document unconditional filtering": keep filtering unconditional (no trigger) and document the intentional divergence from consensus (tx timestamp basis vs chain tip) as a pre-trigger soft mitigation that may hide invites still consumable via back/forward-dated joins.
+  - [x] "Avoid local clock in filtering": ensure repository/API layers avoid local clock use and handle null tip without NPE.
+  - [x] "Update API docs for filtering": update swagger annotations in `GroupsResource` invite endpoints (`/groups/invites/{address}`, `/groups/invites/group/{groupid}`) to note chain-tip-based filtering, inclusive boundary (`expiry >= tip`), `expiry == null` sentinel, skip-when-no-tip behavior, and the intentional pre-trigger UX/safety divergence.
 - [ ] Tests:
   - [ ] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
   - [ ] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -3,7 +3,7 @@
 - [ ] Add `groupInviteExpiryHeight` feature trigger:
   - [x] "Add feature trigger enum entry": add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and ensure startup validation covers it.
   - [x] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
-  - [ ] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
+  - [x] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
   - [ ] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
   - [ ] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
   - [ ] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,7 +23,7 @@
   - [x] "Document unconditional filtering": keep filtering unconditional (no trigger) and document the intentional divergence from consensus (tx timestamp basis vs chain tip) as a pre-trigger soft mitigation that may hide invites still consumable via back/forward-dated joins.
   - [x] "Avoid local clock in filtering": ensure repository/API layers avoid local clock use and handle null tip without NPE.
   - [x] "Update API docs for filtering": update swagger annotations in `GroupsResource` invite endpoints (`/groups/invites/{address}`, `/groups/invites/group/{groupid}`) to note chain-tip-based filtering, inclusive boundary (`expiry >= tip`), `expiry == null` sentinel, skip-when-no-tip behavior, and the intentional pre-trigger UX/safety divergence.
-- [ ] Tests:
+- [x] Tests:
   - [x] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
   - [x] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
   - [x] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,7 +16,7 @@
 - [ ] Document join-first TTL-agnostic auto-approval:
   - [x] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
   - [x] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.
-  - [ ] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
+  - [x] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
 - [ ] API invite filtering:
   - [ ] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [ ] "Filter invites-by-group API": filter `/groups/invites/group/{groupid}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,7 +8,7 @@
   - [x] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
   - [x] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
 - [ ] Enforce invite expiry in invite-first flow:
-  - [ ] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
+  - [x] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
   - [ ] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
   - [ ] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
   - [ ] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,7 +12,7 @@
   - [x] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
   - [x] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
   - [x] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
-  - [ ] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
+  - [x] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
 - [ ] Document join-first TTL-agnostic auto-approval:
   - [ ] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
   - [ ] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -13,12 +13,12 @@
   - [x] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
   - [x] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
   - [x] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
-- [ ] Document join-first TTL-agnostic auto-approval:
+- [x] Document join-first TTL-agnostic auto-approval:
   - [x] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
   - [x] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.
   - [x] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
 - [ ] API invite filtering:
-  - [ ] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
+  - [x] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [ ] "Filter invites-by-group API": filter `/groups/invites/group/{groupid}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [ ] "Document unconditional filtering": keep filtering unconditional (no trigger) and document the intentional divergence from consensus (tx timestamp basis vs chain tip) as a pre-trigger soft mitigation that may hide invites still consumable via back/forward-dated joins.
   - [ ] "Avoid local clock in filtering": ensure repository/API layers avoid local clock use and handle null tip without NPE.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -27,7 +27,7 @@
   - [x] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
   - [x] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
   - [x] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).
-  - [ ] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).
+  - [x] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).
   - [x] "Test API invite filtering": expired omitted, TTL=0/unexpired visible, chain-tip time basis, skip filtering when no tip.
 - [ ] Docs/status updates:
   - [ ] "Update docs with final semantics": reflect trigger heights, invite expiry semantics (both orderings), join-first TTL decision, transaction-timestamp dating windows (forward/backdating), and API filtering behavior.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,7 +14,7 @@
   - [x] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
   - [x] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
 - [ ] Document join-first TTL-agnostic auto-approval:
-  - [ ] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
+  - [x] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
   - [ ] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.
   - [ ] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
 - [ ] API invite filtering:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,7 +26,7 @@
 - [ ] Tests:
   - [x] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
   - [x] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
-  - [ ] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).
+  - [x] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).
   - [ ] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).
   - [ ] "Test API invite filtering": expired omitted, TTL=0/unexpired visible, chain-tip time basis, skip filtering when no tip.
 - [ ] Docs/status updates:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,14 +17,14 @@
   - [x] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.
   - [x] "Auto-approve pending request": always auto-add member and consume the pending join request when a matching invite is confirmed; leave invite handling consistent pre-trigger (no trigger gating) and ensure the pending request exists in the DB before approval.
   - [x] "Honor TTL=0 sentinel": ensure `expiry == null` continues to mean non-expiring.
-- [ ] API invite filtering:
+- [x] API invite filtering:
   - [x] "Filter invites-by-invitee API": filter `/groups/invites/{address}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [x] "Filter invites-by-group API": filter `/groups/invites/group/{groupid}` using chain-tip timestamp; treat `expiry == null` as never; skip filtering if no chain tip.
   - [x] "Document unconditional filtering": keep filtering unconditional (no trigger) and document the intentional divergence from consensus (tx timestamp basis vs chain tip) as a pre-trigger soft mitigation that may hide invites still consumable via back/forward-dated joins.
   - [x] "Avoid local clock in filtering": ensure repository/API layers avoid local clock use and handle null tip without NPE.
   - [x] "Update API docs for filtering": update swagger annotations in `GroupsResource` invite endpoints (`/groups/invites/{address}`, `/groups/invites/group/{groupid}`) to note chain-tip-based filtering, inclusive boundary (`expiry >= tip`), `expiry == null` sentinel, skip-when-no-tip behavior, and the intentional pre-trigger UX/safety divergence.
 - [ ] Tests:
-  - [ ] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
+  - [x] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
   - [ ] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
   - [ ] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).
   - [ ] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,7 +10,7 @@
 - [ ] Enforce invite expiry in invite-first flow:
   - [x] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
   - [x] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
-  - [ ] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
+  - [x] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
   - [ ] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
   - [ ] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
 - [ ] Document join-first TTL-agnostic auto-approval:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # TODO – Invite Expiration Work
 
-- [ ] Add `groupInviteExpiryHeight` feature trigger:
+- [x] Add `groupInviteExpiryHeight` feature trigger:
   - [x] "Add feature trigger enum entry": add `groupInviteExpiryHeight` to `BlockChain.FeatureTrigger` and ensure startup validation covers it.
   - [x] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
   - [x] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
@@ -9,7 +9,7 @@
   - [x] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
 - [ ] Enforce invite expiry in invite-first flow:
   - [x] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
-  - [ ] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
+  - [x] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
   - [ ] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
   - [ ] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
   - [ ] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,7 +5,7 @@
   - [x] "Expose feature trigger getter": add `getGroupInviteExpiryHeight()` in `BlockChain`.
   - [x] "Wire mainnet config placeholder": add `groupInviteExpiryHeight: 99999999` (or similar) to `src/main/resources/blockchain.json`.
   - [x] "Wire testnet config": add a low activation height (e.g., 0/1) to `testnet/testchain.json`.
-  - [ ] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
+  - [x] "Wire test fixtures": add low heights to every `src/test/resources/test-chain-*.json`.
   - [ ] (No commit): Sanity-check trigger coverage across any other chain configs to avoid startup validation errors.
 - [ ] Enforce invite expiry in invite-first flow:
   - [ ] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,7 +11,7 @@
   - [x] "Gate invite-first expiry by trigger": gate `Group.join(...)` invite consumption behind `groupInviteExpiryHeight` using next block height (`nextHeight >= groupInviteExpiryHeight`).
   - [x] "Use join tx timestamp for expiry check": use join transaction timestamp (not local clock) when comparing against invite expiry.
   - [x] "Treat expired invite as absent in join": for closed groups create/keep join request; do not delete the expired invite.
-  - [ ] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
+  - [x] "Preserve pre-trigger join behavior": keep legacy behavior pre-trigger and existing invite-reference handling/consumption for unexpired invites.
   - [ ] "Honor TTL=0 and inclusive boundary": respect `expiry == null` and use `timestamp <= expiry`.
 - [ ] Document join-first TTL-agnostic auto-approval:
   - [ ] "Document join-first time basis": TTL is ignored for pending-request approvals (any invite approves) both pre- and post-trigger; keep behavior documented.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -25,7 +25,7 @@
   - [x] "Update API docs for filtering": update swagger annotations in `GroupsResource` invite endpoints (`/groups/invites/{address}`, `/groups/invites/group/{groupid}`) to note chain-tip-based filtering, inclusive boundary (`expiry >= tip`), `expiry == null` sentinel, skip-when-no-tip behavior, and the intentional pre-trigger UX/safety divergence.
 - [ ] Tests:
   - [x] "Test invite-first expiry enforcement": valid before expiry adds member post-trigger; expired invite treated as request, invite ignored.
-  - [ ] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
+  - [x] "Test join-first behavior": valid invite later auto-adds; aged/“expired by wall clock” invite still auto-adds because TTL is ignored for pending requests (documented); TTL=0 still works.
   - [ ] "Test backdated/forward-dated join window": document/verify behavior when join timestamp <= expiry but block later (tx-timestamp dating windows).
   - [ ] "Test pre/post trigger activation": cover behavior using low-height test chains (`groupInviteExpiryHeight`).
   - [ ] "Test API invite filtering": expired omitted, TTL=0/unexpired visible, chain-tip time basis, skip filtering when no tip.

--- a/src/main/java/org/qortal/api/resource/GroupsResource.java
+++ b/src/main/java/org/qortal/api/resource/GroupsResource.java
@@ -762,7 +762,8 @@ public class GroupsResource {
 	@ApiErrors({ApiError.REPOSITORY_ISSUE})
 	public List<GroupInviteData> getInvitesByGroupId(@PathParam("groupid") int groupId) {
 		try (final Repository repository = RepositoryManager.getRepository()) {
-			return repository.getGroupRepository().getInvitesByGroupId(groupId);
+			List<GroupInviteData> invites = repository.getGroupRepository().getInvitesByGroupId(groupId);
+			return this.filterExpiredInvites(repository, invites);
 		} catch (DataException e) {
 			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.REPOSITORY_ISSUE, e);
 		}

--- a/src/main/java/org/qortal/api/resource/GroupsResource.java
+++ b/src/main/java/org/qortal/api/resource/GroupsResource.java
@@ -724,7 +724,7 @@ public class GroupsResource {
 	@GET
 	@Path("/invites/{address}")
 	@Operation(
-		summary = "Pending group invites",
+		summary = "Pending group invites (expired invites filtered by chain tip; expiry == null never expires; inclusive boundary)",
 		responses = {
 			@ApiResponse(
 				description = "group invite",
@@ -748,7 +748,7 @@ public class GroupsResource {
 	@GET
 	@Path("/invites/group/{groupid}")
 	@Operation(
-		summary = "Pending group invites",
+		summary = "Pending group invites (expired invites filtered by chain tip; expiry == null never expires; inclusive boundary)",
 		responses = {
 			@ApiResponse(
 				description = "group invite",

--- a/src/main/java/org/qortal/api/resource/GroupsResource.java
+++ b/src/main/java/org/qortal/api/resource/GroupsResource.java
@@ -725,6 +725,7 @@ public class GroupsResource {
 	@Path("/invites/{address}")
 	@Operation(
 		summary = "Pending group invites (expired invites filtered by chain tip; expiry == null never expires; inclusive boundary)",
+		description = "Returns pending invites for the given address. Expired invites are filtered using the current chain-tip block timestamp (inclusive: expiry >= chain tip); invites with no expiry (expiry == null) are always returned. If the node has no chain tip yet, filtering is skipped.",
 		responses = {
 			@ApiResponse(
 				description = "group invite",
@@ -749,6 +750,7 @@ public class GroupsResource {
 	@Path("/invites/group/{groupid}")
 	@Operation(
 		summary = "Pending group invites (expired invites filtered by chain tip; expiry == null never expires; inclusive boundary)",
+		description = "Returns pending invites for the given group. Expired invites are filtered using the current chain-tip block timestamp (inclusive: expiry >= chain tip); invites with no expiry (expiry == null) are always returned. If the node has no chain tip yet, filtering is skipped.",
 		responses = {
 			@ApiResponse(
 				description = "group invite",

--- a/src/main/java/org/qortal/block/BlockChain.java
+++ b/src/main/java/org/qortal/block/BlockChain.java
@@ -673,6 +673,9 @@ public class BlockChain {
 		return this.featureTriggers.get(FeatureTrigger.groupMemberCheckHeight.name()).intValue();
 	}
 
+	/**
+	 * Activation height for enforcing group invite expiry in the invite-first flow.
+	 */
 	public int getGroupInviteExpiryHeight() {
 		return this.featureTriggers.get(FeatureTrigger.groupInviteExpiryHeight.name()).intValue();
 	}

--- a/src/main/java/org/qortal/block/BlockChain.java
+++ b/src/main/java/org/qortal/block/BlockChain.java
@@ -88,6 +88,7 @@ public class BlockChain {
 		onlyMintWithNameHeight,
 		removeOnlyMintWithNameHeight,
 		groupMemberCheckHeight,
+		groupInviteExpiryHeight,
 		fixBatchRewardHeight,
 		adminsReplaceFoundersHeight,
 		nullGroupMembershipHeight,
@@ -670,6 +671,10 @@ public class BlockChain {
 
 	public int getGroupMemberCheckHeight() {
 		return this.featureTriggers.get(FeatureTrigger.groupMemberCheckHeight.name()).intValue();
+	}
+
+	public int getGroupInviteExpiryHeight() {
+		return this.featureTriggers.get(FeatureTrigger.groupInviteExpiryHeight.name()).intValue();
 	}
 
 	public int getFixBatchRewardHeight() {

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -807,6 +807,21 @@ public class Group {
 	}
 
 	private GroupInviteData applyInviteExpiry(GroupInviteData groupInviteData, JoinGroupTransactionData joinGroupTransactionData) {
+		if (groupInviteData == null) {
+			return null;
+		}
+
+		Long expiry = groupInviteData.getExpiry();
+		if (expiry == null) {
+			return groupInviteData; // TTL=0 sentinel means never expires
+		}
+
+		long joinTimestamp = joinGroupTransactionData.getTimestamp();
+		// Inclusive boundary: invite valid when join timestamp is <= expiry
+		if (joinTimestamp > expiry) {
+			return null;
+		}
+
 		return groupInviteData;
 	}
 

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -647,6 +647,8 @@ public class Group {
 		String invitee = groupInviteTransactionData.getInvitee();
 
 		// If there is a pending "join request" then add new group member
+		// NOTE: TTL/expiry is intentionally NOT enforced in this join-first path (pre- and post-trigger).
+		// Any matching invite auto-approves the stored request to preserve legacy behavior.
 		GroupJoinRequestData groupJoinRequestData = this.getJoinRequest(invitee);
 		if (groupJoinRequestData != null) {
 			this.addMember(invitee, groupInviteTransactionData);

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -648,7 +648,7 @@ public class Group {
 
 		// If there is a pending "join request" then add new group member
 		// NOTE: TTL/expiry is intentionally NOT enforced in this join-first path (pre- and post-trigger).
-		// Any matching invite auto-approves the stored request to preserve legacy behavior.
+		// Any matching invite auto-approves the stored request to preserve legacy behavior. This consumes the request.
 		GroupJoinRequestData groupJoinRequestData = this.getJoinRequest(invitee);
 		if (groupJoinRequestData != null) {
 			this.addMember(invitee, groupInviteTransactionData);

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -730,6 +730,12 @@ public class Group {
 
 		// Any pending invite?
 		GroupInviteData groupInviteData = this.getInvite(joiner.getAddress());
+		int nextBlockHeight = this.repository.getBlockRepository().getBlockchainHeight() + 1;
+		boolean enforceInviteExpiry = nextBlockHeight >= BlockChain.getInstance().getGroupInviteExpiryHeight();
+
+		if (enforceInviteExpiry) {
+			groupInviteData = this.applyInviteExpiry(groupInviteData, joinGroupTransactionData);
+		}
 
 		// If there is no invites and this group is "closed" (i.e. invite-only) then
 		// this is now a pending "join request"
@@ -798,6 +804,10 @@ public class Group {
 		// Clear cached references
 		joinGroupTransactionData.setInviteReference(null);
 		joinGroupTransactionData.setPreviousGroupId(null);
+	}
+
+	private GroupInviteData applyInviteExpiry(GroupInviteData groupInviteData, JoinGroupTransactionData joinGroupTransactionData) {
+		return groupInviteData;
 	}
 
 	public void leave(LeaveGroupTransactionData leaveGroupTransactionData) throws DataException {

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -649,6 +649,7 @@ public class Group {
 		// If there is a pending "join request" then add new group member
 		// NOTE: TTL/expiry is intentionally NOT enforced in this join-first path (pre- and post-trigger).
 		// Any matching invite auto-approves the stored request to preserve legacy behavior. This consumes the request.
+		// TTL=0 sentinel still applies (non-expiring invite remains valid).
 		GroupJoinRequestData groupJoinRequestData = this.getJoinRequest(invitee);
 		if (groupJoinRequestData != null) {
 			this.addMember(invitee, groupInviteTransactionData);

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -733,6 +733,7 @@ public class Group {
 		int nextBlockHeight = this.repository.getBlockRepository().getBlockchainHeight() + 1;
 		boolean enforceInviteExpiry = nextBlockHeight >= BlockChain.getInstance().getGroupInviteExpiryHeight();
 
+		// Pre-trigger: preserve legacy behavior (no expiry enforcement)
 		if (enforceInviteExpiry) {
 			groupInviteData = this.applyInviteExpiry(groupInviteData, joinGroupTransactionData);
 		}

--- a/src/main/java/org/qortal/group/Group.java
+++ b/src/main/java/org/qortal/group/Group.java
@@ -819,6 +819,7 @@ public class Group {
 		long joinTimestamp = joinGroupTransactionData.getTimestamp();
 		// Inclusive boundary: invite valid when join timestamp is <= expiry
 		if (joinTimestamp > expiry) {
+			// Expired invite: ignore it and leave it stored
 			return null;
 		}
 

--- a/src/main/resources/blockchain.json
+++ b/src/main/resources/blockchain.json
@@ -115,6 +115,7 @@
 		"onlyMintWithNameHeight": 1900300,
 		"removeOnlyMintWithNameHeight": 1935500,
 		"groupMemberCheckHeight": 1902700,
+		"groupInviteExpiryHeight": 99999999,
 		"fixBatchRewardHeight": 1945900,
 		"adminsReplaceFoundersHeight": 2012800,
 		"nullGroupMembershipHeight": 2012800,

--- a/src/test/java/org/qortal/test/api/GroupInviteFilteringApiTests.java
+++ b/src/test/java/org/qortal/test/api/GroupInviteFilteringApiTests.java
@@ -1,0 +1,444 @@
+package org.qortal.test.api;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.qortal.account.PrivateKeyAccount;
+import org.qortal.api.resource.GroupsResource;
+import org.qortal.data.group.GroupInviteData;
+import org.qortal.data.transaction.CreateGroupTransactionData;
+import org.qortal.data.transaction.GroupInviteTransactionData;
+import org.qortal.repository.*;
+import org.qortal.repository.hsqldb.HSQLDBRepositoryFactory;
+import org.qortal.test.common.ApiCommon;
+import org.qortal.test.common.TransactionUtils;
+import org.qortal.test.common.transaction.TestTransaction;
+import org.qortal.test.common.Common;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GroupInviteFilteringApiTests extends ApiCommon {
+	private GroupsResource groupsResource;
+
+	@Before
+	public void buildResource() {
+		this.groupsResource = (GroupsResource) ApiCommon.buildResource(GroupsResource.class);
+	}
+
+	@After
+	public void restoreRepositoryFactory() throws DataException {
+		// Ensure we restore the real factory even if a test swaps it out
+		if (!(RepositoryManager.getRepositoryFactory() instanceof HSQLDBRepositoryFactory)) {
+			Common.useDefaultSettings();
+		}
+	}
+
+	@Test
+	public void testInviteFilteringByChainTip() throws DataException {
+		System.out.println("TEST START: testInviteFilteringByChainTip - expired invites filtered, TTL=0/unexpired retained.");
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			PrivateKeyAccount alice = Common.getTestAccount(repository, "alice");
+			PrivateKeyAccount bob = Common.getTestAccount(repository, "bob");
+			PrivateKeyAccount chloe = Common.getTestAccount(repository, "chloe");
+
+			int groupId = createGroup(repository, alice, "api-filter-group", false);
+
+			// Expired invite for Bob (TTL 1s, timestamp in the past)
+			GroupInviteTransactionData expiredInvite = new GroupInviteTransactionData(TestTransaction.generateBase(alice), groupId, bob.getAddress(), 1);
+			long expiredTimestamp = System.currentTimeMillis() - 60_000;
+			expiredInvite.setTimestamp(expiredTimestamp);
+			TransactionUtils.signAndMint(repository, expiredInvite, alice);
+
+			// Non-expiring invite for Bob
+			GroupInviteTransactionData nonExpiringInvite = new GroupInviteTransactionData(TestTransaction.generateBase(alice), groupId, bob.getAddress(), 0);
+			TransactionUtils.signAndMint(repository, nonExpiringInvite, alice);
+
+			// Unexpired invite for Chloe
+			GroupInviteTransactionData activeInvite = new GroupInviteTransactionData(TestTransaction.generateBase(alice), groupId, chloe.getAddress(), 3_600);
+			TransactionUtils.signAndMint(repository, activeInvite, alice);
+
+			List<GroupInviteData> bobInvites = this.groupsResource.getInvitesByInvitee(bob.getAddress());
+			assertEquals("expected Bob to see only non-expiring invite (expired filtered out)", 1, bobInvites.size());
+
+			List<GroupInviteData> groupInvites = this.groupsResource.getInvitesByGroupId(groupId);
+			assertEquals("expected group to show only non-expiring and unexpired invites", 2, groupInvites.size());
+			System.out.println("TEST PASS: testInviteFilteringByChainTip - expected bobInvites size=1, actual=" + bobInvites.size() + "; expected groupInvites size=2, actual=" + groupInvites.size());
+		}
+	}
+
+	@Test
+	public void testInviteFilteringSkippedWhenNoChainTip() throws DataException {
+		System.out.println("TEST START: testInviteFilteringSkippedWhenNoChainTip - filtering is skipped without a chain tip.");
+		RepositoryFactory originalFactory = RepositoryManager.getRepositoryFactory();
+
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			PrivateKeyAccount alice = Common.getTestAccount(repository, "alice");
+			PrivateKeyAccount bob = Common.getTestAccount(repository, "bob");
+
+			int groupId = createGroup(repository, alice, "api-filter-no-tip", false);
+
+			// Expired invite for Bob (would normally be filtered)
+			GroupInviteTransactionData expiredInvite = new GroupInviteTransactionData(TestTransaction.generateBase(alice), groupId, bob.getAddress(), 1);
+			long expiredTimestamp = System.currentTimeMillis() - 60_000;
+			expiredInvite.setTimestamp(expiredTimestamp);
+			TransactionUtils.signAndMint(repository, expiredInvite, alice);
+		}
+
+		try {
+			RepositoryManager.setRepositoryFactory(new NullTipRepositoryFactory(originalFactory));
+
+			List<GroupInviteData> bobInvites = this.groupsResource.getInvitesByInvitee(this.bobAddress);
+			assertTrue("expected expired invite to remain when no chain tip", bobInvites.stream().anyMatch(invite -> invite.getInvitee().equals(this.bobAddress)));
+			System.out.println("TEST PASS: testInviteFilteringSkippedWhenNoChainTip - expired invite present=" + bobInvites.stream().anyMatch(invite -> invite.getInvitee().equals(this.bobAddress)));
+		} finally {
+			RepositoryManager.setRepositoryFactory(originalFactory);
+		}
+	}
+
+	private int createGroup(Repository repository, PrivateKeyAccount owner, String groupName, boolean isOpen) throws DataException {
+		String description = groupName + " (description)";
+		CreateGroupTransactionData transactionData = new CreateGroupTransactionData(TestTransaction.generateBase(owner), groupName, description, isOpen, org.qortal.group.Group.ApprovalThreshold.ONE, 10, 1440);
+		TransactionUtils.signAndMint(repository, transactionData, owner);
+		return repository.getGroupRepository().fromGroupName(groupName).getGroupId();
+	}
+
+	private static class NullTipRepositoryFactory implements RepositoryFactory {
+		private final RepositoryFactory delegate;
+
+		private NullTipRepositoryFactory(RepositoryFactory delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean wasPristineAtOpen() {
+			return this.delegate.wasPristineAtOpen();
+		}
+
+		@Override
+		public RepositoryFactory reopen() throws DataException {
+			return new NullTipRepositoryFactory(this.delegate.reopen());
+		}
+
+		@Override
+		public Repository getRepository() throws DataException {
+			return new NullTipRepository(this.delegate.getRepository());
+		}
+
+		@Override
+		public Repository tryRepository() throws DataException {
+			return new NullTipRepository(this.delegate.tryRepository());
+		}
+
+		@Override
+		public void close() throws DataException {
+			this.delegate.close();
+		}
+
+		@Override
+		public boolean isDeadlockException(java.sql.SQLException e) {
+			return this.delegate.isDeadlockException(e);
+		}
+	}
+
+	private static class NullTipRepository implements Repository {
+		private final Repository delegate;
+
+		private NullTipRepository(Repository delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ATRepository getATRepository() {
+			return delegate.getATRepository();
+		}
+
+		@Override
+		public AccountRepository getAccountRepository() {
+			return delegate.getAccountRepository();
+		}
+
+		@Override
+		public ArbitraryRepository getArbitraryRepository() {
+			return delegate.getArbitraryRepository();
+		}
+
+		@Override
+		public AssetRepository getAssetRepository() {
+			return delegate.getAssetRepository();
+		}
+
+		@Override
+		public BlockRepository getBlockRepository() {
+			return new NullTipBlockRepository(delegate.getBlockRepository());
+		}
+
+		@Override
+		public BlockArchiveRepository getBlockArchiveRepository() {
+			return delegate.getBlockArchiveRepository();
+		}
+
+		@Override
+		public ChatRepository getChatRepository() {
+			return delegate.getChatRepository();
+		}
+
+		@Override
+		public CrossChainRepository getCrossChainRepository() {
+			return delegate.getCrossChainRepository();
+		}
+
+		@Override
+		public GroupRepository getGroupRepository() {
+			return delegate.getGroupRepository();
+		}
+
+		@Override
+		public MessageRepository getMessageRepository() {
+			return delegate.getMessageRepository();
+		}
+
+		@Override
+		public NameRepository getNameRepository() {
+			return delegate.getNameRepository();
+		}
+
+		@Override
+		public NetworkRepository getNetworkRepository() {
+			return delegate.getNetworkRepository();
+		}
+
+		@Override
+		public TransactionRepository getTransactionRepository() {
+			return delegate.getTransactionRepository();
+		}
+
+		@Override
+		public VotingRepository getVotingRepository() {
+			return delegate.getVotingRepository();
+		}
+
+		@Override
+		public void saveChanges() throws DataException {
+			delegate.saveChanges();
+		}
+
+		@Override
+		public void discardChanges() throws DataException {
+			delegate.discardChanges();
+		}
+
+		@Override
+		public void setSavepoint() throws DataException {
+			delegate.setSavepoint();
+		}
+
+		@Override
+		public void rollbackToSavepoint() throws DataException {
+			delegate.rollbackToSavepoint();
+		}
+
+		@Override
+		public void close() throws DataException {
+			delegate.close();
+		}
+
+		@Override
+		public void rebuild() throws DataException {
+			delegate.rebuild();
+		}
+
+		@Override
+		public boolean getDebug() {
+			return delegate.getDebug();
+		}
+
+		@Override
+		public void setDebug(boolean debugState) {
+			delegate.setDebug(debugState);
+		}
+
+		@Override
+		public void backup(boolean quick, String name, Long timeout) throws DataException, TimeoutException {
+			delegate.backup(quick, name, timeout);
+		}
+
+		@Override
+		public void performPeriodicMaintenance(Long timeout) throws DataException, TimeoutException {
+			delegate.performPeriodicMaintenance(timeout);
+		}
+
+		@Override
+		public void exportNodeLocalData() throws DataException {
+			delegate.exportNodeLocalData();
+		}
+
+		@Override
+		public void importDataFromFile(String filename) throws DataException, IOException {
+			delegate.importDataFromFile(filename);
+		}
+
+		@Override
+		public void checkConsistency() throws DataException {
+			delegate.checkConsistency();
+		}
+
+		@Override
+		public Connection getConnection() {
+			return delegate.getConnection();
+		}
+	}
+
+	private static class NullTipBlockRepository implements BlockRepository {
+		private final BlockRepository delegate;
+
+		private NullTipBlockRepository(BlockRepository delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public org.qortal.data.block.BlockData fromSignature(byte[] signature) throws DataException {
+			return delegate.fromSignature(signature);
+		}
+
+		@Override
+		public org.qortal.data.block.BlockData fromReference(byte[] reference) throws DataException {
+			return delegate.fromReference(reference);
+		}
+
+		@Override
+		public org.qortal.data.block.BlockData fromHeight(int height) throws DataException {
+			return delegate.fromHeight(height);
+		}
+
+		@Override
+		public boolean exists(byte[] signature) throws DataException {
+			return delegate.exists(signature);
+		}
+
+		@Override
+		public int getHeightFromSignature(byte[] signature) throws DataException {
+			return delegate.getHeightFromSignature(signature);
+		}
+
+		@Override
+		public int getHeightFromTimestamp(long timestamp) throws DataException {
+			return delegate.getHeightFromTimestamp(timestamp);
+		}
+
+		@Override
+		public long getTimestampFromHeight(int height) throws DataException {
+			return delegate.getTimestampFromHeight(height);
+		}
+
+		@Override
+		public int getBlockchainHeight() throws DataException {
+			return delegate.getBlockchainHeight();
+		}
+
+		@Override
+		public org.qortal.data.block.BlockData getLastBlock() throws DataException {
+			return null;
+		}
+
+		@Override
+		public List<org.qortal.data.transaction.TransactionData> getTransactionsFromSignature(byte[] signature, Integer limit, Integer offset, Boolean reverse) throws DataException {
+			return delegate.getTransactionsFromSignature(signature, limit, offset, reverse);
+		}
+
+		@Override
+		public int countSignedBlocks(byte[] publicKey) throws DataException {
+			return delegate.countSignedBlocks(publicKey);
+		}
+
+		@Override
+		public int getOnlineAccountsSignaturesTrimHeight() throws DataException {
+			return delegate.getOnlineAccountsSignaturesTrimHeight();
+		}
+
+		@Override
+		public void setOnlineAccountsSignaturesTrimHeight(int trimHeight) throws DataException {
+			delegate.setOnlineAccountsSignaturesTrimHeight(trimHeight);
+		}
+
+		@Override
+		public int trimOldOnlineAccountsSignatures(int minHeight, int maxHeight) throws DataException {
+			return delegate.trimOldOnlineAccountsSignatures(minHeight, maxHeight);
+		}
+
+		@Override
+		public org.qortal.data.block.BlockData getDetachedBlockSignature(int startHeight) throws DataException {
+			return delegate.getDetachedBlockSignature(startHeight);
+		}
+
+		@Override
+		public java.util.List<org.qortal.data.block.BlockSummaryData> getBlockSummaries(int startHeight, int endHeight) throws DataException {
+			return delegate.getBlockSummaries(startHeight, endHeight);
+		}
+
+		@Override
+		public org.qortal.data.block.BlockData getBlockInRangeWithHighestOnlineAccountsCount(int startHeight, int endHeight) throws DataException {
+			return delegate.getBlockInRangeWithHighestOnlineAccountsCount(startHeight, endHeight);
+		}
+
+		@Override
+		public Long getTotalFeesInBlockRange(int startHeight, int endHeight) throws DataException {
+			return delegate.getTotalFeesInBlockRange(startHeight, endHeight);
+		}
+
+		@Override
+		public java.util.List<org.qortal.data.block.BlockData> getBlocks(int startHeight, int endHeight) throws DataException {
+			return delegate.getBlocks(startHeight, endHeight);
+		}
+
+		@Override
+		public java.util.List<org.qortal.data.block.BlockSummaryData> getBlockSummariesBySigner(byte[] publicKey, Integer limit, Integer offset, Boolean reverse) throws DataException {
+			return delegate.getBlockSummariesBySigner(publicKey, limit, offset, reverse);
+		}
+
+		@Override
+		public java.util.List<org.qortal.api.model.BlockSignerSummary> getBlockSigners(java.util.List<String> addresses, Integer limit, Integer offset, Boolean reverse) throws DataException {
+			return delegate.getBlockSigners(addresses, limit, offset, reverse);
+		}
+
+		@Override
+		public int getBlockPruneHeight() throws DataException {
+			return delegate.getBlockPruneHeight();
+		}
+
+		@Override
+		public void setBlockPruneHeight(int pruneHeight) throws DataException {
+			delegate.setBlockPruneHeight(pruneHeight);
+		}
+
+		@Override
+		public int pruneBlocks(int minHeight, int maxHeight) throws DataException {
+			return delegate.pruneBlocks(minHeight, maxHeight);
+		}
+
+		@Override
+		public void save(org.qortal.data.block.BlockData blockData) throws DataException {
+			delegate.save(blockData);
+		}
+
+		@Override
+		public void delete(org.qortal.data.block.BlockData blockData) throws DataException {
+			delegate.delete(blockData);
+		}
+
+		@Override
+		public void save(org.qortal.data.block.BlockTransactionData blockTransactionData) throws DataException {
+			delegate.save(blockTransactionData);
+		}
+
+		@Override
+		public void delete(org.qortal.data.block.BlockTransactionData blockTransactionData) throws DataException {
+			delegate.delete(blockTransactionData);
+		}
+	}
+}

--- a/src/test/resources/test-chain-v2-block-timestamps.json
+++ b/src/test/resources/test-chain-v2-block-timestamps.json
@@ -1,344 +1,137 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerMintingAccount": 20,
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  },
-  {
-   "height": 2,
-   "target": 70000,
-   "deviation": 10000,
-   "power": 0.8
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 9999999999999,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerMintingAccount": 20,
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 },
+		{ "height": 2, "target": 70000, "deviation": 10000, "power": 0.8 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 9999999999999,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-block-timestamps.json
+++ b/src/test/resources/test-chain-v2-block-timestamps.json
@@ -1,136 +1,344 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerMintingAccount": 20,
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 },
-		{ "height": 2, "target": 70000, "deviation": 10000, "power": 0.8 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 9999999999999,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerMintingAccount": 20,
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  },
+  {
+   "height": 2,
+   "target": 70000,
+   "deviation": 10000,
+   "power": 0.8
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 9999999999999,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-disable-reference.json
+++ b/src/test/resources/test-chain-v2-disable-reference.json
@@ -1,139 +1,348 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 0,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 0,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-disable-reference.json
+++ b/src/test/resources/test-chain-v2-disable-reference.json
@@ -1,348 +1,140 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 0,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 0,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-founder-rewards.json
+++ b/src/test/resources/test-chain-v2-founder-rewards.json
@@ -1,135 +1,319 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb", "sharePercent": 100 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "rewardSharePublicKey": "Hebh14YXUdJA66Vq8KyffNXHx3NSDUAZaNH9qbfEvf5M", "sharePercent": 25 }
-
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb",
+    "sharePercent": 100
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "rewardSharePublicKey": "Hebh14YXUdJA66Vq8KyffNXHx3NSDUAZaNH9qbfEvf5M",
+    "sharePercent": 25
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-founder-rewards.json
+++ b/src/test/resources/test-chain-v2-founder-rewards.json
@@ -1,319 +1,136 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb",
-    "sharePercent": 100
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "rewardSharePublicKey": "Hebh14YXUdJA66Vq8KyffNXHx3NSDUAZaNH9qbfEvf5M",
-    "sharePercent": 25
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb", "sharePercent": 100 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "rewardSharePublicKey": "Hebh14YXUdJA66Vq8KyffNXHx3NSDUAZaNH9qbfEvf5M", "sharePercent": 25 }
+
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-leftover-reward.json
+++ b/src/test/resources/test-chain-v2-leftover-reward.json
@@ -1,315 +1,137 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "4000",
-    "assetId": 1
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 8
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "4000", "assetId": 1 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-leftover-reward.json
+++ b/src/test/resources/test-chain-v2-leftover-reward.json
@@ -1,136 +1,315 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "4000", "assetId": 1 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "4000",
+    "assetId": 1
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 8
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-minting.json
+++ b/src/test/resources/test-chain-v2-minting.json
@@ -1,340 +1,142 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 9999999999999,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 0,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 9999999999999,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 1
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 8
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "CGAedAQU91SR73iqoYtss6NAsra284SShXnDWvRXqR4G",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "rewardSharePublicKey": "4QafENiQCCDCnbXgcZfiyCu9qWqZ6YEciXAyFb4TT8YQ",
-    "sharePercent": 100
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 9999999999999,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 0,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 9999999999999,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 8 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "CGAedAQU91SR73iqoYtss6NAsra284SShXnDWvRXqR4G", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "rewardSharePublicKey": "4QafENiQCCDCnbXgcZfiyCu9qWqZ6YEciXAyFb4TT8YQ", "sharePercent": 100 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-minting.json
+++ b/src/test/resources/test-chain-v2-minting.json
@@ -1,141 +1,340 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 9999999999999,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 0,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 9999999999999,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 8 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "CGAedAQU91SR73iqoYtss6NAsra284SShXnDWvRXqR4G", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "rewardSharePublicKey": "4QafENiQCCDCnbXgcZfiyCu9qWqZ6YEciXAyFb4TT8YQ", "sharePercent": 100 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 9999999999999,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 0,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 9999999999999,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 1
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 8
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "7KNBj2MnEb6zq1vvKY1q8G2Voctcc2Z1X4avFyEH2eJC",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "rewardSharePublicKey": "6bnEKqZbsCSWryUQnbBT9Umufdu3CapFvxfAni6afhFb",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "CGAedAQU91SR73iqoYtss6NAsra284SShXnDWvRXqR4G",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "rewardSharePublicKey": "4QafENiQCCDCnbXgcZfiyCu9qWqZ6YEciXAyFb4TT8YQ",
+    "sharePercent": 100
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-penalty-fix.json
+++ b/src/test/resources/test-chain-v2-penalty-fix.json
@@ -1,146 +1,381 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 0,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 20,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 20 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 0,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 18, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"penaltyFixHeight": 5,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 0,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 20,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 20
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 0,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  5,
+  20,
+  30,
+  40,
+  50,
+  60,
+  18,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "penaltyFixHeight": 5,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "UPDATE_GROUP",
+    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 1,
+    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
+    "newDescription": "developer group",
+    "newIsOpen": false,
+    "newApprovalThreshold": "PCT40",
+    "minimumBlockDelay": 10,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 5
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 6
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-penalty-fix.json
+++ b/src/test/resources/test-chain-v2-penalty-fix.json
@@ -1,381 +1,147 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 0,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 20,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 20
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 0,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  5,
-  20,
-  30,
-  40,
-  50,
-  60,
-  18,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "penaltyFixHeight": 5,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "UPDATE_GROUP",
-    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 1,
-    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
-    "newDescription": "developer group",
-    "newIsOpen": false,
-    "newApprovalThreshold": "PCT40",
-    "minimumBlockDelay": 10,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 5
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 6
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 0,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 20,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 20 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 0,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 18, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"penaltyFixHeight": 5,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-qora-holder-extremes.json
+++ b/src/test/resources/test-chain-v2-qora-holder-extremes.json
@@ -1,376 +1,147 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 0,
-  "sharesByLevelV2Height": 1000,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "637557960.49687541",
-    "assetId": 1
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "0.666",
-    "assetId": 1
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 2
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 1
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 0,
+		"sharesByLevelV2Height": 1000,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "637557960.49687541", "assetId": 1 },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "0.666", "assetId": 1 },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 2 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 1 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-qora-holder-extremes.json
+++ b/src/test/resources/test-chain-v2-qora-holder-extremes.json
@@ -1,146 +1,376 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 0,
-		"sharesByLevelV2Height": 1000,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "637557960.49687541", "assetId": 1 },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "0.666", "assetId": 1 },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 2 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 1 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 0,
+  "sharesByLevelV2Height": 1000,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "637557960.49687541",
+    "assetId": 1
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "0.666",
+    "assetId": 1
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 2
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 1
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-qora-holder-reduction.json
+++ b/src/test/resources/test-chain-v2-qora-holder-reduction.json
@@ -1,144 +1,362 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 5, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 5,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"aggregateSignatureTimestamp": 0,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "637557960.49687541", "assetId": 1 },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "0.666", "assetId": 1 },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 5,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 5,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "aggregateSignatureTimestamp": 0,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "637557960.49687541",
+    "assetId": 1
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "0.666",
+    "assetId": 1
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 8
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-qora-holder-reduction.json
+++ b/src/test/resources/test-chain-v2-qora-holder-reduction.json
@@ -1,362 +1,145 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 5,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 5,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "aggregateSignatureTimestamp": 0,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "637557960.49687541",
-    "assetId": 1
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "0.666",
-    "assetId": 1
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 8
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 5, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 5,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"aggregateSignatureTimestamp": 0,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "637557960.49687541", "assetId": 1 },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "0.666", "assetId": 1 },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-qora-holder.json
+++ b/src/test/resources/test-chain-v2-qora-holder.json
@@ -1,361 +1,144 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 1000,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "10000",
-    "assetId": 1
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "8",
-    "assetId": 1
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": 1000000,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 8
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 1000,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "10000", "assetId": 1 },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "8", "assetId": 1 },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-qora-holder.json
+++ b/src/test/resources/test-chain-v2-qora-holder.json
@@ -1,143 +1,361 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 1000,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "10000", "assetId": 1 },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "8", "assetId": 1 },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": 1000000, "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 1000,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "10000",
+    "assetId": 1
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "8",
+    "assetId": 1
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": 1000000,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 8
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-reward-levels.json
+++ b/src/test/resources/test-chain-v2-reward-levels.json
@@ -1,324 +1,138 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 20
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 1,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 6,
-  "sharesByLevelV2Height": 1000,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 2
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 20 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 1,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 6,
+		"sharesByLevelV2Height": 1000,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 2 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-reward-levels.json
+++ b/src/test/resources/test-chain-v2-reward-levels.json
@@ -1,137 +1,324 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 20 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 1,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 6,
-		"sharesByLevelV2Height": 1000,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 2 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 20
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 1,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 6,
+  "sharesByLevelV2Height": 1000,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 2
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-reward-scaling.json
+++ b/src/test/resources/test-chain-v2-reward-scaling.json
@@ -1,330 +1,140 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 20
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 500,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "40000",
-    "assetId": 1
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 8
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 1
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 1
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 20 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 500,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "40000", "assetId": 1 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 1 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-reward-scaling.json
+++ b/src/test/resources/test-chain-v2-reward-scaling.json
@@ -1,139 +1,330 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 20 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 500,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "40000", "assetId": 1 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 8 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 1 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 1 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 20
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 500,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "40000",
+    "assetId": 1
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 8
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 1
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 1
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-reward-shares.json
+++ b/src/test/resources/test-chain-v2-reward-shares.json
@@ -1,140 +1,349 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 1655460000000, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 0,
-		"calcChainWeightTimestamp": 0,
-		"newConsensusTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 1655460000000,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 0,
+  "calcChainWeightTimestamp": 0,
+  "newConsensusTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-reward-shares.json
+++ b/src/test/resources/test-chain-v2-reward-shares.json
@@ -1,349 +1,141 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 1655460000000,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 0,
-  "calcChainWeightTimestamp": 0,
-  "newConsensusTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 1655460000000, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 0,
+		"calcChainWeightTimestamp": 0,
+		"newConsensusTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-self-sponsorship-algo-v1.json
+++ b/src/test/resources/test-chain-v2-self-sponsorship-algo-v1.json
@@ -1,152 +1,408 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 0,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 20,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 20 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 2 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 0,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 18, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 20,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "MINTER", "description": "Minter group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
-			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 2, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "Minter group", "newIsOpen": true, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 1, "maximumBlockDelay": 1440 },
-
-			{ "type": "JOIN_GROUP", "joinerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 2},
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
-
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 0,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 20,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 20
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    2
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 0,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  5,
+  20,
+  30,
+  40,
+  50,
+  60,
+  18,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 20,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "MINTER",
+    "description": "Minter group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "UPDATE_GROUP",
+    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 1,
+    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
+    "newDescription": "developer group",
+    "newIsOpen": false,
+    "newApprovalThreshold": "PCT40",
+    "minimumBlockDelay": 10,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "UPDATE_GROUP",
+    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 2,
+    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
+    "newDescription": "Minter group",
+    "newIsOpen": true,
+    "newApprovalThreshold": "PCT40",
+    "minimumBlockDelay": 1,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "JOIN_GROUP",
+    "joinerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 2
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 5
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 6
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-self-sponsorship-algo-v1.json
+++ b/src/test/resources/test-chain-v2-self-sponsorship-algo-v1.json
@@ -1,408 +1,153 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 0,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 20,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 20
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    2
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 0,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  5,
-  20,
-  30,
-  40,
-  50,
-  60,
-  18,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 20,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "MINTER",
-    "description": "Minter group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "UPDATE_GROUP",
-    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 1,
-    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
-    "newDescription": "developer group",
-    "newIsOpen": false,
-    "newApprovalThreshold": "PCT40",
-    "minimumBlockDelay": 10,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "UPDATE_GROUP",
-    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 2,
-    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
-    "newDescription": "Minter group",
-    "newIsOpen": true,
-    "newApprovalThreshold": "PCT40",
-    "minimumBlockDelay": 1,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "JOIN_GROUP",
-    "joinerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 2
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 5
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 6
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 0,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 20,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 20 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 2 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 0,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 18, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 20,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "MINTER", "description": "Minter group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
+			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 2, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "Minter group", "newIsOpen": true, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 1, "maximumBlockDelay": 1440 },
+
+			{ "type": "JOIN_GROUP", "joinerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 2},
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
+
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-self-sponsorship-algo-v2.json
+++ b/src/test/resources/test-chain-v2-self-sponsorship-algo-v2.json
@@ -1,382 +1,148 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 0,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 20,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 20
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 0,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 0,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  5,
-  20,
-  30,
-  40,
-  50,
-  60,
-  18,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 30,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "UPDATE_GROUP",
-    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 1,
-    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
-    "newDescription": "developer group",
-    "newIsOpen": false,
-    "newApprovalThreshold": "PCT40",
-    "minimumBlockDelay": 10,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 5
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 6
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 0,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 20,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 20 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 0,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 0,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 18, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 30,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-self-sponsorship-algo-v2.json
+++ b/src/test/resources/test-chain-v2-self-sponsorship-algo-v2.json
@@ -1,147 +1,382 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 0,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 20,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 20 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 0,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 0,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 18, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 30,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 0,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 20,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 20
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 0,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 0,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  5,
+  20,
+  30,
+  40,
+  50,
+  60,
+  18,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 30,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "UPDATE_GROUP",
+    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 1,
+    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
+    "newDescription": "developer group",
+    "newIsOpen": false,
+    "newApprovalThreshold": "PCT40",
+    "minimumBlockDelay": 10,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 5
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 6
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2-self-sponsorship-algo-v3.json
+++ b/src/test/resources/test-chain-v2-self-sponsorship-algo-v3.json
@@ -1,382 +1,148 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 0,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.00000001"
-  },
-  {
-   "timestamp": 1645372800000,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 20,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 20
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 0,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": [
-    1
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 0,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  5,
-  20,
-  30,
-  40,
-  50,
-  60,
-  28,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 30,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "UPDATE_GROUP",
-    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 1,
-    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
-    "newDescription": "developer group",
-    "newIsOpen": false,
-    "newApprovalThreshold": "PCT40",
-    "minimumBlockDelay": 10,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "level": 5
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
-    "sharePercent": 100
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "level": 5
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 6
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 0,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.00000001" },
+		{ "timestamp": 1645372800000, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 20,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 20 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 0,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": [ 1 ]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 0,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 28, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 30,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2-self-sponsorship-algo-v3.json
+++ b/src/test/resources/test-chain-v2-self-sponsorship-algo-v3.json
@@ -1,147 +1,382 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 0,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.00000001" },
-		{ "timestamp": 1645372800000, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 20,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 20 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 0,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": [ 1 ]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 0,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 5, 20, 30, 40, 50, 60, 28, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 30,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "level": 5 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp", "sharePercent": 100 },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "level": 5 },
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 6 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 0,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.00000001"
+  },
+  {
+   "timestamp": 1645372800000,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 20,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 20
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 0,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": [
+    1
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 0,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  5,
+  20,
+  30,
+  40,
+  50,
+  60,
+  28,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 30,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "UPDATE_GROUP",
+    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 1,
+    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
+    "newDescription": "developer group",
+    "newIsOpen": false,
+    "newApprovalThreshold": "PCT40",
+    "minimumBlockDelay": 10,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "level": 5
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "rewardSharePublicKey": "CcABzvk26TFEHG7Yok84jxyd4oBtLkx8RJdGFVz2csvp",
+    "sharePercent": 100
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "level": 5
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 6
+   }
+  ]
+ }
 }

--- a/src/test/resources/test-chain-v2.json
+++ b/src/test/resources/test-chain-v2.json
@@ -1,383 +1,149 @@
 {
- "isTestChain": true,
- "blockTimestampMargin": 500,
- "transactionExpiryPeriod": 86400000,
- "maxBlockSize": 2097152,
- "maxBytesPerUnitFee": 1024,
- "unitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 9999999999999,
-   "fee": "1"
-  }
- ],
- "nameRegistrationUnitFees": [
-  {
-   "timestamp": 0,
-   "fee": "0.1"
-  },
-  {
-   "timestamp": 9999999999999,
-   "fee": "5"
-  }
- ],
- "requireGroupForApproval": false,
- "minAccountLevelToRewardShare": 5,
- "maxRewardSharesPerFounderMintingAccount": 6,
- "maxRewardSharesByTimestamp": [
-  {
-   "timestamp": 0,
-   "maxShares": 6
-  },
-  {
-   "timestamp": 9999999999999,
-   "maxShares": 3
-  }
- ],
- "founderEffectiveMintingLevel": 10,
- "onlineAccountSignaturesMinLifetime": 3600000,
- "onlineAccountSignaturesMaxLifetime": 86400000,
- "onlineAccountsModulusV2Timestamp": 9999999999999,
- "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
- "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
- "referenceTimestampBlock": 9999999999999,
- "mempowTransactionUpdatesTimestamp": 0,
- "blockRewardBatchStartHeight": 999999000,
- "blockRewardBatchSize": 10,
- "blockRewardBatchAccountsBlockCount": 3,
- "mintingGroupIds": [
-  {
-   "height": 0,
-   "ids": []
-  },
-  {
-   "height": 5,
-   "ids": [
-    694
-   ]
-  },
-  {
-   "height": 8,
-   "ids": [
-    694,
-    800
-   ]
-  },
-  {
-   "height": 12,
-   "ids": [
-    800
-   ]
-  }
- ],
- "rewardsByHeight": [
-  {
-   "height": 1,
-   "reward": 100
-  },
-  {
-   "height": 11,
-   "reward": 10
-  },
-  {
-   "height": 21,
-   "reward": 1
-  }
- ],
- "sharesByLevelV1": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.05
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.1
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.15
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.2
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.25
-  }
- ],
- "sharesByLevelV2": [
-  {
-   "id": 1,
-   "levels": [
-    1,
-    2
-   ],
-   "share": 0.06
-  },
-  {
-   "id": 2,
-   "levels": [
-    3,
-    4
-   ],
-   "share": 0.13
-  },
-  {
-   "id": 3,
-   "levels": [
-    5,
-    6
-   ],
-   "share": 0.19
-  },
-  {
-   "id": 4,
-   "levels": [
-    7,
-    8
-   ],
-   "share": 0.26
-  },
-  {
-   "id": 5,
-   "levels": [
-    9,
-    10
-   ],
-   "share": 0.32
-  }
- ],
- "qoraHoldersShareByHeight": [
-  {
-   "height": 1,
-   "share": 0.2
-  },
-  {
-   "height": 1000000,
-   "share": 0.01
-  }
- ],
- "qoraPerQortReward": 250,
- "minAccountsToActivateShareBin": 30,
- "shareBinActivationMinLevel": 7,
- "blocksNeededByLevel": [
-  10,
-  20,
-  30,
-  40,
-  50,
-  60,
-  70,
-  80,
-  90,
-  100
- ],
- "blockTimingsByHeight": [
-  {
-   "height": 1,
-   "target": 60000,
-   "deviation": 30000,
-   "power": 0.2
-  }
- ],
- "ciyamAtSettings": {
-  "feePerStep": "0.0001",
-  "maxStepsPerRound": 500,
-  "stepsPerFunctionCall": 10,
-  "minutesPerBlock": 1
- },
- "featureTriggers": {
-  "messageHeight": 0,
-  "atHeight": 0,
-  "assetsTimestamp": 0,
-  "votingTimestamp": 0,
-  "arbitraryTimestamp": 0,
-  "powfixTimestamp": 0,
-  "qortalTimestamp": 0,
-  "newAssetPricingTimestamp": 0,
-  "groupApprovalTimestamp": 0,
-  "atFindNextTransactionFix": 0,
-  "newBlockSigHeight": 999999,
-  "shareBinFix": 999999,
-  "sharesByLevelV2Height": 999999,
-  "rewardShareLimitTimestamp": 9999999999999,
-  "calcChainWeightTimestamp": 0,
-  "transactionV5Timestamp": 0,
-  "transactionV6Timestamp": 0,
-  "disableReferenceTimestamp": 9999999999999,
-  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-  "onlineAccountMinterLevelValidationHeight": 0,
-  "selfSponsorshipAlgoV1Height": 999999999,
-  "selfSponsorshipAlgoV2Height": 999999999,
-  "selfSponsorshipAlgoV3Height": 999999999,
-  "feeValidationFixTimestamp": 0,
-  "chatReferenceTimestamp": 0,
-  "arbitraryOptionalFeeTimestamp": 0,
-  "unconfirmableRewardSharesHeight": 99999999,
-  "disableTransferPrivsTimestamp": 9999999999500,
-  "enableTransferPrivsTimestamp": 9999999999950,
-  "cancelSellNameValidationTimestamp": 9999999999999,
-  "disableRewardshareHeight": 9999999999990,
-  "enableRewardshareHeight": 9999999999999,
-  "onlyMintWithNameHeight": 9999999999990,
-  "groupMemberCheckHeight": 9999999999999,
-  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-  "removeOnlyMintWithNameHeight": 9999999999999,
-  "fixBatchRewardHeight": 9999999999999,
-  "adminsReplaceFoundersHeight": 9999999999999,
-  "ignoreLevelForRewardShareHeight": 9999999999999,
-  "nullGroupMembershipHeight": 20,
-  "adminQueryFixHeight": 9999999999999,
-  "multipleNamesPerAccountHeight": 10,
-  "mintedBlocksAdjustmentRemovalHeight": 27,
-  "groupInviteExpiryHeight": 0
- },
- "genesisInfo": {
-  "version": 4,
-  "timestamp": 0,
-  "transactions": [
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT",
-    "description": "QORT native coin",
-    "data": "",
-    "quantity": 0,
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "Legacy-QORA",
-    "description": "Representative legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "assetName": "QORT-from-QORA",
-    "description": "QORT gained from holding legacy QORA",
-    "quantity": 0,
-    "isDivisible": true,
-    "data": "{}",
-    "isUnspendable": true
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "amount": "1000000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
-    "amount": "1000000"
-   },
-   {
-    "type": "GENESIS",
-    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "amount": "1000000"
-   },
-   {
-    "type": "CREATE_GROUP",
-    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupName": "dev-group",
-    "description": "developer group",
-    "isOpen": false,
-    "approvalThreshold": "PCT100",
-    "minimumBlockDelay": 0,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "UPDATE_GROUP",
-    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "groupId": 1,
-    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
-    "newDescription": "developer group",
-    "newIsOpen": false,
-    "newApprovalThreshold": "PCT40",
-    "minimumBlockDelay": 10,
-    "maximumBlockDelay": 1440
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "TEST",
-    "description": "test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
-    "assetName": "OTHER",
-    "description": "other test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ISSUE_ASSET",
-    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "assetName": "GOLD",
-    "description": "gold test asset",
-    "data": "",
-    "quantity": "1000000",
-    "isDivisible": true,
-    "fee": 0
-   },
-   {
-    "type": "ACCOUNT_FLAGS",
-    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "andMask": -1,
-    "orMask": 1,
-    "xorMask": 0
-   },
-   {
-    "type": "REWARD_SHARE",
-    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
-    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
-    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
-    "sharePercent": "100"
-   },
-   {
-    "type": "ACCOUNT_LEVEL",
-    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
-    "level": 5
-   }
-  ]
- }
+	"isTestChain": true,
+	"blockTimestampMargin": 500,
+	"transactionExpiryPeriod": 86400000,
+	"maxBlockSize": 2097152,
+	"maxBytesPerUnitFee": 1024,
+	"unitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 9999999999999, "fee": "1" }
+	],
+	"nameRegistrationUnitFees": [
+		{ "timestamp": 0, "fee": "0.1" },
+		{ "timestamp": 9999999999999, "fee": "5" }
+	],
+	"requireGroupForApproval": false,
+	"minAccountLevelToRewardShare": 5,
+	"maxRewardSharesPerFounderMintingAccount": 6,
+	"maxRewardSharesByTimestamp": [
+		{ "timestamp": 0, "maxShares": 6 },
+		{ "timestamp": 9999999999999, "maxShares": 3 }
+	],
+	"founderEffectiveMintingLevel": 10,
+	"onlineAccountSignaturesMinLifetime": 3600000,
+	"onlineAccountSignaturesMaxLifetime": 86400000,
+	"onlineAccountsModulusV2Timestamp": 9999999999999,
+	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+	"referenceTimestampBlock": 9999999999999,
+	"mempowTransactionUpdatesTimestamp": 0,
+	"blockRewardBatchStartHeight": 999999000,
+	"blockRewardBatchSize": 10,
+	"blockRewardBatchAccountsBlockCount": 3,
+	"mintingGroupIds": [
+		{ "height": 0, "ids": []},
+		{ "height": 5, "ids": [694]},
+		{ "height": 8, "ids": [694, 800]},
+		{ "height": 12, "ids": [800]}
+	],
+	"rewardsByHeight": [
+		{ "height": 1, "reward": 100 },
+		{ "height": 11, "reward": 10 },
+		{ "height": 21, "reward": 1 }
+	],
+	"sharesByLevelV1": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
+	],
+	"sharesByLevelV2": [
+		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
+		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
+		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
+		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
+		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
+	],
+	"qoraHoldersShareByHeight": [
+		{ "height": 1, "share": 0.20 },
+		{ "height": 1000000, "share": 0.01 }
+	],
+	"qoraPerQortReward": 250,
+	"minAccountsToActivateShareBin": 30,
+	"shareBinActivationMinLevel": 7,
+	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
+	"blockTimingsByHeight": [
+		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
+	],
+	"ciyamAtSettings": {
+		"feePerStep": "0.0001",
+		"maxStepsPerRound": 500,
+		"stepsPerFunctionCall": 10,
+		"minutesPerBlock": 1
+	},
+	"featureTriggers": {
+		"messageHeight": 0,
+		"atHeight": 0,
+		"assetsTimestamp": 0,
+		"votingTimestamp": 0,
+		"arbitraryTimestamp": 0,
+		"powfixTimestamp": 0,
+		"qortalTimestamp": 0,
+		"newAssetPricingTimestamp": 0,
+		"groupApprovalTimestamp": 0,
+		"atFindNextTransactionFix": 0,
+		"newBlockSigHeight": 999999,
+		"shareBinFix": 999999,
+		"sharesByLevelV2Height": 999999,
+		"rewardShareLimitTimestamp": 9999999999999,
+		"calcChainWeightTimestamp": 0,
+		"transactionV5Timestamp": 0,
+		"transactionV6Timestamp": 0,
+		"disableReferenceTimestamp": 9999999999999,
+		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+		"onlineAccountMinterLevelValidationHeight": 0,
+		"selfSponsorshipAlgoV1Height": 999999999,
+		"selfSponsorshipAlgoV2Height": 999999999,
+		"selfSponsorshipAlgoV3Height": 999999999,
+		"feeValidationFixTimestamp": 0,
+		"chatReferenceTimestamp": 0,
+		"arbitraryOptionalFeeTimestamp": 0,
+		"unconfirmableRewardSharesHeight": 99999999,
+		"disableTransferPrivsTimestamp": 9999999999500,
+		"enableTransferPrivsTimestamp": 9999999999950,
+		"cancelSellNameValidationTimestamp": 9999999999999,
+		"disableRewardshareHeight": 9999999999990,
+		"enableRewardshareHeight": 9999999999999,
+		"onlyMintWithNameHeight": 9999999999990,
+		"groupMemberCheckHeight": 9999999999999,
+		"groupInviteExpiryHeight": 0,
+		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+		"removeOnlyMintWithNameHeight": 9999999999999,
+		"fixBatchRewardHeight": 9999999999999,
+		"adminsReplaceFoundersHeight": 9999999999999,
+		"ignoreLevelForRewardShareHeight": 9999999999999,
+		"nullGroupMembershipHeight": 20,
+		"adminQueryFixHeight": 9999999999999,
+		"multipleNamesPerAccountHeight": 10,
+		"mintedBlocksAdjustmentRemovalHeight": 27
+	},
+	"genesisInfo": {
+		"version": 4,
+		"timestamp": 0,
+		"transactions": [
+			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
+
+			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
+			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
+			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
+
+			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
+
+			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
+
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
+
+			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
+			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
+
+			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
+		]
+	}
 }

--- a/src/test/resources/test-chain-v2.json
+++ b/src/test/resources/test-chain-v2.json
@@ -1,148 +1,383 @@
 {
-	"isTestChain": true,
-	"blockTimestampMargin": 500,
-	"transactionExpiryPeriod": 86400000,
-	"maxBlockSize": 2097152,
-	"maxBytesPerUnitFee": 1024,
-	"unitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 9999999999999, "fee": "1" }
-	],
-	"nameRegistrationUnitFees": [
-		{ "timestamp": 0, "fee": "0.1" },
-		{ "timestamp": 9999999999999, "fee": "5" }
-	],
-	"requireGroupForApproval": false,
-	"minAccountLevelToRewardShare": 5,
-	"maxRewardSharesPerFounderMintingAccount": 6,
-	"maxRewardSharesByTimestamp": [
-		{ "timestamp": 0, "maxShares": 6 },
-		{ "timestamp": 9999999999999, "maxShares": 3 }
-	],
-	"founderEffectiveMintingLevel": 10,
-	"onlineAccountSignaturesMinLifetime": 3600000,
-	"onlineAccountSignaturesMaxLifetime": 86400000,
-	"onlineAccountsModulusV2Timestamp": 9999999999999,
-	"selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
-	"selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
-	"referenceTimestampBlock": 9999999999999,
-	"mempowTransactionUpdatesTimestamp": 0,
-	"blockRewardBatchStartHeight": 999999000,
-	"blockRewardBatchSize": 10,
-	"blockRewardBatchAccountsBlockCount": 3,
-	"mintingGroupIds": [
-		{ "height": 0, "ids": []},
-		{ "height": 5, "ids": [694]},
-		{ "height": 8, "ids": [694, 800]},
-		{ "height": 12, "ids": [800]}
-	],
-	"rewardsByHeight": [
-		{ "height": 1, "reward": 100 },
-		{ "height": 11, "reward": 10 },
-		{ "height": 21, "reward": 1 }
-	],
-	"sharesByLevelV1": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.05 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.10 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.15 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.20 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.25 }
-	],
-	"sharesByLevelV2": [
-		{ "id": 1, "levels": [ 1, 2 ], "share": 0.06 },
-		{ "id": 2, "levels": [ 3, 4 ], "share": 0.13 },
-		{ "id": 3, "levels": [ 5, 6 ], "share": 0.19 },
-		{ "id": 4, "levels": [ 7, 8 ], "share": 0.26 },
-		{ "id": 5, "levels": [ 9, 10 ], "share": 0.32 }
-	],
-	"qoraHoldersShareByHeight": [
-		{ "height": 1, "share": 0.20 },
-		{ "height": 1000000, "share": 0.01 }
-	],
-	"qoraPerQortReward": 250,
-	"minAccountsToActivateShareBin": 30,
-	"shareBinActivationMinLevel": 7,
-	"blocksNeededByLevel": [ 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 ],
-	"blockTimingsByHeight": [
-		{ "height": 1, "target": 60000, "deviation": 30000, "power": 0.2 }
-	],
-	"ciyamAtSettings": {
-		"feePerStep": "0.0001",
-		"maxStepsPerRound": 500,
-		"stepsPerFunctionCall": 10,
-		"minutesPerBlock": 1
-	},
-	"featureTriggers": {
-		"messageHeight": 0,
-		"atHeight": 0,
-		"assetsTimestamp": 0,
-		"votingTimestamp": 0,
-		"arbitraryTimestamp": 0,
-		"powfixTimestamp": 0,
-		"qortalTimestamp": 0,
-		"newAssetPricingTimestamp": 0,
-		"groupApprovalTimestamp": 0,
-		"atFindNextTransactionFix": 0,
-		"newBlockSigHeight": 999999,
-		"shareBinFix": 999999,
-		"sharesByLevelV2Height": 999999,
-		"rewardShareLimitTimestamp": 9999999999999,
-		"calcChainWeightTimestamp": 0,
-		"transactionV5Timestamp": 0,
-		"transactionV6Timestamp": 0,
-		"disableReferenceTimestamp": 9999999999999,
-		"increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
-		"onlineAccountMinterLevelValidationHeight": 0,
-		"selfSponsorshipAlgoV1Height": 999999999,
-		"selfSponsorshipAlgoV2Height": 999999999,
-		"selfSponsorshipAlgoV3Height": 999999999,
-		"feeValidationFixTimestamp": 0,
-		"chatReferenceTimestamp": 0,
-		"arbitraryOptionalFeeTimestamp": 0,
-		"unconfirmableRewardSharesHeight": 99999999,
-		"disableTransferPrivsTimestamp": 9999999999500,
-		"enableTransferPrivsTimestamp": 9999999999950,
-		"cancelSellNameValidationTimestamp": 9999999999999,
-		"disableRewardshareHeight": 9999999999990,
-		"enableRewardshareHeight": 9999999999999,
-		"onlyMintWithNameHeight": 9999999999990,
-		"groupMemberCheckHeight": 9999999999999,
-		"decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
-		"removeOnlyMintWithNameHeight": 9999999999999,
-		"fixBatchRewardHeight": 9999999999999,
-		"adminsReplaceFoundersHeight": 9999999999999,
-		"ignoreLevelForRewardShareHeight": 9999999999999,
-		"nullGroupMembershipHeight": 20,
-		"adminQueryFixHeight": 9999999999999,
-		"multipleNamesPerAccountHeight": 10,
-		"mintedBlocksAdjustmentRemovalHeight": 27
-	},
-	"genesisInfo": {
-		"version": 4,
-		"timestamp": 0,
-		"transactions": [
-			{ "type": "ISSUE_ASSET", "assetName": "QORT", "description": "QORT native coin", "data": "", "quantity": 0, "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "assetName": "Legacy-QORA", "description": "Representative legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-			{ "type": "ISSUE_ASSET", "assetName": "QORT-from-QORA", "description": "QORT gained from holding legacy QORA", "quantity": 0, "isDivisible": true, "data": "{}", "isUnspendable": true },
-
-			{ "type": "GENESIS", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "amount": "1000000000" },
-			{ "type": "GENESIS", "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL", "amount": "1000000" },
-			{ "type": "GENESIS", "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "amount": "1000000" },
-
-			{ "type": "CREATE_GROUP", "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupName": "dev-group", "description": "developer group", "isOpen": false, "approvalThreshold": "PCT100", "minimumBlockDelay": 0, "maximumBlockDelay": 1440 },
-
-			{ "type": "UPDATE_GROUP", "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "groupId": 1, "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG", "newDescription": "developer group", "newIsOpen": false, "newApprovalThreshold": "PCT40", "minimumBlockDelay": 10, "maximumBlockDelay": 1440 },
-
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "TEST", "description": "test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry", "assetName": "OTHER", "description": "other test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-			{ "type": "ISSUE_ASSET", "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "assetName": "GOLD", "description": "gold test asset", "data": "", "quantity": "1000000", "isDivisible": true, "fee": 0 },
-
-			{ "type": "ACCOUNT_FLAGS", "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "andMask": -1, "orMask": 1, "xorMask": 0 },
-			{ "type": "REWARD_SHARE", "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP", "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v", "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox", "sharePercent": "100" },
-
-			{ "type": "ACCOUNT_LEVEL", "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er", "level": 5 }
-		]
-	}
+ "isTestChain": true,
+ "blockTimestampMargin": 500,
+ "transactionExpiryPeriod": 86400000,
+ "maxBlockSize": 2097152,
+ "maxBytesPerUnitFee": 1024,
+ "unitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 9999999999999,
+   "fee": "1"
+  }
+ ],
+ "nameRegistrationUnitFees": [
+  {
+   "timestamp": 0,
+   "fee": "0.1"
+  },
+  {
+   "timestamp": 9999999999999,
+   "fee": "5"
+  }
+ ],
+ "requireGroupForApproval": false,
+ "minAccountLevelToRewardShare": 5,
+ "maxRewardSharesPerFounderMintingAccount": 6,
+ "maxRewardSharesByTimestamp": [
+  {
+   "timestamp": 0,
+   "maxShares": 6
+  },
+  {
+   "timestamp": 9999999999999,
+   "maxShares": 3
+  }
+ ],
+ "founderEffectiveMintingLevel": 10,
+ "onlineAccountSignaturesMinLifetime": 3600000,
+ "onlineAccountSignaturesMaxLifetime": 86400000,
+ "onlineAccountsModulusV2Timestamp": 9999999999999,
+ "selfSponsorshipAlgoV1SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV2SnapshotTimestamp": 9999999999999,
+ "selfSponsorshipAlgoV3SnapshotTimestamp": 9999999999999,
+ "referenceTimestampBlock": 9999999999999,
+ "mempowTransactionUpdatesTimestamp": 0,
+ "blockRewardBatchStartHeight": 999999000,
+ "blockRewardBatchSize": 10,
+ "blockRewardBatchAccountsBlockCount": 3,
+ "mintingGroupIds": [
+  {
+   "height": 0,
+   "ids": []
+  },
+  {
+   "height": 5,
+   "ids": [
+    694
+   ]
+  },
+  {
+   "height": 8,
+   "ids": [
+    694,
+    800
+   ]
+  },
+  {
+   "height": 12,
+   "ids": [
+    800
+   ]
+  }
+ ],
+ "rewardsByHeight": [
+  {
+   "height": 1,
+   "reward": 100
+  },
+  {
+   "height": 11,
+   "reward": 10
+  },
+  {
+   "height": 21,
+   "reward": 1
+  }
+ ],
+ "sharesByLevelV1": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.05
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.1
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.15
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.2
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.25
+  }
+ ],
+ "sharesByLevelV2": [
+  {
+   "id": 1,
+   "levels": [
+    1,
+    2
+   ],
+   "share": 0.06
+  },
+  {
+   "id": 2,
+   "levels": [
+    3,
+    4
+   ],
+   "share": 0.13
+  },
+  {
+   "id": 3,
+   "levels": [
+    5,
+    6
+   ],
+   "share": 0.19
+  },
+  {
+   "id": 4,
+   "levels": [
+    7,
+    8
+   ],
+   "share": 0.26
+  },
+  {
+   "id": 5,
+   "levels": [
+    9,
+    10
+   ],
+   "share": 0.32
+  }
+ ],
+ "qoraHoldersShareByHeight": [
+  {
+   "height": 1,
+   "share": 0.2
+  },
+  {
+   "height": 1000000,
+   "share": 0.01
+  }
+ ],
+ "qoraPerQortReward": 250,
+ "minAccountsToActivateShareBin": 30,
+ "shareBinActivationMinLevel": 7,
+ "blocksNeededByLevel": [
+  10,
+  20,
+  30,
+  40,
+  50,
+  60,
+  70,
+  80,
+  90,
+  100
+ ],
+ "blockTimingsByHeight": [
+  {
+   "height": 1,
+   "target": 60000,
+   "deviation": 30000,
+   "power": 0.2
+  }
+ ],
+ "ciyamAtSettings": {
+  "feePerStep": "0.0001",
+  "maxStepsPerRound": 500,
+  "stepsPerFunctionCall": 10,
+  "minutesPerBlock": 1
+ },
+ "featureTriggers": {
+  "messageHeight": 0,
+  "atHeight": 0,
+  "assetsTimestamp": 0,
+  "votingTimestamp": 0,
+  "arbitraryTimestamp": 0,
+  "powfixTimestamp": 0,
+  "qortalTimestamp": 0,
+  "newAssetPricingTimestamp": 0,
+  "groupApprovalTimestamp": 0,
+  "atFindNextTransactionFix": 0,
+  "newBlockSigHeight": 999999,
+  "shareBinFix": 999999,
+  "sharesByLevelV2Height": 999999,
+  "rewardShareLimitTimestamp": 9999999999999,
+  "calcChainWeightTimestamp": 0,
+  "transactionV5Timestamp": 0,
+  "transactionV6Timestamp": 0,
+  "disableReferenceTimestamp": 9999999999999,
+  "increaseOnlineAccountsDifficultyTimestamp": 9999999999990,
+  "onlineAccountMinterLevelValidationHeight": 0,
+  "selfSponsorshipAlgoV1Height": 999999999,
+  "selfSponsorshipAlgoV2Height": 999999999,
+  "selfSponsorshipAlgoV3Height": 999999999,
+  "feeValidationFixTimestamp": 0,
+  "chatReferenceTimestamp": 0,
+  "arbitraryOptionalFeeTimestamp": 0,
+  "unconfirmableRewardSharesHeight": 99999999,
+  "disableTransferPrivsTimestamp": 9999999999500,
+  "enableTransferPrivsTimestamp": 9999999999950,
+  "cancelSellNameValidationTimestamp": 9999999999999,
+  "disableRewardshareHeight": 9999999999990,
+  "enableRewardshareHeight": 9999999999999,
+  "onlyMintWithNameHeight": 9999999999990,
+  "groupMemberCheckHeight": 9999999999999,
+  "decreaseOnlineAccountsDifficultyTimestamp": 9999999999999,
+  "removeOnlyMintWithNameHeight": 9999999999999,
+  "fixBatchRewardHeight": 9999999999999,
+  "adminsReplaceFoundersHeight": 9999999999999,
+  "ignoreLevelForRewardShareHeight": 9999999999999,
+  "nullGroupMembershipHeight": 20,
+  "adminQueryFixHeight": 9999999999999,
+  "multipleNamesPerAccountHeight": 10,
+  "mintedBlocksAdjustmentRemovalHeight": 27,
+  "groupInviteExpiryHeight": 0
+ },
+ "genesisInfo": {
+  "version": 4,
+  "timestamp": 0,
+  "transactions": [
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT",
+    "description": "QORT native coin",
+    "data": "",
+    "quantity": 0,
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "Legacy-QORA",
+    "description": "Representative legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "assetName": "QORT-from-QORA",
+    "description": "QORT gained from holding legacy QORA",
+    "quantity": 0,
+    "isDivisible": true,
+    "data": "{}",
+    "isUnspendable": true
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "amount": "1000000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QixPbJUwsaHsVEofJdozU9zgVqkK6aYhrK",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "QaUpHNhT3Ygx6avRiKobuLdusppR5biXjL",
+    "amount": "1000000"
+   },
+   {
+    "type": "GENESIS",
+    "recipient": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "amount": "1000000"
+   },
+   {
+    "type": "CREATE_GROUP",
+    "creatorPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupName": "dev-group",
+    "description": "developer group",
+    "isOpen": false,
+    "approvalThreshold": "PCT100",
+    "minimumBlockDelay": 0,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "UPDATE_GROUP",
+    "ownerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "groupId": 1,
+    "newOwner": "QdSnUy6sUiEnaN87dWmE92g1uQjrvPgrWG",
+    "newDescription": "developer group",
+    "newIsOpen": false,
+    "newApprovalThreshold": "PCT40",
+    "minimumBlockDelay": 10,
+    "maximumBlockDelay": 1440
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "TEST",
+    "description": "test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "C6wuddsBV3HzRrXUtezE7P5MoRXp5m3mEDokRDGZB6ry",
+    "assetName": "OTHER",
+    "description": "other test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ISSUE_ASSET",
+    "issuerPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "assetName": "GOLD",
+    "description": "gold test asset",
+    "data": "",
+    "quantity": "1000000",
+    "isDivisible": true,
+    "fee": 0
+   },
+   {
+    "type": "ACCOUNT_FLAGS",
+    "target": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "andMask": -1,
+    "orMask": 1,
+    "xorMask": 0
+   },
+   {
+    "type": "REWARD_SHARE",
+    "minterPublicKey": "2tiMr5LTpaWCgbRvkPK8TFd7k63DyHJMMFFsz9uBf1ZP",
+    "recipient": "QgV4s3xnzLhVBEJxcYui4u4q11yhUHsd9v",
+    "rewardSharePublicKey": "7PpfnvLSG7y4HPh8hE7KoqAjLCkv7Ui6xw4mKAkbZtox",
+    "sharePercent": "100"
+   },
+   {
+    "type": "ACCOUNT_LEVEL",
+    "target": "Qci5m9k4rcwe4ruKrZZQKka4FzUUMut3er",
+    "level": 5
+   }
+  ]
+ }
 }

--- a/testnet/testchain.json
+++ b/testnet/testchain.json
@@ -106,7 +106,8 @@
 		"disableRewardshareHeight": 8450,
 		"enableRewardshareHeight": 11400,
 		"onlyMintWithNameHeight": 8500,
-		"groupMemberCheckHeight": 11200
+		"groupMemberCheckHeight": 11200,
+		"groupInviteExpiryHeight": 0
 	},
 	"genesisInfo": {
 		"version": 4,


### PR DESCRIPTION
Fixes #285 - Bug: GROUP_INVITE expiration not enforced (invites never expire)

## Summary
- Add the `groupInviteExpiryHeight` feature trigger (enum entry + getter) and wire it through mainnet, testnet, and all test-chain fixtures; startup now validates the trigger presence.
- Implement invite expiry enforcement in `Group.join(...)` gated by the trigger: invite-first joins use join tx timestamps with an inclusive boundary and `expiry == null` sentinel; expired invites are treated as absent and fall back to join requests; pre-trigger behavior is unchanged. Join-first auto-approvals remain TTL-agnostic (any invite approves a pending request).
- Apply chain-tip-based invite filtering to API endpoints via a shared helper in `GroupsResource` (inclusive boundary, `expiry == null` never expires, skip when no tip) and document the behavior in swagger.
- Update docs (`INVITE_EXPIRATION.md`, `IMPLEMENTATION.md`, `CONSENSUS_CHANGE.md`) with final semantics, activation plan, join-first clarifications, and activation rollout guidance.
- Add comprehensive tests: invite-first expiry enforcement, join-first TTL-agnostic behavior, backdated/forward-dated windows, pre/post-trigger activation, and API invite filtering (chain-tip filtering and no-tip fallback). Includes a dedicated `GroupInviteFilteringApiTests` class.

## Tests
- `mvn -q -DskipTests=false -Dtest=org.qortal.test.group.MiscTests test`
- `mvn -q -DskipTests=false -Dtest=org.qortal.test.api.GroupInviteFilteringApiTests test`

## Follow-up for activation
- Choose and set a real `groupInviteExpiryHeight` for mainnet once network coverage is sufficient; keep the placeholder until then.
- Communicate the activation height/date to operators and include it in release notes/changelog.
- Verify testnet/fixture triggers remain at immediate activation for ongoing coverage, adjusting only if the activation scheme changes.
