### PR TITLE
Fix networking batch handling, wallet scan timeouts, payments API validation, and startup responsiveness

### DIFF
--- a/src/main/java/org/qortal/api/resource/TransactionsResource.java
+++ b/src/main/java/org/qortal/api/resource/TransactionsResource.java
@@ -479,20 +479,24 @@ public class TransactionsResource {
 					)
 			}
 	)
-	@ApiErrors({ApiError.INVALID_CRITERIA, ApiError.INVALID_ADDRESS, ApiError.REPOSITORY_ISSUE})
-	public List<TransactionData> getPaymentsBetweenAddresses(
-			@Parameter(description = "Recipient's address") @QueryParam("recipientAddress") String recipientAddress,
-			@Parameter(description = "Sender's address") @QueryParam("senderAddress") String senderAddress,
-			@Parameter(description = "Payment amount (e.g., 1 or 1.5 for QORT)") @QueryParam("amount") String amountString,
-			@Parameter(description = "Start block height") @QueryParam("startBlock") Integer startBlock,
-			@Parameter(description = "Block limit (number of blocks to search from startBlock)") @QueryParam("blockLimit") Integer blockLimit,
-			@Parameter(
-					description = "whether to include confirmed, unconfirmed or both",
-					required = true
-			) @QueryParam("confirmationStatus") ConfirmationStatus confirmationStatus,
-			@Parameter(ref = "limit") @QueryParam("limit") Integer limit,
-			@Parameter(ref = "offset") @QueryParam("offset") Integer offset,
-			@Parameter(ref = "reverse") @QueryParam("reverse") Boolean reverse) {
+		@ApiErrors({ApiError.INVALID_CRITERIA, ApiError.INVALID_ADDRESS, ApiError.REPOSITORY_ISSUE})
+		public List<TransactionData> getPaymentsBetweenAddresses(
+				@Parameter(description = "Recipient's address") @QueryParam("recipientAddress") String recipientAddress,
+				@Parameter(description = "Sender's address") @QueryParam("senderAddress") String senderAddress,
+				@Parameter(description = "Payment amount (e.g., 1 or 1.5 for QORT)") @QueryParam("amount") String amountString,
+				@Parameter(description = "Start block height") @QueryParam("startBlock") Integer startBlock,
+				@Parameter(description = "Block limit (number of blocks to search from startBlock)") @QueryParam("blockLimit") Integer blockLimit,
+				@Parameter(
+						description = "whether to include confirmed, unconfirmed or both",
+						required = true
+				) @QueryParam("confirmationStatus") ConfirmationStatus confirmationStatus,
+				@Parameter(ref = "limit") @QueryParam("limit") Integer limit,
+				@Parameter(ref = "offset") @QueryParam("offset") Integer offset,
+				@Parameter(ref = "reverse") @QueryParam("reverse") Boolean reverse) {
+
+			if (confirmationStatus == null) {
+				throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_CRITERIA);
+			}
 
 		// Validate that at least one address is provided
 		boolean hasRecipient = recipientAddress != null && !recipientAddress.isEmpty();

--- a/src/main/java/org/qortal/controller/Controller.java
+++ b/src/main/java/org/qortal/controller/Controller.java
@@ -1996,7 +1996,7 @@ public class Controller extends Thread {
 
 						if (responseMessage == null || !peer.sendMessage(responseMessage)) {
 							peer.disconnect("failed to send our chain tip info");
-							return;
+							continue;
 						}
 					}
 				}
@@ -2009,7 +2009,7 @@ public class Controller extends Thread {
 					 * Hence, these are NOT simple "here's my chain tip" broadcasts from other peers.
 					 */
 					LOGGER.debug("Discarding late {} message with ID {} from {}", message.getType().name(), message.getId(), peer);
-					return;
+					continue;
 				}
 
 				// Update peer chain tip data

