### PR TITLE
Ignore .qortal metadata in QDN size validation to fix CHAIN_COMMENT read failures

### DIFF
--- a/src/main/java/org/qortal/arbitrary/misc/Service.java
+++ b/src/main/java/org/qortal/arbitrary/misc/Service.java
@@ -214,7 +214,7 @@ public enum Service {
         // Load the first 25KB of data. This only needs to be long enough to check the prefix
         // and also to allow for possible additional future validation of smaller files.
         byte[] data = FilesystemUtils.getSingleFileContents(path, 25*1024);
-        long size = FilesystemUtils.getDirectorySize(path);
+        long size = FilesystemUtils.getDirectorySize(path, true);
 
         // Validate max size if needed
         if (this.maxSize != null) {

--- a/src/main/java/org/qortal/utils/FilesystemUtils.java
+++ b/src/main/java/org/qortal/utils/FilesystemUtils.java
@@ -208,13 +208,27 @@ public class FilesystemUtils {
     }
 
     public static long getDirectorySize(Path path) throws IOException {
+        return getDirectorySize(path, false);
+    }
+
+    public static long getDirectorySize(Path path, boolean excludeQortalDirectory) throws IOException {
         if (path == null || !Files.exists(path)) {
             return 0L;
         }
         return Files.walk(path)
                 .filter(p -> p.toFile().isFile())
+                .filter(p -> !excludeQortalDirectory || !isQortalMetadataPath(p))
                 .mapToLong(p -> p.toFile().length())
                 .sum();
+    }
+
+    private static boolean isQortalMetadataPath(Path path) {
+        for (Path part : path) {
+            if (".qortal".equals(part.toString())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 

--- a/src/test/java/org/qortal/test/arbitrary/ArbitraryServiceTests.java
+++ b/src/test/java/org/qortal/test/arbitrary/ArbitraryServiceTests.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -55,6 +56,26 @@ public class ArbitraryServiceTests extends Common {
         Service service = Service.ARBITRARY_DATA;
         assertFalse(service.isValidationRequired());
         // Test validation anyway to ensure that no exception is thrown
+        assertEquals(ValidationResult.OK, service.validate(path));
+    }
+
+    @Test
+    public void testValidateChainCommentIgnoresQortalMetadata() throws IOException {
+        Path path = Files.createTempDirectory("testValidateChainCommentIgnoresQortalMetadata");
+        path.toFile().deleteOnExit();
+
+        byte[] commentData = new byte[200];
+        Arrays.fill(commentData, (byte) 'a');
+        Files.write(Paths.get(path.toString(), "comment"), commentData, StandardOpenOption.CREATE);
+
+        Path qortalPath = Paths.get(path.toString(), ".qortal");
+        Files.createDirectories(qortalPath);
+        byte[] metadata = new byte[512];
+        Arrays.fill(metadata, (byte) 'b');
+        Files.write(Paths.get(qortalPath.toString(), "cache"), metadata, StandardOpenOption.CREATE);
+
+        Service service = Service.CHAIN_COMMENT;
+        assertTrue(service.isValidationRequired());
         assertEquals(ValidationResult.OK, service.validate(path));
     }
 


### PR DESCRIPTION
# Description:
This PR fixes QDN read failures where CHAIN_COMMENT resources under the 239‑byte limit still fail to render with `EXCEEDS_SIZE_LIMIT`. The root cause is that Core’s size validation counts internal `.qortal` metadata (e.g., `.qortal/cache`) when measuring resource size during read/build. For CHAIN_COMMENT, that metadata (~140 bytes) leaves only ~99 bytes for actual comment text, so valid comments are rejected on read.

Issue: https://github.com/Qortal/qortal/issues/299

# Summary of changes:
- `src/main/java/org/qortal/utils/FilesystemUtils.java`
  - Added `getDirectorySize(path, excludeQortalDirectory)` and a helper to detect `.qortal` metadata paths.
  - Kept existing `getDirectorySize(path)` as a wrapper to preserve current behavior for other callers.
  - Why: Enable size checks that exclude internal metadata when appropriate.

- `src/main/java/org/qortal/arbitrary/misc/Service.java`
  - Switched size validation to use `getDirectorySize(path, true)` so `.qortal` is ignored.
  - Why: Ensure service max-size checks apply to user data only, not internal cache files.

- `src/test/java/org/qortal/test/arbitrary/ArbitraryServiceTests.java`
  - Added `testValidateChainCommentIgnoresQortalMetadata` to verify CHAIN_COMMENT validation passes when `.qortal/cache` exists.
  - Why: Prevent regression of the read‑side size check bug.

# What problem this fixes:
Valid CHAIN_COMMENT resources can be published but later fail to render because size validation counts internal `.qortal` metadata, causing `EXCEEDS_SIZE_LIMIT`. This results in missing comments in apps and confusing API errors.

# How this fixes it:
Size validation now ignores `.qortal` metadata, so limits are enforced against user data only. This restores expected CHAIN_COMMENT behavior and prevents metadata from invalidating otherwise valid resources.

# Tests:
- `mvn -Dtest=ArbitraryServiceTests test`