### PR TITLE
Make bootstrap safer with marker-based restart and cache timer guards

### DIFF
--- a/src/main/java/org/qortal/ApplyBootstrap.java
+++ b/src/main/java/org/qortal/ApplyBootstrap.java
@@ -7,16 +7,14 @@ import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 import org.qortal.api.ApiKey;
 import org.qortal.api.ApiRequest;
 import org.qortal.controller.BootstrapNode;
+import org.qortal.repository.Bootstrap;
 import org.qortal.settings.Settings;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.security.Security;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -68,8 +66,7 @@ public class ApplyBootstrap {
 
 		waitForParentExit(parsedArgs.parentPid);
 
-		// Delete db
-		deleteDB();
+		requestBootstrapMarker();
 
 		// Restart node
 		restartNode(filteredArgs);
@@ -152,28 +149,11 @@ public class ApplyBootstrap {
 		}
 	}
 
-	private static void deleteDB() {
-		// Get the repository path from settings
-		String repositoryPath = Settings.getInstance().getRepositoryPath();
-		LOGGER.debug(String.format("Repository path: %s", repositoryPath));
-
+	private static void requestBootstrapMarker() {
 		try {
-			Path directory = Paths.get(repositoryPath);
-			Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
-				@Override
-				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-					Files.delete(file);
-					return FileVisitResult.CONTINUE;
-				}
-
-				@Override
-				public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-					Files.delete(dir);
-					return FileVisitResult.CONTINUE;
-				}
-			});
+			Bootstrap.requestBootstrap();
 		} catch (IOException e) {
-			LOGGER.error("Error deleting DB: {}", e.getMessage());
+			LOGGER.error("Error creating bootstrap request marker: {}", e.getMessage());
 		}
 	}
 

