### PR TITLE
feat(render): add startup theme palette support for Q-Apps via _qdnThemePalette (Qortal-Hub#231)

### DIFF
--- a/src/main/java/org/qortal/api/proxy/resource/DevProxyServerResource.java
+++ b/src/main/java/org/qortal/api/proxy/resource/DevProxyServerResource.java
@@ -152,10 +152,12 @@ public class DevProxyServerResource {
             theme = "light";
         }
 
+        String themePalette = request.getParameter("themePalette");
+
         // Parse and modify output if needed
         if (HTMLParser.isHtmlFile(filename)) {
             // HTML file - needs to be parsed
-            HTMLParser htmlParser = new HTMLParser("", inPath, "", false, data, "proxy", Service.APP, null, theme , true, lang);
+            HTMLParser htmlParser = new HTMLParser("", inPath, "", false, data, "proxy", Service.APP, null, theme, true, lang, themePalette);
             htmlParser.addAdditionalHeaderTags();
             response.addHeader("Content-Security-Policy", "default-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' data: blob:; img-src 'self' data: blob:; connect-src 'self' ws:; font-src 'self' data:;");
             response.setContentType(con.getContentType());

--- a/src/main/java/org/qortal/api/restricted/resource/RenderResource.java
+++ b/src/main/java/org/qortal/api/restricted/resource/RenderResource.java
@@ -71,33 +71,36 @@ public class RenderResource {
     @Path("/signature/{signature}")
     @SecurityRequirement(name = "apiKey")
     public HttpServletResponse getIndexBySignature(@PathParam("signature") String signature,
-                                                   @QueryParam("theme") String theme, @QueryParam("lang") String lang) {
+                                                   @QueryParam("theme") String theme, @QueryParam("lang") String lang,
+                                                   @QueryParam("themePalette") String themePalette) {
         if (!Settings.getInstance().isQDNAuthBypassEnabled())
             Security.requirePriorAuthorization(request, signature, Service.WEBSITE, null);
 
-        return this.get(signature, ResourceIdType.SIGNATURE, null, null, "/", null, "/render/signature", true, true, theme, lang);
+        return this.get(signature, ResourceIdType.SIGNATURE, null, null, "/", null, "/render/signature", true, true, theme, lang, themePalette);
     }
 
     @GET
     @Path("/signature/{signature}/{path:.*}")
     @SecurityRequirement(name = "apiKey")
     public HttpServletResponse getPathBySignature(@PathParam("signature") String signature, @PathParam("path") String inPath,
-                                                  @QueryParam("theme") String theme, @QueryParam("lang") String lang) {
+                                                  @QueryParam("theme") String theme, @QueryParam("lang") String lang,
+                                                  @QueryParam("themePalette") String themePalette) {
         if (!Settings.getInstance().isQDNAuthBypassEnabled())
             Security.requirePriorAuthorization(request, signature, Service.WEBSITE, null);
 
-        return this.get(signature, ResourceIdType.SIGNATURE, null, null, inPath,null, "/render/signature", true, true, theme, lang);
+        return this.get(signature, ResourceIdType.SIGNATURE, null, null, inPath,null, "/render/signature", true, true, theme, lang, themePalette);
     }
 
     @GET
     @Path("/hash/{hash}")
     @SecurityRequirement(name = "apiKey")
     public HttpServletResponse getIndexByHash(@PathParam("hash") String hash58, @QueryParam("secret") String secret58,
-                                              @QueryParam("theme") String theme,  @QueryParam("lang") String lang) {
+                                              @QueryParam("theme") String theme,  @QueryParam("lang") String lang,
+                                              @QueryParam("themePalette") String themePalette) {
         if (!Settings.getInstance().isQDNAuthBypassEnabled())
             Security.requirePriorAuthorization(request, hash58, Service.WEBSITE, null);
 
-        return this.get(hash58, ResourceIdType.FILE_HASH, Service.ARBITRARY_DATA, null, "/", secret58, "/render/hash", true, false, theme, lang);
+        return this.get(hash58, ResourceIdType.FILE_HASH, Service.ARBITRARY_DATA, null, "/", secret58, "/render/hash", true, false, theme, lang, themePalette);
     }
 
     @GET
@@ -105,11 +108,12 @@ public class RenderResource {
     @SecurityRequirement(name = "apiKey")
     public HttpServletResponse getPathByHash(@PathParam("hash") String hash58, @PathParam("path") String inPath,
                                              @QueryParam("secret") String secret58,
-                                             @QueryParam("theme") String theme, @QueryParam("lang") String lang) {
+                                             @QueryParam("theme") String theme, @QueryParam("lang") String lang,
+                                             @QueryParam("themePalette") String themePalette) {
         if (!Settings.getInstance().isQDNAuthBypassEnabled())
             Security.requirePriorAuthorization(request, hash58, Service.WEBSITE, null);
 
-        return this.get(hash58, ResourceIdType.FILE_HASH, Service.ARBITRARY_DATA, null, inPath, secret58, "/render/hash", true, false, theme, lang);
+        return this.get(hash58, ResourceIdType.FILE_HASH, Service.ARBITRARY_DATA, null, inPath, secret58, "/render/hash", true, false, theme, lang, themePalette);
     }
 
     @GET
@@ -119,12 +123,13 @@ public class RenderResource {
                                              @PathParam("name") String name,
                                              @PathParam("path") String inPath,
                                              @QueryParam("identifier") String identifier,
-                                             @QueryParam("theme") String theme, @QueryParam("lang") String lang) {
+                                             @QueryParam("theme") String theme, @QueryParam("lang") String lang,
+                                             @QueryParam("themePalette") String themePalette) {
         if (!Settings.getInstance().isQDNAuthBypassEnabled())
             Security.requirePriorAuthorization(request, name, service, null);
 
         String prefix = String.format("/render/%s", service);
-        return this.get(name, ResourceIdType.NAME, service, identifier, inPath, null, prefix, true, true, theme, lang);
+        return this.get(name, ResourceIdType.NAME, service, identifier, inPath, null, prefix, true, true, theme, lang, themePalette);
     }
 
     @GET
@@ -133,18 +138,20 @@ public class RenderResource {
     public HttpServletResponse getIndexByName(@PathParam("service") Service service,
                                               @PathParam("name") String name,
                                               @QueryParam("identifier") String identifier,
-                                              @QueryParam("theme") String theme, @QueryParam("lang") String lang) {
+                                              @QueryParam("theme") String theme, @QueryParam("lang") String lang,
+                                              @QueryParam("themePalette") String themePalette) {
         if (!Settings.getInstance().isQDNAuthBypassEnabled())
             Security.requirePriorAuthorization(request, name, service, null);
 
         String prefix = String.format("/render/%s", service);
-        return this.get(name, ResourceIdType.NAME, service, identifier, "/", null, prefix, true, true, theme, lang);
+        return this.get(name, ResourceIdType.NAME, service, identifier, "/", null, prefix, true, true, theme, lang, themePalette);
     }
 
 
 
     private HttpServletResponse get(String resourceId, ResourceIdType resourceIdType, Service service, String identifier,
-                                    String inPath, String secret58, String prefix, boolean includeResourceIdInPrefix, boolean async, String theme, String lang) {
+                                    String inPath, String secret58, String prefix, boolean includeResourceIdInPrefix, boolean async,
+                                    String theme, String lang, String themePalette) {
 
         ArbitraryDataRenderer renderer = new ArbitraryDataRenderer(resourceId, resourceIdType, service, identifier, inPath,
                 secret58, prefix, includeResourceIdInPrefix, async, "render", request, response, context);
@@ -154,6 +161,9 @@ public class RenderResource {
         }
         if (lang != null) {
             renderer.setLang(lang);
+        }
+        if (themePalette != null) {
+            renderer.setThemePalette(themePalette);
         }
         return renderer.render();
     }

--- a/src/main/java/org/qortal/arbitrary/ArbitraryDataRenderer.java
+++ b/src/main/java/org/qortal/arbitrary/ArbitraryDataRenderer.java
@@ -41,6 +41,7 @@ public class ArbitraryDataRenderer {
     private final String identifier;
     private String theme = "light";
     private String lang = "en"; 
+    private String themePalette = null;
     private String inPath;
     private final String secret58;
     private final String prefix;
@@ -177,7 +178,7 @@ public class ArbitraryDataRenderer {
                 } else {
                     encodedResourceId = resourceId;
                 }
-                HTMLParser htmlParser = new HTMLParser(encodedResourceId, inPath, prefix, includeResourceIdInPrefix, data, qdnContext, service, identifier, theme, usingCustomRouting, lang);
+                HTMLParser htmlParser = new HTMLParser(encodedResourceId, inPath, prefix, includeResourceIdInPrefix, data, qdnContext, service, identifier, theme, usingCustomRouting, lang, themePalette);
                 htmlParser.addAdditionalHeaderTags();
                 response.addHeader(
                     "Content-Security-Policy",
@@ -279,6 +280,9 @@ public class ArbitraryDataRenderer {
     }
     public void setLang(String lang) {
         this.lang = lang;
-    }    
+    }
+    public void setThemePalette(String themePalette) {
+        this.themePalette = themePalette;
+    }
 
 }

--- a/src/main/resources/q-apps/q-apps.js
+++ b/src/main/resources/q-apps/q-apps.js
@@ -46,6 +46,7 @@ function parseUrl(url) {
         // Remove theme, identifier, and time queries if they exist
         parsedUrl.searchParams.delete("theme");
         parsedUrl.searchParams.delete("lang");
+        parsedUrl.searchParams.delete("themePalette");
         parsedUrl.searchParams.delete("identifier");
         parsedUrl.searchParams.delete("time");
         parsedUrl.searchParams.delete("isManualNavigation");
@@ -218,6 +219,17 @@ function buildResourceUrl(service, name, identifier, path, isLink) {
         const hasQuery = url.includes("?");
         const queryPrefix = hasQuery ? "&" : "?";
         url += queryPrefix + "theme=" + _qdnTheme + "&lang=" + _qdnLang;
+
+        if (typeof _qdnThemePalette !== "undefined" && _qdnThemePalette !== null) {
+            try {
+                const serializedThemePalette = JSON.stringify(_qdnThemePalette);
+                if (serializedThemePalette != null) {
+                    url += "&themePalette=" + encodeURIComponent(serializedThemePalette);
+                }
+            } catch (error) {
+                console.warn("Unable to serialize _qdnThemePalette:", error);
+            }
+        }
     }
     return url;
 }
@@ -735,4 +747,3 @@ navigation.addEventListener('navigate', (event) => {
     handleQDNResourceDisplayed(processedPath);
    }, 100)
 });
-

--- a/src/test/java/org/qortal/test/api/HTMLParserTests.java
+++ b/src/test/java/org/qortal/test/api/HTMLParserTests.java
@@ -1,0 +1,69 @@
+package org.qortal.test.api;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.qortal.api.HTMLParser;
+import org.qortal.arbitrary.misc.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HTMLParserTests {
+
+    private static final String MINIMAL_HTML = "<html><head></head><body>hello</body></html>";
+
+    @Test
+    public void testThemePaletteInjectsValidObject() {
+        String themePalette = "{\"primary\":\"#111111\",\"surface\":{\"main\":\"#ffffff\"}}";
+        HTMLParser parser = new HTMLParser("appname", "/", "/render/APP", true,
+                MINIMAL_HTML.getBytes(StandardCharsets.UTF_8), "render", Service.APP,
+                "default", "dark", false, "en", themePalette);
+
+        parser.addAdditionalHeaderTags();
+
+        String parsedHtml = new String(parser.getData(), StandardCharsets.UTF_8);
+        String themePaletteExpression = extractThemePaletteExpression(parsedHtml);
+        JSONObject parsedThemePalette = new JSONObject(themePaletteExpression);
+
+        assertEquals("#111111", parsedThemePalette.getString("primary"));
+        assertEquals("#ffffff", parsedThemePalette.getJSONObject("surface").getString("main"));
+    }
+
+    @Test
+    public void testThemePaletteInvalidJsonFallsBackToNull() {
+        HTMLParser parser = new HTMLParser("appname", "/", "/render/APP", true,
+                MINIMAL_HTML.getBytes(StandardCharsets.UTF_8), "render", Service.APP,
+                "default", "dark", false, "en", "not-json");
+
+        parser.addAdditionalHeaderTags();
+
+        String parsedHtml = new String(parser.getData(), StandardCharsets.UTF_8);
+        String themePaletteExpression = extractThemePaletteExpression(parsedHtml);
+        assertEquals("null", themePaletteExpression);
+    }
+
+    @Test
+    public void testThemePaletteNonObjectFallsBackToNull() {
+        HTMLParser parser = new HTMLParser("appname", "/", "/render/APP", true,
+                MINIMAL_HTML.getBytes(StandardCharsets.UTF_8), "render", Service.APP,
+                "default", "dark", false, "en", "[1,2,3]");
+
+        parser.addAdditionalHeaderTags();
+
+        String parsedHtml = new String(parser.getData(), StandardCharsets.UTF_8);
+        String themePaletteExpression = extractThemePaletteExpression(parsedHtml);
+        assertEquals("null", themePaletteExpression);
+    }
+
+    private String extractThemePaletteExpression(String html) {
+        Pattern pattern = Pattern.compile("var _qdnThemePalette=([^;]*);");
+        Matcher matcher = pattern.matcher(html);
+        assertTrue(matcher.find());
+        return matcher.group(1);
+    }
+}
+


### PR DESCRIPTION
## Summary

This PR adds Core-side support for startup theme palette delivery to Q-Apps by accepting an optional `themePalette` query parameter on `/render/*` routes and injecting it into rendered HTML as:

```js
var _qdnThemePalette = <object-or-null>;
```

This complements the Hub work in:
- https://github.com/Qortal/Qortal-Hub/pull/256

and addresses the remaining startup-path gap for:
- https://github.com/Qortal/Qortal-Hub/issues/231

## Problem

Hub now sends runtime theme updates with full palette (`THEME_CHANGED` with `{ theme, palette }`), but Q-Apps also need palette data immediately at startup (before runtime `postMessage`) to avoid first-paint theme drift.

Before this PR, Core only injected startup globals for mode/language (`_qdnTheme`, `_qdnLang`) and had no startup palette global.

## What This PR Changes

### 1) Render API support (additive)

`/render/*` endpoints now accept optional query param:
- `themePalette` (string, URL-encoded JSON object)

Updated:
- `RenderResource` to read and forward `themePalette` to the renderer.

### 2) Renderer plumbing

`ArbitraryDataRenderer` now carries an optional `themePalette` field and passes it into `HTMLParser`.

### 3) HTML startup global injection

`HTMLParser` now:
- accepts `themePalette`,
- validates/parses it as JSON object only,
- injects startup global:
  - `var _qdnThemePalette = <object-or-null>;`
- falls back to `null` when missing, invalid JSON, or non-object payload,
- preserves existing globals (`_qdnTheme`, `_qdnLang`, `_qdnContext`, etc.) unchanged.

### 4) Injection safety

Palette JSON is normalized and escaped for inline script context (e.g. `<`, `>`, `&`, line separators) before interpolation.

### 5) Dev proxy parity

`DevProxyServerResource` now reads optional `themePalette` and passes it to `HTMLParser` so dev mode behavior matches render mode.

### 6) Internal link propagation support (`q-apps.js`)

When Q-Apps build internal resource URLs, Core `q-apps.js` now appends:
- `theme`
- `lang`
- optional `themePalette` (`JSON.stringify` + `encodeURIComponent`, fail-safe)

It also strips `themePalette` in URL parsing cleanup used for navigation history.

## Supported `themePalette` Format

`themePalette` must be a URL-encoded JSON object string.

Example:
- Raw JSON:
  - `{"primary":"#111111","surface":{"main":"#ffffff"}}`
- Query value:
  - `themePalette=%7B%22primary%22%3A%22%23111111%22%2C%22surface%22%3A%7B%22main%22%3A%22%23ffffff%22%7D%7D`

Behavior:
- Valid object: injected as object.
- Missing / invalid JSON / non-object: injected as `null`.

## Backward Compatibility

- Existing behavior for `_qdnTheme`, `_qdnLang`, and render flows remains unchanged.
- Existing clients that only use theme mode continue to work.
- Q-Apps/Core paths that ignore `themePalette` continue to work.
- No breaking API changes.

## Validation

- Added parser-level tests:
  - valid object injection,
  - invalid JSON fallback to `null`,
  - non-object fallback to `null`.
- Build/test checks passed:
  - `mvn -DskipJUnitTests=false -Dtest=org.qortal.test.api.HTMLParserTests test`
  - `mvn -DskipTests package`

## End-to-End with Hub + Q-Place

With Hub `feature/theme-sharing` + Hub PR #256 behavior and this Core PR:
- Q-Apps get full palette at startup from Core-injected `_qdnThemePalette`,
- Q-Apps continue receiving runtime updates via `THEME_CHANGED` (`{ theme, palette }`).

`qortal://APP/qplace` supports this feature and can be used for verification:
1. Open Q-Place in Hub.
2. Confirm startup theme matches current Hub palette immediately.
3. Change Hub theme mode/palette.
4. Confirm Q-Place updates live without full app restart.