### PR TITLE
Improve wallet repair with previews, validation, error handling, and multi-coin support

### DIFF
--- a/src/main/java/org/qortal/api/resource/CrossChainBitcoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainBitcoinResource.java
@@ -1,6 +1,7 @@
 package org.qortal.api.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -517,7 +518,10 @@ public class CrossChainBitcoinResource {
 	)
 	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
 	@SecurityRequirement(name = "apiKey")
-	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey,
+			@Parameter(description = "Force repair even if preview does not recommend it", example = "true")
+			@QueryParam("force") Boolean force,
+			String key58) {
 		Security.checkApiCallAllowed(request);
 
 		Bitcoin bitcoin = Bitcoin.getInstance();

--- a/src/main/java/org/qortal/api/resource/CrossChainDigibyteResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainDigibyteResource.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Transaction;
 import org.qortal.api.ApiError;
 import org.qortal.api.ApiErrors;
@@ -20,6 +21,7 @@ import org.qortal.crosschain.ChainableServer;
 import org.qortal.crosschain.ElectrumX;
 import org.qortal.crosschain.ForeignBlockchainException;
 import org.qortal.crosschain.Digibyte;
+import org.qortal.crosschain.RepairWalletPreview;
 import org.qortal.crosschain.ServerConnectionInfo;
 import org.qortal.crosschain.ServerInfo;
 import org.qortal.crosschain.SimpleTransaction;
@@ -30,6 +32,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
@@ -448,6 +451,92 @@ public class CrossChainDigibyteResource {
 					false,
 					System.currentTimeMillis(),
 					CrossChainUtils.getNotes(e));
+		}
+	}
+
+	@POST
+	@Path("/repair/preview")
+	@Operation(
+			summary = "Previews wallet repair sweep",
+			description = "Supply BIP32 'm' private/public key in base58, starting with 'xprv'/'xpub' for mainnet, 'tprv'/'tpub' for testnet",
+			requestBody = @RequestBody(
+					required = true,
+					content = @Content(
+							mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(
+									type = "string",
+									description = "BIP32 'm' private/public key in base58",
+									example = "tpubD6NzVbkrYhZ4XTPc4btCZ6SMgn8CxmWkj6VBVZ1tfcJfMq4UwAjZbG8U74gGSypL9XBYk2R2BLbDBe8pcEyBKM1edsGQEPKXNbEskZozeZc"
+							)
+					)
+			),
+			responses = {
+					@ApiResponse(
+							content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = RepairWalletPreview.class))
+					)
+			}
+	)
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@SecurityRequirement(name = "apiKey")
+	public RepairWalletPreview previewRepairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, String key58) {
+		Security.checkApiCallAllowed(request);
+
+		Digibyte digibyte = Digibyte.getInstance();
+
+		if (!digibyte.isValidDeterministicKey(key58))
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
+
+		try {
+			return digibyte.previewRepairOldWallet(key58);
+		} catch (ForeignBlockchainException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
+		}
+	}
+
+	@POST
+	@Path("/repair")
+	@Operation(
+			summary = "Sends all coins in wallet to primary receive address",
+			description = "Supply BIP32 'm' private key in base58, starting with 'xprv' for mainnet, 'tprv' for testnet. If repair is not recommended, set force=true to override.",
+			requestBody = @RequestBody(
+					required = true,
+					content = @Content(
+							mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(
+									type = "string",
+									description = "BIP32 'm' private key in base58",
+									example = "tprv8ZgxMBicQKsPdahhFSrCdvC1bsWyzHHZfTneTVqUXN6s1wEtZLwAkZXzFP6TYLg2aQMecZLXLre5bTVGajEB55L1HYJcawpdFG66STVAWPJ"
+							)
+					)
+			),
+			responses = {
+					@ApiResponse(
+							content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string", description = "transaction hash"))
+					)
+			}
+	)
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@SecurityRequirement(name = "apiKey")
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+		Security.checkApiCallAllowed(request);
+
+		Digibyte digibyte = Digibyte.getInstance();
+
+		if (!digibyte.isValidDeterministicPrivateKey(key58))
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
+
+		try {
+			if (force == null || !force) {
+				RepairWalletPreview preview = digibyte.previewRepairOldWallet(key58);
+				if (!preview.isRepairRecommended())
+					throw ApiExceptionFactory.INSTANCE.createCustomException(request, ApiError.INVALID_CRITERIA, "Repair not recommended; use force=true to override");
+			}
+
+			return digibyte.repairOldWallet(key58);
+		} catch (InsufficientMoneyException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE);
+		} catch (ForeignBlockchainException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
 		}
 	}
 

--- a/src/main/java/org/qortal/api/resource/CrossChainDigibyteResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainDigibyteResource.java
@@ -1,6 +1,7 @@
 package org.qortal.api.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -517,7 +518,10 @@ public class CrossChainDigibyteResource {
 	)
 	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
 	@SecurityRequirement(name = "apiKey")
