### PR TITLE
Allow same-node Alice tradebot entries for AT offers

### DIFF
--- a/src/main/java/org/qortal/controller/tradebot/TradeBot.java
+++ b/src/main/java/org/qortal/controller/tradebot/TradeBot.java
@@ -218,7 +218,7 @@ public class TradeBot implements Listener {
 		}
 
 		// Check Alice doesn't already have an existing, on-going trade-bot entry for this AT.
-		if (repository.getCrossChainRepository().existsTradeWithAtExcludingStates(atData.getATAddress(), acctTradeBot.getEndStates()))
+		if (repository.getCrossChainRepository().existsAliceTradeWithAtExcludingStates(atData.getATAddress(), acctTradeBot.getEndStates()))
 			return ResponseResult.TRADE_ALREADY_EXISTS;
 
 		return acctTradeBot.startResponse(repository, atData, acct, crossChainTradeData, foreignKey, receivingAddress);
@@ -253,7 +253,7 @@ public class TradeBot implements Listener {
 
 		for( CrossChainTradeData tradeData : crossChainTradeDataList) {
 			// Check Alice doesn't already have an existing, on-going trade-bot entry for this AT.
-			if (repository.getCrossChainRepository().existsTradeWithAtExcludingStates(tradeData.qortalAtAddress, acctTradeBot.getEndStates()))
+			if (repository.getCrossChainRepository().existsAliceTradeWithAtExcludingStates(tradeData.qortalAtAddress, acctTradeBot.getEndStates()))
 				return ResponseResult.TRADE_ALREADY_EXISTS;
 		}
 		return TradeBotUtils.startResponseMultiple(repository, acct, crossChainTradeDataList, receiveAddress, foreignKey, bitcoiny);

--- a/src/main/java/org/qortal/repository/CrossChainRepository.java
+++ b/src/main/java/org/qortal/repository/CrossChainRepository.java
@@ -11,6 +11,9 @@ public interface CrossChainRepository {
 	/** Returns true if there is an existing trade-bot entry relating to given AT address, excluding trade-bot entries with given states. */
 	public boolean existsTradeWithAtExcludingStates(String atAddress, List<String> excludeStates) throws DataException;
 
+	/** Returns true if there is an existing Alice-side trade-bot entry relating to given AT address, excluding trade-bot entries with given states. */
+	public boolean existsAliceTradeWithAtExcludingStates(String atAddress, List<String> excludeStates) throws DataException;
+
 	public List<TradeBotData> getAllTradeBotData() throws DataException;
 
 	public void save(TradeBotData tradeBotData) throws DataException;

--- a/src/test/java/org/qortal/test/CrossChainRepositoryTests.java
+++ b/src/test/java/org/qortal/test/CrossChainRepositoryTests.java
@@ -1,0 +1,84 @@
+package org.qortal.test;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.qortal.account.PublicKeyAccount;
+import org.qortal.controller.tradebot.LitecoinACCTv1TradeBot;
+import org.qortal.controller.tradebot.TradeBot;
+import org.qortal.crosschain.LitecoinACCTv1;
+import org.qortal.crosschain.SupportedBlockchain;
+import org.qortal.crypto.Crypto;
+import org.qortal.data.crosschain.TradeBotData;
+import org.qortal.repository.DataException;
+import org.qortal.repository.Repository;
+import org.qortal.repository.RepositoryManager;
+import org.qortal.test.common.Common;
+import org.qortal.utils.NTP;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CrossChainRepositoryTests extends Common {
+
+	@Before
+	public void beforeTest() throws DataException {
+		Common.useDefaultSettings();
+	}
+
+	@Test
+	public void testExistsAliceTradeWithAtExcludingStates() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			String atAddress = Crypto.toATAddress(new byte[64]);
+			List<String> endStates = LitecoinACCTv1TradeBot.getInstance().getEndStates();
+
+			TradeBotData bobData = buildTradeBotData(repository, atAddress, LitecoinACCTv1TradeBot.State.BOB_WAITING_FOR_AT_CONFIRM);
+			repository.getCrossChainRepository().save(bobData);
+			repository.saveChanges();
+
+			assertFalse(repository.getCrossChainRepository().existsAliceTradeWithAtExcludingStates(atAddress, endStates));
+
+			TradeBotData aliceData = buildTradeBotData(repository, atAddress, LitecoinACCTv1TradeBot.State.ALICE_WAITING_FOR_AT_LOCK);
+			repository.getCrossChainRepository().save(aliceData);
+			repository.saveChanges();
+
+			assertTrue(repository.getCrossChainRepository().existsAliceTradeWithAtExcludingStates(atAddress, endStates));
+
+			aliceData.setState(LitecoinACCTv1TradeBot.State.ALICE_DONE.name());
+			aliceData.setStateValue(LitecoinACCTv1TradeBot.State.ALICE_DONE.value);
+			repository.getCrossChainRepository().save(aliceData);
+			repository.saveChanges();
+
+			assertFalse(repository.getCrossChainRepository().existsAliceTradeWithAtExcludingStates(atAddress, endStates));
+		}
+	}
+
+	private TradeBotData buildTradeBotData(Repository repository, String atAddress, LitecoinACCTv1TradeBot.State state) {
+		byte[] tradePrivateKey = TradeBot.generateTradePrivateKey();
+
+		byte[] tradeNativePublicKey = TradeBot.deriveTradeNativePublicKey(tradePrivateKey);
+		byte[] tradeNativePublicKeyHash = Crypto.hash160(tradeNativePublicKey);
+		String tradeNativeAddress = Crypto.toAddress(tradeNativePublicKey);
+
+		byte[] tradeForeignPublicKey = TradeBot.deriveTradeForeignPublicKey(tradePrivateKey);
+		byte[] tradeForeignPublicKeyHash = Crypto.hash160(tradeForeignPublicKey);
+
+		byte[] creatorPublicKey = new byte[32];
+		PublicKeyAccount creator = new PublicKeyAccount(repository, creatorPublicKey);
+
+		long timestamp = NTP.getTime();
+		long foreignAmount = 1234L;
+		long qortAmount = 5678L;
+		byte[] receivingAccountInfo = new byte[20];
+
+		return new TradeBotData(tradePrivateKey, LitecoinACCTv1.NAME,
+				state.name(), state.value,
+				creator.getAddress(), atAddress, timestamp, qortAmount,
+				tradeNativePublicKey, tradeNativePublicKeyHash, tradeNativeAddress,
+				null, null,
+				SupportedBlockchain.LITECOIN.name(),
+				tradeForeignPublicKey, tradeForeignPublicKeyHash,
+				foreignAmount, null, null, null, receivingAccountInfo);
+	}
+}


