### PR TITLE
Fix #316: add Linux-native tray fallback and notifications when AWT SystemTray is unavailable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<commons-compress.version>1.27.1</commons-compress.version>
 		<commons-lang3.version>3.17.0</commons-lang3.version>
 		<dagger.version>1.2.2</dagger.version>
+		<dorkbox-systemtray.version>4.4</dorkbox-systemtray.version>
 		<extendedset.version>0.12.3</extendedset.version>
 		<git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
 		<grpc.version>1.68.3</grpc.version>
@@ -620,6 +621,19 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
+		</dependency>
+		<!-- Linux tray fallback when AWT SystemTray is unavailable -->
+		<dependency>
+			<groupId>com.dorkbox</groupId>
+			<artifactId>SystemTray</artifactId>
+			<version>${dorkbox-systemtray.version}</version>
+			<exclusions>
+				<!-- Keep project-wide slf4j-api version -->
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- Servlet related -->
 		<dependency>


### PR DESCRIPTION
## Summary
Fixes https://github.com/Qortal/qortal/issues/316 by making Qortal Core tray support work on Linux systems where `java.awt.SystemTray` is unsupported.

## Root Cause
The existing tray implementation was AWT-only.  
On many Linux desktop setups, `SystemTray.isSupported()` returns `false`, so tray initialization exited early and no icon/menu/notifications were available.

## What This PR Changes

### 1) Add Linux-native tray backend fallback
- Added `com.dorkbox:SystemTray` dependency in `pom.xml`.
- `SysTray` now supports backend selection via:
  - `-Dqortal.tray.backend=auto|awt|sni|appindicator|none`
- Default `auto` behavior:
  - Try AWT tray first (preserves current behavior where it works)
  - On Linux, fall back to Linux-native tray if AWT is unavailable

### 2) Improve backend diagnostics
- Added startup logging for tray backend decisions:
  - requested backend
  - OS
  - headless state
  - AWT support
  - session/desktop env values

### 3) AppIndicator tooltip fallback
- AppIndicator often does not support hover tooltips.
- For Linux-native AppIndicator, tray text now falls back to status text (`setStatus`) instead of tooltip only.

### 4) Linux notification support
- Linux-native backend now attempts desktop notifications via `notify-send` from `showMessage(...)`.
- If `notify-send` is unavailable/fails, it gracefully falls back to debug logging (no crash/regression).

## Compatibility / Risk
- Windows/macOS and Linux systems where AWT tray already works keep existing behavior.
- Linux-native path is only used when selected or when `auto` fallback is needed.
- No API changes to existing tray callers.

## Commits Included
1. `65fb8cfd` feat(gui): add Linux-native system tray backend fallback  
2. `3cfc1254` fix(gui): fallback to status text for AppIndicator tray  
3. `139a3798` feat(gui): send Linux tray notifications via notify-send

## Validation
- Project compiles successfully (`mvn -DskipTests compile`).
- Manual Linux verification with `appindicator`:
  - tray icon appears
  - tray menu works
  - status text updates
  - desktop notifications are shown