-	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey,
+			@Parameter(description = "Force repair even if preview does not recommend it", example = "true")
+			@QueryParam("force") Boolean force,
+			String key58) {
 		Security.checkApiCallAllowed(request);
 
 		Digibyte digibyte = Digibyte.getInstance();

--- a/src/main/java/org/qortal/api/resource/CrossChainDogecoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainDogecoinResource.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Transaction;
 import org.qortal.api.ApiError;
 import org.qortal.api.ApiErrors;
@@ -20,6 +21,7 @@ import org.qortal.crosschain.ChainableServer;
 import org.qortal.crosschain.ElectrumX;
 import org.qortal.crosschain.ForeignBlockchainException;
 import org.qortal.crosschain.Dogecoin;
+import org.qortal.crosschain.RepairWalletPreview;
 import org.qortal.crosschain.ServerConnectionInfo;
 import org.qortal.crosschain.ServerInfo;
 import org.qortal.crosschain.SimpleTransaction;
@@ -30,6 +32,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
@@ -448,6 +451,92 @@ public class CrossChainDogecoinResource {
 					false,
 					System.currentTimeMillis(),
 					CrossChainUtils.getNotes(e));
+		}
+	}
+
+	@POST
+	@Path("/repair/preview")
+	@Operation(
+			summary = "Previews wallet repair sweep",
+			description = "Supply BIP32 'm' private/public key in base58, starting with 'xprv'/'xpub' for mainnet, 'tprv'/'tpub' for testnet",
+			requestBody = @RequestBody(
+					required = true,
+					content = @Content(
+							mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(
+									type = "string",
+									description = "BIP32 'm' private/public key in base58",
+									example = "tpubD6NzVbkrYhZ4XTPc4btCZ6SMgn8CxmWkj6VBVZ1tfcJfMq4UwAjZbG8U74gGSypL9XBYk2R2BLbDBe8pcEyBKM1edsGQEPKXNbEskZozeZc"
+							)
+					)
+			),
+			responses = {
+					@ApiResponse(
+							content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = RepairWalletPreview.class))
+					)
+			}
+	)
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@SecurityRequirement(name = "apiKey")
+	public RepairWalletPreview previewRepairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, String key58) {
+		Security.checkApiCallAllowed(request);
+
+		Dogecoin dogecoin = Dogecoin.getInstance();
+
+		if (!dogecoin.isValidDeterministicKey(key58))
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
+
+		try {
+			return dogecoin.previewRepairOldWallet(key58);
+		} catch (ForeignBlockchainException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
+		}
+	}
+
+	@POST
+	@Path("/repair")
+	@Operation(
+			summary = "Sends all coins in wallet to primary receive address",
+			description = "Supply BIP32 'm' private key in base58, starting with 'xprv' for mainnet, 'tprv' for testnet. If repair is not recommended, set force=true to override.",
+			requestBody = @RequestBody(
+					required = true,
+					content = @Content(
+							mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(
+									type = "string",
+									description = "BIP32 'm' private key in base58",
+									example = "tprv8ZgxMBicQKsPdahhFSrCdvC1bsWyzHHZfTneTVqUXN6s1wEtZLwAkZXzFP6TYLg2aQMecZLXLre5bTVGajEB55L1HYJcawpdFG66STVAWPJ"
+							)
+					)
+			),
+			responses = {
+					@ApiResponse(
+							content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string", description = "transaction hash"))
+					)
+			}
+	)
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@SecurityRequirement(name = "apiKey")
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+		Security.checkApiCallAllowed(request);
+
+		Dogecoin dogecoin = Dogecoin.getInstance();
+
+		if (!dogecoin.isValidDeterministicPrivateKey(key58))
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
+
+		try {
+			if (force == null || !force) {
+				RepairWalletPreview preview = dogecoin.previewRepairOldWallet(key58);
+				if (!preview.isRepairRecommended())
+					throw ApiExceptionFactory.INSTANCE.createCustomException(request, ApiError.INVALID_CRITERIA, "Repair not recommended; use force=true to override");
+			}
+
+			return dogecoin.repairOldWallet(key58);
+		} catch (InsufficientMoneyException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE);
+		} catch (ForeignBlockchainException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
 		}
 	}
 

--- a/src/main/java/org/qortal/api/resource/CrossChainDogecoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainDogecoinResource.java
@@ -1,6 +1,7 @@
 package org.qortal.api.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -517,7 +518,10 @@ public class CrossChainDogecoinResource {
 	)
 	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
 	@SecurityRequirement(name = "apiKey")
-	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey,
+			@Parameter(description = "Force repair even if preview does not recommend it", example = "true")
+			@QueryParam("force") Boolean force,
+			String key58) {
 		Security.checkApiCallAllowed(request);
 
 		Dogecoin dogecoin = Dogecoin.getInstance();

--- a/src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java
@@ -1,6 +1,7 @@
 package org.qortal.api.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -523,7 +524,10 @@ public class CrossChainLitecoinResource {
 	)
 	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
 	@SecurityRequirement(name = "apiKey")
-	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey,
+			@Parameter(description = "Force repair even if preview does not recommend it", example = "true")
+			@QueryParam("force") Boolean force,
+			String key58) {
 		Security.checkApiCallAllowed(request);
 
 		Litecoin litecoin = Litecoin.getInstance();

--- a/src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Transaction;
 import org.qortal.api.ApiError;
 import org.qortal.api.ApiErrors;
@@ -479,7 +480,7 @@ public class CrossChainLitecoinResource {
 					)
 			}
 	)