### PR DESCRIPTION
## Summary
This fixes the “same-node buy fails for a different local account” bug (https://github.com/Qortal/qortal/issues/292). Today, any local trade-bot entry for an AT blocks a response, so Bob’s offer entry prevents a different account on the same node from accepting the offer. That’s a node-local guard and not account-aware, which is why same-node trades fail.

## Reason for fix
We only need to prevent *multiple* concurrent Alice responses for the same AT. A Bob offer and a single Alice response can coexist safely. Scoping the guard to active ALICE entries preserves the safety invariant while allowing same-node trades.

## Changes
- `src/main/java/org/qortal/repository/CrossChainRepository.java`: add `existsAliceTradeWithAtExcludingStates(...)` to support ALICE-only checks.
- `src/main/java/org/qortal/repository/hsqldb/HSQLDBCrossChainRepository.java`: implement ALICE-only existence query using `trade_state LIKE 'ALICE_%'` while still excluding end states.
- `src/main/java/org/qortal/controller/tradebot/TradeBot.java`: use the ALICE-only guard in `startResponse` and `startResponseMultiple` so Bob’s entry no longer blocks a same-node Alice response.
- `src/test/java/org/qortal/test/CrossChainRepositoryTests.java`: add coverage ensuring Bob-only does not block, active Alice does block, and Alice end-state no longer blocks.

## Tests
- `mvn -q -Dtest=CrossChainRepositoryTests test`