--- a/src/main/java/org/qortal/controller/BootstrapNode.java
+++ b/src/main/java/org/qortal/controller/BootstrapNode.java
@@ -24,6 +24,7 @@ public class BootstrapNode {
 
 	public static final String JAR_FILENAME = "qortal.jar";
 	public static final String AGENTLIB_JVM_HOLDER_ARG = "-DQORTAL_agentlib=";
+	private static final String PARENT_PID_ARG = "--parent-pid";
 
 	private static final Logger LOGGER = LogManager.getLogger(BootstrapNode.class);
 
@@ -75,6 +76,9 @@ public class BootstrapNode {
 			String[] savedArgs = Controller.getInstance().getSavedArgs();
 			if (savedArgs != null)
 				javaCmd.addAll(Arrays.asList(savedArgs));
+
+			long parentPid = ProcessHandle.current().pid();
+			javaCmd.addAll(Arrays.asList(PARENT_PID_ARG, Long.toString(parentPid)));
 
 			LOGGER.info(String.format("Restarting node with: %s", String.join(" ", javaCmd)));
 

--- a/src/main/java/org/qortal/controller/Controller.java
+++ b/src/main/java/org/qortal/controller/Controller.java
@@ -413,6 +413,20 @@ public class Controller extends Thread {
 			RepositoryManager.setRepositoryFactory(repositoryFactory);
 			RepositoryManager.setRequestedCheckpoint(Boolean.TRUE);
 
+			if (Bootstrap.isBootstrapRequested()) {
+				LOGGER.info("Bootstrap requested on startup. Applying bootstrap...");
+				try {
+					Bootstrap bootstrap = new Bootstrap();
+					bootstrap.startImport();
+					if (!Controller.isStopping()) {
+						Bootstrap.clearBootstrapRequest();
+					}
+				} catch (InterruptedException e) {
+					LOGGER.error("Interrupted while applying bootstrap", e);
+					return; // Not System.exit() so that GUI can display error
+				}
+			}
+
 			try (final Repository repository = RepositoryManager.getRepository()) {
 				// RepositoryManager.rebuildTransactionSequences(repository);
 				ArbitraryDataCacheManager.getInstance().buildArbitraryResourcesCache(repository, false);

--- a/src/main/java/org/qortal/controller/Controller.java
+++ b/src/main/java/org/qortal/controller/Controller.java
@@ -417,36 +417,6 @@ public class Controller extends Thread {
 				// RepositoryManager.rebuildTransactionSequences(repository);
 				ArbitraryDataCacheManager.getInstance().buildArbitraryResourcesCache(repository, false);
 			}
-
-			if( Settings.getInstance().isDbCacheEnabled() ) {
-				LOGGER.info("Db Cache Starting ...");
-				HSQLDBDataCacheManager hsqldbDataCacheManager = new HSQLDBDataCacheManager();
-				hsqldbDataCacheManager.start();
-			}
-			else {
-				LOGGER.info("Db Cache Disabled");
-			}
-
-			LOGGER.info("Arbitrary Indexing Starting ...");
-			ArbitraryIndexUtils.startCaching(
-				Settings.getInstance().getArbitraryIndexingPriority(),
-				Settings.getInstance().getArbitraryIndexingFrequency()
-			);
-
-			if( Settings.getInstance().isBalanceRecorderEnabled() ) {
-				Optional<HSQLDBBalanceRecorder> recorder = HSQLDBBalanceRecorder.getInstance();
-
-				if( recorder.isPresent() ) {
-					LOGGER.info("Balance Recorder Starting ...");
-					recorder.get().start();
-				}
-				else {
-					LOGGER.info("Balance Recorder won't start.");
-				}
-			}
-			else {
-				LOGGER.info("Balance Recorder Disabled");
-			}
 		} catch (DataException e) {
 			// If exception has no cause or message then repository is in use by some other process.
 			if (e.getCause() == null && e.getMessage() == null) {
@@ -501,6 +471,37 @@ public class Controller extends Thread {
 		} catch (DataException e) {
 			LOGGER.error("Error checking transaction sequences in repository", e);
 			return;
+		}
+
+		// Start cache/indexing timers after validation to avoid repository swaps during bootstrap.
+		if( Settings.getInstance().isDbCacheEnabled() ) {
+			LOGGER.info("Db Cache Starting ...");
+			HSQLDBDataCacheManager hsqldbDataCacheManager = new HSQLDBDataCacheManager();
+			hsqldbDataCacheManager.start();
+		}
+		else {
+			LOGGER.info("Db Cache Disabled");
+		}
+
+		LOGGER.info("Arbitrary Indexing Starting ...");
+		ArbitraryIndexUtils.startCaching(
+			Settings.getInstance().getArbitraryIndexingPriority(),
+			Settings.getInstance().getArbitraryIndexingFrequency()
+		);
+
+		if( Settings.getInstance().isBalanceRecorderEnabled() ) {
+			Optional<HSQLDBBalanceRecorder> recorder = HSQLDBBalanceRecorder.getInstance();
+
+			if( recorder.isPresent() ) {
+				LOGGER.info("Balance Recorder Starting ...");
+				recorder.get().start();
+			}
+			else {
+				LOGGER.info("Balance Recorder won't start.");
+			}
+		}
+		else {
+			LOGGER.info("Balance Recorder Disabled");
 		}
 
 		// Import current trade bot states and minting accounts if they exist


### PR DESCRIPTION
**Overview**
This PR hardens the bootstrap flow so the core no longer deletes `db` while it may still be open, and it prevents cache/index timers from running during repository swaps. The goal is to eliminate startup failures and noisy “No repository available” errors when bootstrapping via the API.

**Changes by Commit**

**59172be53d34b47f843d4fad509cf1101dd4da4b — Wait for parent exit before bootstrap delete**
- `src/main/java/org/qortal/controller/BootstrapNode.java`: appends `--parent-pid <pid>` when launching `ApplyBootstrap` so the child can explicitly wait for the parent process to exit.
- `src/main/java/org/qortal/ApplyBootstrap.java`: parses/strips `--parent-pid`, waits up to 5 minutes for the parent to exit before continuing, and restarts using filtered args. This prevented deleting `db` while the repository might still be open.

**96ab26eb1e8054dc56dadb8973c5e47b8181738a — Defer cache timers until after validation**
- `src/main/java/org/qortal/controller/Controller.java`: moves db cache / arbitrary index / balance recorder startup to after blockchain validation and upgrade checks. This avoids timer tasks firing during bootstrap import when the repository factory is temporarily swapped.

**6b9f3ea1277486d8b3deb73bee49ec4bbe8f9ed7 — Skip cache timers when repository unavailable**
- `src/main/java/org/qortal/repository/hsqldb/HSQLDBCacheUtils.java`: skips cache/balance runs if the repository factory is unavailable and downgrades “No repository available” to debug, preventing noisy errors during bootstrap.
- `src/main/java/org/qortal/utils/ArbitraryIndexUtils.java`: adds the same repository-availability guard and lowers log severity for this specific transient case.

**0ff5762046554fd879c5dc249ab4fce474745a3b — Request bootstrap via marker on restart**
- `src/main/java/org/qortal/ApplyBootstrap.java`: replaces “delete `db` then restart” with creation of a one‑shot bootstrap request marker, then restarts. This avoids unsafe filesystem deletes during shutdown.
- `src/main/java/org/qortal/repository/Bootstrap.java`: owns marker lifecycle (create/check/clear) using `bootstrap.requested` in the parent of the repository path.
- `src/main/java/org/qortal/controller/Controller.java`: checks for the marker immediately after repository factory setup and applies bootstrap before continuing startup, clearing the marker unless the controller is stopping.

**Notes**
- All four commits are additive safety/robustness changes; no functional changes to bootstrap contents or archive selection.
- Tests not run in CI for this PR (manual live validation performed).