-	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
 	@SecurityRequirement(name = "apiKey")
 	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, String key58) {
 		Security.checkApiCallAllowed(request);
@@ -491,6 +492,8 @@ public class CrossChainLitecoinResource {
 
 		try {
 			return litecoin.repairOldWallet(key58);
+		} catch (InsufficientMoneyException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE);
 		} catch (ForeignBlockchainException e) {
 			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
 		}

--- a/src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java
@@ -461,15 +461,15 @@ public class CrossChainLitecoinResource {
 	@Path("/repair")
 	@Operation(
 			summary = "Sends all coins in wallet to primary receive address",
-			description = "Supply BIP32 'm' private/public key in base58, starting with 'xprv'/'xpub' for mainnet, 'tprv'/'tpub' for testnet",
+			description = "Supply BIP32 'm' private key in base58, starting with 'xprv' for mainnet, 'tprv' for testnet",
 			requestBody = @RequestBody(
 					required = true,
 					content = @Content(
 							mediaType = MediaType.TEXT_PLAIN,
 							schema = @Schema(
 									type = "string",
-									description = "BIP32 'm' private/public key in base58",
-									example = "tpubD6NzVbkrYhZ4XTPc4btCZ6SMgn8CxmWkj6VBVZ1tfcJfMq4UwAjZbG8U74gGSypL9XBYk2R2BLbDBe8pcEyBKM1edsGQEPKXNbEskZozeZc"
+									description = "BIP32 'm' private key in base58",
+									example = "tprv8ZgxMBicQKsPdahhFSrCdvC1bsWyzHHZfTneTVqUXN6s1wEtZLwAkZXzFP6TYLg2aQMecZLXLre5bTVGajEB55L1HYJcawpdFG66STVAWPJ"
 							)
 					)
 			),
@@ -486,7 +486,7 @@ public class CrossChainLitecoinResource {
 
 		Litecoin litecoin = Litecoin.getInstance();
 
-		if (!litecoin.isValidDeterministicKey(key58))
+		if (!litecoin.isValidDeterministicPrivateKey(key58))
 			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
 
 		try {

--- a/src/main/java/org/qortal/api/resource/CrossChainRavencoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainRavencoinResource.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Transaction;
 import org.qortal.api.ApiError;
 import org.qortal.api.ApiErrors;
@@ -20,6 +21,7 @@ import org.qortal.crosschain.ChainableServer;
 import org.qortal.crosschain.ElectrumX;
 import org.qortal.crosschain.ForeignBlockchainException;
 import org.qortal.crosschain.Ravencoin;
+import org.qortal.crosschain.RepairWalletPreview;
 import org.qortal.crosschain.ServerConnectionInfo;
 import org.qortal.crosschain.ServerInfo;
 import org.qortal.crosschain.SimpleTransaction;
@@ -30,6 +32,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
@@ -448,6 +451,92 @@ public class CrossChainRavencoinResource {
 					false,
 					System.currentTimeMillis(),
 					CrossChainUtils.getNotes(e));
+		}
+	}
+
+	@POST
+	@Path("/repair/preview")
+	@Operation(
+			summary = "Previews wallet repair sweep",
+			description = "Supply BIP32 'm' private/public key in base58, starting with 'xprv'/'xpub' for mainnet, 'tprv'/'tpub' for testnet",
+			requestBody = @RequestBody(
+					required = true,
+					content = @Content(
+							mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(
+									type = "string",
+									description = "BIP32 'm' private/public key in base58",
+									example = "tpubD6NzVbkrYhZ4XTPc4btCZ6SMgn8CxmWkj6VBVZ1tfcJfMq4UwAjZbG8U74gGSypL9XBYk2R2BLbDBe8pcEyBKM1edsGQEPKXNbEskZozeZc"
+							)
+					)
+			),
+			responses = {
+					@ApiResponse(
+							content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = RepairWalletPreview.class))
+					)
+			}
+	)
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@SecurityRequirement(name = "apiKey")
+	public RepairWalletPreview previewRepairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, String key58) {
+		Security.checkApiCallAllowed(request);
+
+		Ravencoin ravencoin = Ravencoin.getInstance();
+
+		if (!ravencoin.isValidDeterministicKey(key58))
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
+
+		try {
+			return ravencoin.previewRepairOldWallet(key58);
+		} catch (ForeignBlockchainException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
+		}
+	}
+
+	@POST
+	@Path("/repair")
+	@Operation(
+			summary = "Sends all coins in wallet to primary receive address",
+			description = "Supply BIP32 'm' private key in base58, starting with 'xprv' for mainnet, 'tprv' for testnet. If repair is not recommended, set force=true to override.",
+			requestBody = @RequestBody(
+					required = true,
+					content = @Content(
+							mediaType = MediaType.TEXT_PLAIN,
+							schema = @Schema(
+									type = "string",
+									description = "BIP32 'm' private key in base58",
+									example = "tprv8ZgxMBicQKsPdahhFSrCdvC1bsWyzHHZfTneTVqUXN6s1wEtZLwAkZXzFP6TYLg2aQMecZLXLre5bTVGajEB55L1HYJcawpdFG66STVAWPJ"
+							)
+					)
+			),
+			responses = {
+					@ApiResponse(
+							content = @Content(mediaType = MediaType.TEXT_PLAIN, schema = @Schema(type = "string", description = "transaction hash"))
+					)
+			}
+	)
+	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
+	@SecurityRequirement(name = "apiKey")
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+		Security.checkApiCallAllowed(request);
+
+		Ravencoin ravencoin = Ravencoin.getInstance();
+
+		if (!ravencoin.isValidDeterministicPrivateKey(key58))
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_PRIVATE_KEY);
+
+		try {
+			if (force == null || !force) {
+				RepairWalletPreview preview = ravencoin.previewRepairOldWallet(key58);
+				if (!preview.isRepairRecommended())
+					throw ApiExceptionFactory.INSTANCE.createCustomException(request, ApiError.INVALID_CRITERIA, "Repair not recommended; use force=true to override");
+			}
+
+			return ravencoin.repairOldWallet(key58);
+		} catch (InsufficientMoneyException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE);
+		} catch (ForeignBlockchainException e) {
+			throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE);
 		}
 	}
 

--- a/src/main/java/org/qortal/api/resource/CrossChainRavencoinResource.java
+++ b/src/main/java/org/qortal/api/resource/CrossChainRavencoinResource.java
@@ -1,6 +1,7 @@
 package org.qortal.api.resource;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -517,7 +518,10 @@ public class CrossChainRavencoinResource {
 	)
 	@ApiErrors({ApiError.INVALID_PRIVATE_KEY, ApiError.INVALID_CRITERIA, ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, ApiError.FOREIGN_BLOCKCHAIN_NETWORK_ISSUE})
 	@SecurityRequirement(name = "apiKey")