--- a/src/main/java/org/qortal/controller/Controller.java
+++ b/src/main/java/org/qortal/controller/Controller.java
@@ -398,9 +398,9 @@ public class Controller extends Thread {
 
 		final Controller controller = Controller.newInstance(args);
 
-		NETWORK_BLOCK_SUMMARIES_V_2_MESSAGE_SCHEDULER.scheduleAtFixedRate(() -> processNetworkBlockSummariesV2Messages(), 60, 1, TimeUnit.SECONDS);
+		NETWORK_BLOCK_SUMMARIES_V_2_MESSAGE_SCHEDULER.scheduleAtFixedRate(() -> processNetworkBlockSummariesV2Messages(), 0, 1, TimeUnit.SECONDS);
 
-		GET_BLOCK_MESSAGE_SCHEDULER.scheduleAtFixedRate( () -> controller.processNetworkGetBlockMessages(), 60, 1, TimeUnit.SECONDS);
+		GET_BLOCK_MESSAGE_SCHEDULER.scheduleAtFixedRate( () -> controller.processNetworkGetBlockMessages(), 0, 1, TimeUnit.SECONDS);
 
 		cleanChunkUploadTempDir(); // cleanup leftover chunks from streaming to disk
 

--- a/src/main/java/org/qortal/crosschain/Bitcoiny.java
+++ b/src/main/java/org/qortal/crosschain/Bitcoiny.java
@@ -38,6 +38,7 @@ public abstract class Bitcoiny implements ForeignBlockchain {
 
 	public static final int HASH160_LENGTH = 20;
 	private static final int TIMEOUT = 10;
+	private static final int HISTORY_TIMEOUT = 15;
 	private static final int RETRIES = 3;
 
 	protected final BitcoinyBlockchainProvider blockchainProvider;
@@ -1207,7 +1208,7 @@ public List<SimpleTransaction> getWalletTransactions(String key58) throws Foreig
 				Future<Boolean> future = futureMap.get(index);
 
 				try {
-					if( future.get(TIMEOUT, TimeUnit.SECONDS) ) {
+					if( future.get(HISTORY_TIMEOUT, TimeUnit.SECONDS) ) {
 						result = BooleanResult.TRUE_FOUND;
 						break;
 					}

--- a/src/main/java/org/qortal/crosschain/Bitcoiny.java
+++ b/src/main/java/org/qortal/crosschain/Bitcoiny.java
@@ -1097,11 +1097,13 @@ public List<SimpleTransaction> getWalletTransactions(String key58) throws Foreig
 		}
 
 		// process more keys
-		if( needToProcessAdditionalKeys || anyTrue( executor, transactionChecks, RETRIES )) {
+		BooleanResult hasHistory = anyTrue( executor, transactionChecks, RETRIES );
+
+		if( needToProcessAdditionalKeys || hasHistory == BooleanResult.TRUE_FOUND ) {
 			keySet.addAll(processKeys(executor, generateMoreKeys(keyChain), keyChain, 0));
 		}
 		// if no additional keys were already processed and the if the gap limit held, then process additional keys
-		else if ( unusedCounter < Settings.getInstance().getGapLimit()) {
+		else if ( unusedCounter < Settings.getInstance().getGapLimit() && hasHistory == BooleanResult.ALL_FALSE) {
 
 			keySet.addAll(processKeys(executor, generateMoreKeys(keyChain), keyChain, unusedCounter + WALLET_KEY_LOOKAHEAD_INCREMENT));
 		}
@@ -1146,11 +1148,13 @@ public List<SimpleTransaction> getWalletTransactions(String key58) throws Foreig
 			}
 		}
 
-		if( needToProcessAdditionalKeys || anyTrue( executor, transactionChecks, RETRIES )) {
+		BooleanResult hasHistory = anyTrue( executor, transactionChecks, RETRIES );
+
+		if( needToProcessAdditionalKeys || hasHistory == BooleanResult.TRUE_FOUND ) {
 			keySet.addAll(processKeysOnly(executor, generateMoreKeys(keyChain), keyChain, 0));
 		}
 		// if no additional keys were already processed and the if the gap limit held, then process additional keys
-		else if ( unusedCounter < Settings.getInstance().getGapLimit()) {
+		else if ( unusedCounter < Settings.getInstance().getGapLimit() && hasHistory == BooleanResult.ALL_FALSE) {
 
 			keySet.addAll(processKeysOnly(executor, generateMoreKeys(keyChain), keyChain, unusedCounter + WALLET_KEY_LOOKAHEAD_INCREMENT));
 		}
@@ -1167,10 +1171,15 @@ public List<SimpleTransaction> getWalletTransactions(String key58) throws Foreig
 	 *
 	 * @return true if any task returns true, false if all tasks return false
 	 */
-	public static boolean anyTrue(ExecutorService executor, List<Supplier<Boolean>> suppliers, int retries) throws ForeignBlockchainException {
+	public enum BooleanResult {
+		TRUE_FOUND,
+		ALL_FALSE,
+		UNKNOWN_TIMEOUT
+	}
 
-		// return value
-		boolean anyTrueYet = false;
+	public static BooleanResult anyTrue(ExecutorService executor, List<Supplier<Boolean>> suppliers, int retries) throws ForeignBlockchainException {
+
+		BooleanResult result = BooleanResult.ALL_FALSE;
 
 		// for recursion if necessary
 		List<Supplier<Boolean>> suppliersToRetry = new ArrayList<>(suppliers.size());
@@ -1199,10 +1208,11 @@ public List<SimpleTransaction> getWalletTransactions(String key58) throws Foreig
 
 				try {
 					if( future.get(TIMEOUT, TimeUnit.SECONDS) ) {
-						anyTrueYet = true;
+						result = BooleanResult.TRUE_FOUND;
 						break;
 					}
 				} catch (TimeoutException e) {
+					result = BooleanResult.UNKNOWN_TIMEOUT;
 					suppliersToRetry.add(supplierMap.get(index));
 				}
 			}
@@ -1214,11 +1224,11 @@ public List<SimpleTransaction> getWalletTransactions(String key58) throws Foreig
 			throw new ForeignBlockchainException(e.getMessage());
 		}
 
-		if( retries > 0 && !anyTrueYet && !suppliersToRetry.isEmpty() ) {
+		if( retries > 0 && result == BooleanResult.UNKNOWN_TIMEOUT && !suppliersToRetry.isEmpty() ) {
 			return anyTrue(executor, suppliersToRetry, retries - 1);
 		}
 		else {
-			return anyTrueYet;
+			return result;
 		}
 	}
 


### PR DESCRIPTION
## Summary:
- Ensure batched GET_BLOCK replies go to all requesters.
- Process all BLOCK_SUMMARIES_V2 messages without early exit and start schedulers immediately.
- Validate required params in payments-between API to avoid 500s.
- Prevent Electrum timeouts from causing under-reported balances; increase history timeout.

## Fix GET_BLOCK batching to respond to all requesters
   - File: src/main/java/org/qortal/controller/Controller.java
   - Change: Group GET_BLOCK requests by signature and send cached/fetched/archive/unknown responses to every requesting peer instead of overwriting duplicates.
   - Fixes: Peers asking for the same uncached block at the same time no longer get dropped/responses lost.

## Process all BLOCK_SUMMARIES_V2 batch messages
   - File: src/main/java/org/qortal/controller/Controller.java
   - Change: Replace early returns in the BLOCK_SUMMARIES_V2 batch loop with continue, so all queued summaries are processed.
   - Fixes: Peers weren’t getting chain-tip updates if an earlier message failed.

## Validate confirmationStatus for payments-between API
   - File: src/main/java/org/qortal/api/resource/TransactionsResource.java
   - Change: Add null check for confirmationStatus and return INVALID_CRITERIA instead of NPE/500.
   - Fixes: Calling /transactions/payments/between without confirmationStatus no longer crashes.

## Avoid treating Electrum timeouts as empty history in wallet scan
   - File: src/main/java/org/qortal/crosschain/Bitcoiny.java
   - Change: Introduce tri-state result for async history checks and don’t advance gap on timeouts; only on confirmed empty history.
   - Fixes: Prevents wallet address scanning from stopping early and under-reporting balances when Electrum servers are slow.

## Increase history timeout for Electrum address scans
   - File: src/main/java/org/qortal/crosschain/Bitcoiny.java
   - Change: Raise transaction-history check timeout to 15s (keep others at 10s).
   - Fixes: Reduces false timeouts that could still lead to extra scanning or missed addresses.

## Start GET_BLOCK and BLOCK_SUMMARIES_V2 schedulers immediately
   - File: src/main/java/org/qortal/controller/Controller.java
   - Change: Remove the 60s initial delay on the batch schedulers (start at 0s, run every second).
   - Fixes: Node responds to block/summary requests immediately after startup instead of waiting a minute.