-	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey, @QueryParam("force") Boolean force, String key58) {
+	public String repairOldWallet(@HeaderParam(Security.API_KEY_HEADER) String apiKey,
+			@Parameter(description = "Force repair even if preview does not recommend it", example = "true")
+			@QueryParam("force") Boolean force,
+			String key58) {
 		Security.checkApiCallAllowed(request);
 
 		Ravencoin ravencoin = Ravencoin.getInstance();

--- a/src/main/java/org/qortal/crosschain/Bitcoiny.java
+++ b/src/main/java/org/qortal/crosschain/Bitcoiny.java
@@ -143,6 +143,16 @@ public abstract class Bitcoiny implements ForeignBlockchain {
 		}
 	}
 
+	public boolean isValidDeterministicPrivateKey(String key58) {
+		try {
+			Context.propagate(this.bitcoinjContext);
+			DeterministicKey key = DeterministicKey.deserializeB58(null, key58, this.params);
+			return key.hasPrivKey();
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+
 	/** Returns P2PKH address using passed public key hash. */
 	public String pkhToAddress(byte[] publicKeyHash) {
 		Context.propagate(this.bitcoinjContext);

--- a/src/main/java/org/qortal/crosschain/Bitcoiny.java
+++ b/src/main/java/org/qortal/crosschain/Bitcoiny.java
@@ -1644,12 +1644,12 @@ private Set<String> processKeysIterative(ExecutorService executor, Deterministic
 	 *
 	 * @param privateMasterKey
 	 *
-	 * @return the transaction Id of the spend operation that moves the balances or the exception name if an exception
-	 * is thrown
+	 * @return the transaction Id of the spend operation that moves the balances
 	 *
 	 * @throws ForeignBlockchainException
+	 * @throws InsufficientMoneyException
 	 */
-	public String repairOldWallet(String privateMasterKey) throws ForeignBlockchainException {
+	public String repairOldWallet(String privateMasterKey) throws ForeignBlockchainException, InsufficientMoneyException {
 
 		// create a deterministic wallet to satisfy the bitcoinj API
 		Wallet wallet = Wallet.createDeterministic(this.bitcoinjContext, ScriptType.P2PKH);
@@ -1679,10 +1679,13 @@ private Set<String> processKeysIterative(ExecutorService executor, Deterministic
 			// return the transaction Id
 			return sendRequest.tx.getTxId().toString();
 		}
-		catch( Exception e ) {
-			// log error and return exception name
-			LOGGER.error(e.getMessage(), e);
-			return e.getClass().getSimpleName();
+		catch (InsufficientMoneyException e) {
+			LOGGER.warn("Unable to repair wallet due to insufficient funds", e);
+			throw e;
+		}
+		catch (Exception e) {
+			LOGGER.error("Failed to repair wallet", e);
+			throw new ForeignBlockchainException("Unable to repair wallet", e);
 		}
 	}
 }

--- a/src/main/java/org/qortal/crosschain/ForeignBlockchainException.java
+++ b/src/main/java/org/qortal/crosschain/ForeignBlockchainException.java
@@ -11,6 +11,10 @@ public class ForeignBlockchainException extends Exception {
 		super(message);
 	}
 
+	public ForeignBlockchainException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
 	public static class NetworkException extends ForeignBlockchainException {
 		private final Integer daemonErrorCode;
 		private final transient Object server;

--- a/src/main/java/org/qortal/crosschain/RepairWalletPreview.java
+++ b/src/main/java/org/qortal/crosschain/RepairWalletPreview.java
@@ -1,0 +1,114 @@
+package org.qortal.crosschain;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import java.util.Objects;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RepairWalletPreview {
+	private long oldBalance;
+	private long currentBalance;
+	private long missingBalance;
+	private long estimatedFee;
+	private long dustThreshold;
+	private boolean repairRecommended;
+	private int addressCountOld;
+	private int addressCountCurrent;
+	private int missingUtxoCount;
+
+	public RepairWalletPreview() {
+	}
+
+	public RepairWalletPreview(
+			long oldBalance,
+			long currentBalance,
+			long missingBalance,
+			long estimatedFee,
+			long dustThreshold,
+			boolean repairRecommended,
+			int addressCountOld,
+			int addressCountCurrent,
+			int missingUtxoCount) {
+		this.oldBalance = oldBalance;
+		this.currentBalance = currentBalance;
+		this.missingBalance = missingBalance;
+		this.estimatedFee = estimatedFee;
+		this.dustThreshold = dustThreshold;
+		this.repairRecommended = repairRecommended;
+		this.addressCountOld = addressCountOld;
+		this.addressCountCurrent = addressCountCurrent;
+		this.missingUtxoCount = missingUtxoCount;
+	}
+
+	public long getOldBalance() {
+		return oldBalance;
+	}
+
+	public long getCurrentBalance() {
+		return currentBalance;
+	}
+
+	public long getMissingBalance() {
+		return missingBalance;
+	}
+
+	public long getEstimatedFee() {
+		return estimatedFee;
+	}
+
+	public long getDustThreshold() {
+		return dustThreshold;
+	}
+
+	public boolean isRepairRecommended() {
+		return repairRecommended;
+	}
+
+	public int getAddressCountOld() {
+		return addressCountOld;
+	}
+
+	public int getAddressCountCurrent() {
+		return addressCountCurrent;
+	}
+
+	public int getMissingUtxoCount() {
+		return missingUtxoCount;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		RepairWalletPreview that = (RepairWalletPreview) o;
+		return oldBalance == that.oldBalance
+				&& currentBalance == that.currentBalance
+				&& missingBalance == that.missingBalance
+				&& estimatedFee == that.estimatedFee
+				&& dustThreshold == that.dustThreshold
+				&& repairRecommended == that.repairRecommended
+				&& addressCountOld == that.addressCountOld
+				&& addressCountCurrent == that.addressCountCurrent
+				&& missingUtxoCount == that.missingUtxoCount;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(oldBalance, currentBalance, missingBalance, estimatedFee, dustThreshold, repairRecommended, addressCountOld, addressCountCurrent, missingUtxoCount);
+	}
+
+	@Override
+	public String toString() {
+		return "RepairWalletPreview{" +
+				"oldBalance=" + oldBalance +
+				", currentBalance=" + currentBalance +
+				", missingBalance=" + missingBalance +
+				", estimatedFee=" + estimatedFee +
+				", dustThreshold=" + dustThreshold +
+				", repairRecommended=" + repairRecommended +
+				", addressCountOld=" + addressCountOld +
+				", addressCountCurrent=" + addressCountCurrent +
+				", missingUtxoCount=" + missingUtxoCount +
+				'}';
+	}
+}

--- a/src/test/java/org/qortal/test/api/CrossChainRepairApiTests.java
+++ b/src/test/java/org/qortal/test/api/CrossChainRepairApiTests.java
@@ -1,0 +1,279 @@
+package org.qortal.test.api;
+
+import cash.z.wallet.sdk.rpc.CompactFormats.CompactBlock;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.qortal.api.ApiError;
+import org.qortal.api.ApiException;
+import org.qortal.api.resource.CrossChainBitcoinResource;
+import org.qortal.api.resource.CrossChainDigibyteResource;
+import org.qortal.api.resource.CrossChainDogecoinResource;
+import org.qortal.api.resource.CrossChainLitecoinResource;
+import org.qortal.api.resource.CrossChainRavencoinResource;
+import org.qortal.crosschain.*;
+import org.qortal.settings.Settings;
+import org.qortal.test.common.ApiCommon;
+import org.qortal.test.common.Common;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CrossChainRepairApiTests extends ApiCommon {
+
+	private static final String BITCOIN_XPRV = "tprv8ZgxMBicQKsPdahhFSrCdvC1bsWyzHHZfTneTVqUXN6s1wEtZLwAkZXzFP6TYLg2aQMecZLXLre5bTVGajEB55L1HYJcawpdFG66STVAWPJ";
+	private static final String BITCOIN_XPUB = "tpubDCxs3oB9X7XJYkQGU6gfPwd4h3NEiBGA8mfD1aEbZiG5x3BTH4cJqszDP6dtoHPPjZNEj5jPxuSWHCvjg9AHz4dNg6w5vQhv1B8KwWKpxoz";
+	private static final String LITECOIN_XPRV = "tprv8ZgxMBicQKsPdahhFSrCdvC1bsWyzHHZfTneTVqUXN6s1wEtZLwAkZXzFP6TYLg2aQMecZLXLre5bTVGajEB55L1HYJcawpdFG66STVAWPJ";
+	private static final String LITECOIN_XPUB = "tpubDCxs3oB9X7XJYkQGU6gfPwd4h3NEiBGA8mfD1aEbZiG5x3BTH4cJqszDP6dtoHPPjZNEj5jPxuSWHCvjg9AHz4dNg6w5vQhv1B8KwWKpxoz";
+	private static final String DOGECOIN_XPRV = "dgpv51eADS3spNJh9drNeW1Tc1P9z2LyaQRXPBortsq6yice1k47C2u2Prvgxycr2ihNBWzKZ2LthcBBGiYkWZ69KUTVkcLVbnjq7pD8mnApEru";
+	private static final String DOGECOIN_XPUB = "dgub8rqf3khHiPeYE3cNn3Y4DQQ411nAnFpuSUPt5k5GJZQsydsTLkaf4onaWn4N8pHvrV3oNMEATKoPGTFZwm2Uhh7Dy9gYwA7rkSv6oLofbag";
+	private static final String DIGIBYTE_XPRV = "xprv9z8QpS7vxwMC2fCnG1oZc6c4aFRLgsqSF86yWrJBKEzMY3T3ySCo85x8Uv5FxTavAQwgEDy1g3iLRT5kdtFjoNNBKukLTMzKwCUn1Abwoxg";
+	private static final String DIGIBYTE_XPUB = "xpub6D7mDwepoJuVF9HFN3LZyEYo8HFq6LZHcM2aKEhnsaXLQqnCWyX3ftGcLDcjYmiPCc9GNX4VjfT32hwvYQnh9H5Z5diAvMsXRrxFmckyNoR";
+	private static final String RAVENCOIN_XPRV = "xprv9z8QpS7vxwMC2fCnG1oZc6c4aFRLgsqSF86yWrJBKEzMY3T3ySCo85x8Uv5FxTavAQwgEDy1g3iLRT5kdtFjoNNBKukLTMzKwCUn1Abwoxg";
+	private static final String RAVENCOIN_XPUB = "xpub6D7mDwepoJuVF9HFN3LZyEYo8HFq6LZHcM2aKEhnsaXLQqnCWyX3ftGcLDcjYmiPCc9GNX4VjfT32hwvYQnh9H5Z5diAvMsXRrxFmckyNoR";
+
+	private CrossChainBitcoinResource bitcoinResource;
+	private CrossChainLitecoinResource litecoinResource;
+	private CrossChainDogecoinResource dogecoinResource;
+	private CrossChainDigibyteResource digibyteResource;
+	private CrossChainRavencoinResource ravencoinResource;
+
+	private BitcoinyBlockchainProvider bitcoinProviderOriginal;
+	private BitcoinyBlockchainProvider litecoinProviderOriginal;
+	private BitcoinyBlockchainProvider dogecoinProviderOriginal;
+	private BitcoinyBlockchainProvider digibyteProviderOriginal;
+	private BitcoinyBlockchainProvider ravencoinProviderOriginal;
+	private boolean localAuthBypassOriginal;
+
+	@Before
+	public void beforeTest() throws Exception {
+		Common.useDefaultSettings();
+
+		localAuthBypassOriginal = Settings.getInstance().isLocalAuthBypassEnabled();
+		FieldUtils.writeField(Settings.getInstance(), "localAuthBypassEnabled", true, true);
+
+		this.bitcoinResource = (CrossChainBitcoinResource) ApiCommon.buildResource(CrossChainBitcoinResource.class);
+		this.litecoinResource = (CrossChainLitecoinResource) ApiCommon.buildResource(CrossChainLitecoinResource.class);
+		this.dogecoinResource = (CrossChainDogecoinResource) ApiCommon.buildResource(CrossChainDogecoinResource.class);
+		this.digibyteResource = (CrossChainDigibyteResource) ApiCommon.buildResource(CrossChainDigibyteResource.class);
+		this.ravencoinResource = (CrossChainRavencoinResource) ApiCommon.buildResource(CrossChainRavencoinResource.class);
+
+		bitcoinProviderOriginal = installDummyProvider(Bitcoin.getInstance(), "Bitcoin-TEST");
+		litecoinProviderOriginal = installDummyProvider(Litecoin.getInstance(), "Litecoin-TEST");
+		dogecoinProviderOriginal = installDummyProvider(Dogecoin.getInstance(), "Dogecoin-TEST");
+		digibyteProviderOriginal = installDummyProvider(Digibyte.getInstance(), "Digibyte-TEST");
+		ravencoinProviderOriginal = installDummyProvider(Ravencoin.getInstance(), "Ravencoin-TEST");
+	}
+
+	@After
+	public void afterTest() throws Exception {
+		restoreProvider(Bitcoin.getInstance(), bitcoinProviderOriginal);
+		restoreProvider(Litecoin.getInstance(), litecoinProviderOriginal);
+		restoreProvider(Dogecoin.getInstance(), dogecoinProviderOriginal);
+		restoreProvider(Digibyte.getInstance(), digibyteProviderOriginal);
+		restoreProvider(Ravencoin.getInstance(), ravencoinProviderOriginal);
+
+		FieldUtils.writeField(Settings.getInstance(), "localAuthBypassEnabled", localAuthBypassOriginal, true);
+	}
+
+	@Test
+	public void testRepairPreviewEndpoints() {
+		assertPreview(bitcoinResource.previewRepairOldWallet(null, BITCOIN_XPUB));
+		assertPreview(litecoinResource.previewRepairOldWallet(null, LITECOIN_XPUB));
+		assertPreview(dogecoinResource.previewRepairOldWallet(null, DOGECOIN_XPUB));
+		assertPreview(digibyteResource.previewRepairOldWallet(null, DIGIBYTE_XPUB));
+		assertPreview(ravencoinResource.previewRepairOldWallet(null, RAVENCOIN_XPUB));
+	}
+
+	@Test
+	public void testRepairRequiresForceWhenNotRecommended() {
+		assertApiError(ApiError.INVALID_CRITERIA, () -> bitcoinResource.repairOldWallet(null, null, BITCOIN_XPRV));
+		assertApiError(ApiError.INVALID_CRITERIA, () -> litecoinResource.repairOldWallet(null, null, LITECOIN_XPRV));
+		assertApiError(ApiError.INVALID_CRITERIA, () -> dogecoinResource.repairOldWallet(null, null, DOGECOIN_XPRV));
+		assertApiError(ApiError.INVALID_CRITERIA, () -> digibyteResource.repairOldWallet(null, null, DIGIBYTE_XPRV));
+		assertApiError(ApiError.INVALID_CRITERIA, () -> ravencoinResource.repairOldWallet(null, null, RAVENCOIN_XPRV));
+	}
+
+	@Test
+	public void testRepairForceBypassesRecommendation() {
+		assertApiError(ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, () -> bitcoinResource.repairOldWallet(null, true, BITCOIN_XPRV));
+		assertApiError(ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, () -> litecoinResource.repairOldWallet(null, true, LITECOIN_XPRV));
+		assertApiError(ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, () -> dogecoinResource.repairOldWallet(null, true, DOGECOIN_XPRV));
+		assertApiError(ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, () -> digibyteResource.repairOldWallet(null, true, DIGIBYTE_XPRV));
+		assertApiError(ApiError.FOREIGN_BLOCKCHAIN_BALANCE_ISSUE, () -> ravencoinResource.repairOldWallet(null, true, RAVENCOIN_XPRV));
+	}
+
+	private void assertPreview(RepairWalletPreview preview) {
+		assertNotNull(preview);
+		assertFalse(preview.isRepairRecommended());
+		assertTrue(preview.getOldBalance() >= 0L);
+		assertTrue(preview.getCurrentBalance() >= 0L);
+		assertTrue(preview.getMissingBalance() >= 0L);
+		assertTrue(preview.getEstimatedFee() >= 0L);
+		assertTrue(preview.getDustThreshold() >= 0L);
+		assertTrue(preview.getAddressCountOld() > 0);
+		assertTrue(preview.getAddressCountCurrent() > 0);
+		assertTrue(preview.getMissingUtxoCount() >= 0);
+	}
+
+	private void assertApiError(ApiError expectedApiError, Runnable apiCall) {
+		try {
+			apiCall.run();
+			fail("Expected ApiException");
+		} catch (ApiException e) {
+			ApiError actualApiError = ApiError.fromCode(e.error);
+			assertEquals(expectedApiError, actualApiError);
+		}
+	}
+
+	private BitcoinyBlockchainProvider installDummyProvider(Bitcoiny bitcoiny, String netId) throws IllegalAccessException {
+		BitcoinyBlockchainProvider original = bitcoiny.getBlockchainProvider();
+		DummyBitcoinyProvider dummyProvider = new DummyBitcoinyProvider(netId);
+		dummyProvider.setBlockchain(bitcoiny);
+		FieldUtils.writeField(bitcoiny, "blockchainProvider", dummyProvider, true);
+		return original;
+	}
+
+	private void restoreProvider(Bitcoiny bitcoiny, BitcoinyBlockchainProvider original) throws IllegalAccessException {
+		if (original == null)
+			return;
+
+		original.setBlockchain(bitcoiny);
+		FieldUtils.writeField(bitcoiny, "blockchainProvider", original, true);
+	}
+
+	private static class DummyBitcoinyProvider extends BitcoinyBlockchainProvider {
+		private final String netId;
+
+		private DummyBitcoinyProvider(String netId) {
+			this.netId = netId;
+		}
+
+		@Override
+		public void setBlockchain(Bitcoiny blockchain) {
+		}
+
+		@Override
+		public String getNetId() {
+			return this.netId;
+		}
+
+		@Override
+		public int getCurrentHeight() {
+			return 0;
+		}
+
+		@Override
+		public List<CompactBlock> getCompactBlocks(int startHeight, int count) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<byte[]> getRawBlockHeaders(int startHeight, int count) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<Long> getBlockTimestamps(int startHeight, int count) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public long getConfirmedBalance(byte[] scriptPubKey) {
+			return 0L;
+		}
+
+		@Override
+		public long getConfirmedAddressBalance(String base58Address) {
+			return 0L;
+		}
+
+		@Override
+		public byte[] getRawTransaction(String txHash) {
+			return new byte[0];
+		}
+
+		@Override
+		public byte[] getRawTransaction(byte[] txHash) {
+			return new byte[0];
+		}
+
+		@Override
+		public BitcoinyTransaction getTransaction(String txHash) {
+			return new BitcoinyTransaction(txHash, 0, 0, null, Collections.emptyList(), Collections.emptyList());
+		}
+
+		@Override
+		public List<TransactionHash> getAddressTransactions(byte[] scriptPubKey, boolean includeUnconfirmed) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<BitcoinyTransaction> getAddressBitcoinyTransactions(String address, boolean includeUnconfirmed) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<UnspentOutput> getUnspentOutputs(String address, boolean includeUnconfirmed) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public List<UnspentOutput> getUnspentOutputs(byte[] scriptPubKey, boolean includeUnconfirmed) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public void broadcastTransaction(byte[] rawTransaction) {
+		}
+
+		@Override
+		public Set<ChainableServer> getServers() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public Set<ChainableServer> getUselessServers() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public ChainableServer getCurrentServer() {
+			return null;
+		}
+
+		@Override
+		public boolean addServer(ChainableServer server) {
+			return false;
+		}
+
+		@Override
+		public boolean removeServer(ChainableServer server) {
+			return false;
+		}
+
+		@Override
+		public Optional<ChainableServerConnection> setCurrentServer(ChainableServer server, String requestedBy) {
+			return Optional.empty();
+		}
+
+		@Override
+		public List<ChainableServerConnection> getServerConnections() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public ChainableServer getServer(String hostName, ChainableServer.ConnectionType type, int port) {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/qortal/test/api/CrossChainRepairApiTests.java
+++ b/src/test/java/org/qortal/test/api/CrossChainRepairApiTests.java
@@ -6,7 +6,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.qortal.api.ApiError;
-import org.qortal.api.ApiException;
 import org.qortal.api.resource.CrossChainBitcoinResource;
 import org.qortal.api.resource.CrossChainDigibyteResource;
 import org.qortal.api.resource.CrossChainDogecoinResource;
@@ -23,10 +22,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class CrossChainRepairApiTests extends ApiCommon {
 
@@ -123,16 +120,6 @@ public class CrossChainRepairApiTests extends ApiCommon {
 		assertTrue(preview.getAddressCountOld() > 0);
 		assertTrue(preview.getAddressCountCurrent() > 0);
 		assertTrue(preview.getMissingUtxoCount() >= 0);
-	}
-
-	private void assertApiError(ApiError expectedApiError, Runnable apiCall) {
-		try {
-			apiCall.run();
-			fail("Expected ApiException");
-		} catch (ApiException e) {
-			ApiError actualApiError = ApiError.fromCode(e.error);
-			assertEquals(expectedApiError, actualApiError);
-		}
 	}
 
 	private BitcoinyBlockchainProvider installDummyProvider(Bitcoiny bitcoiny, String netId) throws IllegalAccessException {

--- a/src/test/java/org/qortal/test/crosschain/BitcoinyTests.java
+++ b/src/test/java/org/qortal/test/crosschain/BitcoinyTests.java
@@ -1,5 +1,6 @@
 package org.qortal.test.crosschain;
 
+import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Transaction;
 import org.junit.After;
 import org.junit.Before;
@@ -100,7 +101,7 @@ public abstract class BitcoinyTests extends Common {
 		assertNotNull(transaction);
 	}
 	@Test
-	public void testRepair() throws ForeignBlockchainException {
+	public void testRepair() throws ForeignBlockchainException, InsufficientMoneyException {
 		String xprv58 = getDeterministicKey58();
 
 		String transaction = bitcoiny.repairOldWallet(xprv58);

--- a/src/test/java/org/qortal/test/crosschain/BitcoinyTests.java
+++ b/src/test/java/org/qortal/test/crosschain/BitcoinyTests.java
@@ -10,6 +10,7 @@ import org.qortal.crosschain.AddressInfo;
 import org.qortal.crosschain.Bitcoiny;
 import org.qortal.crosschain.BitcoinyHTLC;
 import org.qortal.crosschain.ForeignBlockchainException;
+import org.qortal.crosschain.RepairWalletPreview;
 import org.qortal.repository.DataException;
 import org.qortal.test.common.Common;
 
@@ -109,6 +110,23 @@ public abstract class BitcoinyTests extends Common {
 
 		assertNotNull(transaction);
 		Sha256Hash.wrap(transaction);
+	}
+
+	@Test
+	public void testRepairPreview() throws ForeignBlockchainException {
+		String xpub58 = getDeterministicPublicKey58();
+
+		RepairWalletPreview preview = bitcoiny.previewRepairOldWallet(xpub58);
+
+		assertNotNull(preview);
+		assertTrue(preview.getOldBalance() >= 0L);
+		assertTrue(preview.getCurrentBalance() >= 0L);
+		assertTrue(preview.getMissingBalance() >= 0L);
+		assertTrue(preview.getEstimatedFee() >= 0L);
+		assertTrue(preview.getDustThreshold() >= 0L);
+		assertTrue(preview.getAddressCountOld() > 0);
+		assertTrue(preview.getAddressCountCurrent() > 0);
+		assertTrue(preview.getMissingUtxoCount() >= 0);
 	}
 
 	@Test

--- a/src/test/java/org/qortal/test/crosschain/BitcoinyTests.java
+++ b/src/test/java/org/qortal/test/crosschain/BitcoinyTests.java
@@ -1,6 +1,7 @@
 package org.qortal.test.crosschain;
 
 import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.junit.After;
 import org.junit.Before;
@@ -107,6 +108,7 @@ public abstract class BitcoinyTests extends Common {
 		String transaction = bitcoiny.repairOldWallet(xprv58);
 
 		assertNotNull(transaction);
+		Sha256Hash.wrap(transaction);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Enforce deterministic private keys for repair, rejecting xpub/tpub on sweep endpoints.
- Surface proper API errors on repair failures instead of returning non-txid strings.
- Add repair preview summaries and gate repair behind recommendations with a `force` override.
- Extend repair/preview behavior to BTC, DOGE, DGB, and RVN.
- Strengthen unit and API tests to validate txid format and new preview/force behavior.

## Issue
Refs: https://github.com/Qortal/qortal/issues/294

## Commit breakdown

### Require private key for litecoin repair
- `src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java`: validate deterministic private keys for repair so xpub/tpub are rejected.
- `src/main/java/org/qortal/crosschain/Bitcoiny.java`: add a private-key validator helper used by repair endpoints.

### Return API errors for wallet repair failures
- `src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java`: map repair failures to API errors so clients get clear error responses.
- `src/main/java/org/qortal/crosschain/Bitcoiny.java`: throw structured exceptions instead of returning class-name strings.
- `src/test/java/org/qortal/test/crosschain/BitcoinyTests.java`: align tests with the new error handling.

### Assert repair returns valid txid
- `src/test/java/org/qortal/test/crosschain/BitcoinyTests.java`: verify txid format rather than just non-null responses.

### Add litecoin repair preview endpoint
- `src/main/java/org/qortal/crosschain/RepairWalletPreview.java`: new response model for preview summaries.
- `src/main/java/org/qortal/crosschain/Bitcoiny.java`: implement old-vs-current scan comparison, missing balance, fee/dust estimate, and recommendation logic.
- `src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java`: add `/repair/preview` endpoint to expose the summary.
- `src/test/java/org/qortal/test/crosschain/BitcoinyTests.java`: add preview test coverage.

### Gate litecoin repair behind recommendation
- `src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java`: refuse repair when preview is not recommended unless `force=true`.

### Add repair preview and gated repair for BTC/DOGE/DGB/RVN
- `src/main/java/org/qortal/api/resource/CrossChainBitcoinResource.java`: add preview endpoint and force-gated repair.
- `src/main/java/org/qortal/api/resource/CrossChainDogecoinResource.java`: add preview endpoint and force-gated repair.
- `src/main/java/org/qortal/api/resource/CrossChainDigibyteResource.java`: add preview endpoint and force-gated repair.
- `src/main/java/org/qortal/api/resource/CrossChainRavencoinResource.java`: add preview endpoint and force-gated repair.

### Document force query param in repair endpoints
- `src/main/java/org/qortal/api/resource/CrossChainBitcoinResource.java`: OpenAPI `@Parameter` docs for `force`.
- `src/main/java/org/qortal/api/resource/CrossChainLitecoinResource.java`: OpenAPI `@Parameter` docs for `force`.
- `src/main/java/org/qortal/api/resource/CrossChainDogecoinResource.java`: OpenAPI `@Parameter` docs for `force`.
- `src/main/java/org/qortal/api/resource/CrossChainDigibyteResource.java`: OpenAPI `@Parameter` docs for `force`.
- `src/main/java/org/qortal/api/resource/CrossChainRavencoinResource.java`: OpenAPI `@Parameter` docs for `force`.

### Add API tests for repair preview and force
- `src/test/java/org/qortal/test/api/CrossChainRepairApiTests.java`: new API-level tests for preview summaries and force-gated repair behavior using a dummy provider to avoid network calls.

### Fix repair test compilation and exception ctor
- `src/main/java/org/qortal/crosschain/ForeignBlockchainException.java`: add a `(String, Throwable)` constructor so repair paths can preserve causes without build errors.
- `src/test/java/org/qortal/test/api/CrossChainRepairApiTests.java`: rely on the static `ApiCommon.assertApiError` helper to avoid an invalid instance override and keep tests compiling.