### PR TITLE
Add endpoint for appRatings

### DIFF
--- a/src/main/java/org/qortal/api/model/AppRatingsResponse.java
+++ b/src/main/java/org/qortal/api/model/AppRatingsResponse.java
@@ -1,0 +1,85 @@
+package org.qortal.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Bulk app ratings response")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AppRatingsResponse {
+
+	@Schema(description = "Total number of rating polls")
+	public Integer count;
+
+	@Schema(description = "Pagination offset")
+	public Integer offset;
+
+	@Schema(description = "Map of poll names to rating data")
+	public Map<String, AppRating> ratings;
+
+	// For JAX-RS
+	protected AppRatingsResponse() {
+	}
+
+	public AppRatingsResponse(Integer count, Integer offset, Map<String, AppRating> ratings) {
+		this.count = count;
+		this.offset = offset;
+		this.ratings = ratings;
+	}
+
+	@Schema(description = "App rating data with vote counts")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	public static class AppRating {
+		@Schema(description = "Poll name")
+		public String pollName;
+
+		@Schema(description = "Service type (APP or WEBSITE)")
+		public String service;
+
+		@Schema(description = "App name")
+		public String appName;
+
+		@Schema(description = "Poll owner address")
+		public String owner;
+
+		@Schema(description = "Publication timestamp")
+		public Long published;
+
+		@Schema(description = "Poll description")
+		public String description;
+
+		@Schema(description = "Total number of votes")
+		public Integer totalVotes;
+
+		@Schema(description = "Total weight of votes")
+		public Integer totalWeight;
+
+		@Schema(description = "List of vote counts for each option")
+		public List<PollVotes.OptionCount> voteCounts;
+
+		@Schema(description = "List of vote weights for each option")
+		public List<PollVotes.OptionWeight> voteWeights;
+
+		// For JAX-RS
+		protected AppRating() {
+		}
+
+		public AppRating(String pollName, String service, String appName, String owner, Long published,
+				String description, Integer totalVotes, Integer totalWeight,
+				List<PollVotes.OptionCount> voteCounts, List<PollVotes.OptionWeight> voteWeights) {
+			this.pollName = pollName;
+			this.service = service;
+			this.appName = appName;
+			this.owner = owner;
+			this.published = published;
+			this.description = description;
+			this.totalVotes = totalVotes;
+			this.totalWeight = totalWeight;
+			this.voteCounts = voteCounts;
+			this.voteWeights = voteWeights;
+		}
+	}
+}

--- a/src/main/java/org/qortal/api/resource/PollsResource.java
+++ b/src/main/java/org/qortal/api/resource/PollsResource.java
@@ -12,12 +12,14 @@ import org.qortal.api.ApiError;
 import org.qortal.api.ApiErrors;
 import org.qortal.api.ApiException;
 import org.qortal.api.ApiExceptionFactory;
+import org.qortal.api.model.AppRatingsResponse;
 import org.qortal.api.model.PollVotes;
 import org.qortal.crypto.Crypto;
 import org.qortal.data.account.AccountData;
 import org.qortal.data.transaction.CreatePollTransactionData;
 import org.qortal.data.transaction.VoteOnPollTransactionData;
 import org.qortal.data.voting.PollData;
+import org.qortal.data.voting.PollDataWithVotes;
 import org.qortal.data.voting.PollOptionData;
 import org.qortal.data.voting.VoteOnPollData;
 import org.qortal.repository.DataException;
@@ -168,6 +170,115 @@ public class PollsResource {
                     } else {
                         return new PollVotes(votes, totalVotes, totalWeight, voteCounts, voteWeights);
                     }
+            } catch (ApiException e) {
+                    throw e;
+            } catch (DataException e) {
+                    throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.REPOSITORY_ISSUE, e);
+            }
+    }
+
+    @GET
+    @Path("/apps/ratings")
+    @Operation(
+            summary = "Get all app rating polls with vote counts",
+            description = "Returns aggregated vote data for all app library rating polls in a single request. " +
+                    "This endpoint optimizes bulk fetching of app ratings by reducing N×2 API calls to a single call.",
+            responses = {
+                    @ApiResponse(
+                            description = "Bulk app ratings data",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = AppRatingsResponse.class)
+                            )
+                    )
+            }
+    )
+    @ApiErrors({ApiError.REPOSITORY_ISSUE, ApiError.INVALID_CRITERIA})
+    public AppRatingsResponse getAppRatings(
+            @Parameter(description = "Filter by service type (APP or WEBSITE)")
+            @QueryParam("service") String service,
+
+            @Parameter(ref = "limit")
+            @QueryParam("limit") Integer limit,
+
+            @Parameter(ref = "offset")
+            @QueryParam("offset") Integer offset,
+
+            @Parameter(description = "Return polls published before this timestamp")
+            @QueryParam("before") Long before,
+
+            @Parameter(description = "Return polls published after this timestamp")
+            @QueryParam("after") Long after
+    ) {
+            try (final Repository repository = RepositoryManager.getRepository()) {
+                    // Build prefix based on service filter
+                    String prefix = "app-library-";
+                    if (service != null) {
+                            if (!service.equals("APP") && !service.equals("WEBSITE")) {
+                                    throw ApiExceptionFactory.INSTANCE.createException(request, ApiError.INVALID_CRITERIA);
+                            }
+                            prefix = "app-library-" + service + "-rating-";
+                    }
+
+                    // Fetch polls with votes
+                    List<PollDataWithVotes> pollsWithVotes =
+                            repository.getVotingRepository().getPollsByPrefix(prefix, limit, offset);
+
+                    // Filter by timestamp if needed
+                    if (before != null || after != null) {
+                            pollsWithVotes = pollsWithVotes.stream()
+                                    .filter(p -> {
+                                            long published = p.getPollData().getPublished();
+                                            if (before != null && published >= before) return false;
+                                            if (after != null && published <= after) return false;
+                                            return true;
+                                    })
+                                    .collect(Collectors.toList());
+                    }
+
+                    // Build response
+                    Map<String, AppRatingsResponse.AppRating> ratingsMap = new HashMap<>();
+
+                    for (PollDataWithVotes pollWithVotes : pollsWithVotes) {
+                            PollData pollData = pollWithVotes.getPollData();
+                            String pollName = pollData.getPollName();
+
+                            // Parse poll name: app-library-{SERVICE}-rating-{APP_NAME}
+                            String extractedService = null;
+                            String appName = null;
+                            String[] parts = pollName.split("-", 5);
+                            if (parts.length >= 5) {
+                                    extractedService = parts[2];  // APP or WEBSITE
+                                    appName = parts[4];            // Q-Tube, etc.
+                            }
+
+                            // Convert vote maps to lists
+                            List<PollVotes.OptionCount> voteCounts = pollWithVotes.getVoteCountMap().entrySet().stream()
+                                    .map(e -> new PollVotes.OptionCount(e.getKey(), e.getValue()))
+                                    .collect(Collectors.toList());
+
+                            List<PollVotes.OptionWeight> voteWeights = pollWithVotes.getVoteWeightMap().entrySet().stream()
+                                    .map(e -> new PollVotes.OptionWeight(e.getKey(), e.getValue()))
+                                    .collect(Collectors.toList());
+
+                            AppRatingsResponse.AppRating rating = new AppRatingsResponse.AppRating(
+                                    pollName,
+                                    extractedService,
+                                    appName,
+                                    pollData.getOwner(),
+                                    pollData.getPublished(),
+                                    pollData.getDescription(),
+                                    pollWithVotes.getTotalVotes(),
+                                    pollWithVotes.getTotalWeight(),
+                                    voteCounts,
+                                    voteWeights
+                            );
+
+                            ratingsMap.put(pollName, rating);
+                    }
+
+                    return new AppRatingsResponse(ratingsMap.size(), offset != null ? offset : 0, ratingsMap);
+
             } catch (ApiException e) {
                     throw e;
             } catch (DataException e) {

--- a/src/main/java/org/qortal/data/voting/PollDataWithVotes.java
+++ b/src/main/java/org/qortal/data/voting/PollDataWithVotes.java
@@ -1,0 +1,75 @@
+package org.qortal.data.voting;
+
+import java.util.Map;
+
+/**
+ * Container class that holds poll data along with aggregated vote counts and weights.
+ * Used for bulk fetching of poll data with voting information.
+ */
+public class PollDataWithVotes {
+
+	// Properties
+	private PollData pollData;
+	private Integer totalVotes;
+	private Integer totalWeight;
+	private Map<String, Integer> voteCountMap;
+	private Map<String, Integer> voteWeightMap;
+
+	// Constructors
+
+	public PollDataWithVotes() {
+		super();
+	}
+
+	public PollDataWithVotes(PollData pollData, Integer totalVotes, Integer totalWeight,
+			Map<String, Integer> voteCountMap, Map<String, Integer> voteWeightMap) {
+		this.pollData = pollData;
+		this.totalVotes = totalVotes;
+		this.totalWeight = totalWeight;
+		this.voteCountMap = voteCountMap;
+		this.voteWeightMap = voteWeightMap;
+	}
+
+	// Getters/setters
+
+	public PollData getPollData() {
+		return this.pollData;
+	}
+
+	public void setPollData(PollData pollData) {
+		this.pollData = pollData;
+	}
+
+	public Integer getTotalVotes() {
+		return this.totalVotes;
+	}
+
+	public void setTotalVotes(Integer totalVotes) {
+		this.totalVotes = totalVotes;
+	}
+
+	public Integer getTotalWeight() {
+		return this.totalWeight;
+	}
+
+	public void setTotalWeight(Integer totalWeight) {
+		this.totalWeight = totalWeight;
+	}
+
+	public Map<String, Integer> getVoteCountMap() {
+		return this.voteCountMap;
+	}
+
+	public void setVoteCountMap(Map<String, Integer> voteCountMap) {
+		this.voteCountMap = voteCountMap;
+	}
+
+	public Map<String, Integer> getVoteWeightMap() {
+		return this.voteWeightMap;
+	}
+
+	public void setVoteWeightMap(Map<String, Integer> voteWeightMap) {
+		this.voteWeightMap = voteWeightMap;
+	}
+
+}

--- a/src/main/java/org/qortal/repository/VotingRepository.java
+++ b/src/main/java/org/qortal/repository/VotingRepository.java
@@ -1,6 +1,7 @@
 package org.qortal.repository;
 
 import org.qortal.data.voting.PollData;
+import org.qortal.data.voting.PollDataWithVotes;
 import org.qortal.data.voting.VoteOnPollData;
 
 import java.util.List;
@@ -12,6 +13,19 @@ public interface VotingRepository {
 	public List<PollData> getAllPolls(Integer limit, Integer offset, Boolean reverse) throws DataException;
 
 	public PollData fromPollName(String pollName) throws DataException;
+
+	/**
+	 * Get polls matching a name prefix with aggregated vote data.
+	 * This method is optimized for bulk fetching of poll data with vote counts,
+	 * reducing the need for multiple separate queries.
+	 *
+	 * @param prefix Poll name prefix to match (e.g., "app-library-")
+	 * @param limit Maximum number of results (0 = all)
+	 * @param offset Pagination offset
+	 * @return List of polls with aggregated vote counts and weights
+	 * @throws DataException if database error occurs
+	 */
+	public List<PollDataWithVotes> getPollsByPrefix(String prefix, Integer limit, Integer offset) throws DataException;
 
 	public boolean pollExists(String pollName) throws DataException;
 

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBVotingRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBVotingRepository.java
@@ -1,6 +1,7 @@
 package org.qortal.repository.hsqldb;
 
 import org.qortal.data.voting.PollData;
+import org.qortal.data.voting.PollDataWithVotes;
 import org.qortal.data.voting.PollOptionData;
 import org.qortal.data.voting.VoteOnPollData;
 import org.qortal.repository.DataException;
@@ -9,7 +10,10 @@ import org.qortal.repository.VotingRepository;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class HSQLDBVotingRepository implements VotingRepository {
 
@@ -101,6 +105,80 @@ public class HSQLDBVotingRepository implements VotingRepository {
 			}
 		} catch (SQLException e) {
 			throw new DataException("Unable to fetch poll from repository", e);
+		}
+	}
+
+	@Override
+	public List<PollDataWithVotes> getPollsByPrefix(String prefix, Integer limit, Integer offset) throws DataException {
+		StringBuilder sql = new StringBuilder(1024);
+
+		// Query to get all polls matching prefix with their options and aggregated vote data
+		sql.append("SELECT ");
+		sql.append("  p.poll_name, p.description, p.creator, p.owner, p.published_when, ");
+		sql.append("  po.option_index, po.option_name, ");
+		sql.append("  COUNT(pv.voter) AS vote_count, ");
+		sql.append("  COALESCE(SUM(CASE WHEN a.blocks_minted + a.blocks_minted_penalty < 0 THEN 0 ELSE a.blocks_minted + a.blocks_minted_penalty END), 0) AS vote_weight ");
+		sql.append("FROM Polls p ");
+		sql.append("LEFT JOIN PollOptions po ON p.poll_name = po.poll_name ");
+		sql.append("LEFT JOIN PollVotes pv ON p.poll_name = pv.poll_name AND po.option_index = pv.option_index ");
+		sql.append("LEFT JOIN Accounts a ON pv.voter = a.public_key ");
+		sql.append("WHERE p.poll_name LIKE ? ");
+		sql.append("GROUP BY p.poll_name, p.description, p.creator, p.owner, p.published_when, po.option_index, po.option_name ");
+		sql.append("ORDER BY p.poll_name, po.option_index");
+
+		HSQLDBRepository.limitOffsetSql(sql, limit, offset);
+
+		List<PollDataWithVotes> results = new ArrayList<>();
+		Map<String, PollDataWithVotes> pollMap = new LinkedHashMap<>();
+
+		try (ResultSet resultSet = this.repository.checkedExecute(sql.toString(), prefix + "%")) {
+			if (resultSet == null)
+				return results;
+
+			// Process results - multiple rows per poll (one per option)
+			do {
+				String pollName = resultSet.getString(1);
+				String description = resultSet.getString(2);
+				byte[] creatorPublicKey = resultSet.getBytes(3);
+				String owner = resultSet.getString(4);
+				long published = resultSet.getLong(5);
+				Integer optionIndex = resultSet.getInt(6);
+				String optionName = resultSet.getString(7);
+				int voteCount = resultSet.getInt(8);
+				int voteWeight = resultSet.getInt(9);
+
+				// Get or create PollDataWithVotes for this poll
+				PollDataWithVotes pollWithVotes = pollMap.get(pollName);
+				if (pollWithVotes == null) {
+					// Create new poll data
+					PollData pollData = new PollData(creatorPublicKey, owner, pollName, description, new ArrayList<>(), published);
+					Map<String, Integer> voteCountMap = new HashMap<>();
+					Map<String, Integer> voteWeightMap = new HashMap<>();
+					pollWithVotes = new PollDataWithVotes(pollData, 0, 0, voteCountMap, voteWeightMap);
+					pollMap.put(pollName, pollWithVotes);
+				}
+
+				// Add option to poll if not null
+				if (optionName != null) {
+					pollWithVotes.getPollData().getPollOptions().add(new PollOptionData(optionName));
+
+					// Add vote counts and weights
+					pollWithVotes.getVoteCountMap().put(optionName, voteCount);
+					pollWithVotes.getVoteWeightMap().put(optionName, voteWeight);
+
+					// Update totals
+					pollWithVotes.setTotalVotes(pollWithVotes.getTotalVotes() + voteCount);
+					pollWithVotes.setTotalWeight(pollWithVotes.getTotalWeight() + voteWeight);
+				}
+
+			} while (resultSet.next());
+
+			// Convert map to list
+			results.addAll(pollMap.values());
+
+			return results;
+		} catch (SQLException e) {
+			throw new DataException("Unable to fetch polls by prefix from repository", e);
 		}
 	}
 

--- a/src/test/java/org/qortal/test/api/PollsApiTests.java
+++ b/src/test/java/org/qortal/test/api/PollsApiTests.java
@@ -1,0 +1,184 @@
+package org.qortal.test.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.qortal.api.model.AppRatingsResponse;
+import org.qortal.api.resource.PollsResource;
+import org.qortal.data.voting.PollData;
+import org.qortal.data.voting.PollDataWithVotes;
+import org.qortal.data.voting.PollOptionData;
+import org.qortal.repository.DataException;
+import org.qortal.repository.Repository;
+import org.qortal.repository.RepositoryManager;
+import org.qortal.test.common.ApiCommon;
+import org.qortal.test.common.Common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PollsApiTests extends ApiCommon {
+
+	private PollsResource pollsResource;
+
+	@Before
+	public void buildResource() {
+		this.pollsResource = (PollsResource) ApiCommon.buildResource(PollsResource.class);
+	}
+
+	@Test
+	public void testResource() {
+		assertNotNull(this.pollsResource);
+	}
+
+	@Test
+	public void testGetAppRatings() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Create test app rating polls
+			createTestAppRatingPoll(repository, "app-library-APP-rating-Q-Tube");
+			createTestAppRatingPoll(repository, "app-library-WEBSITE-rating-Q-Blog");
+			createTestAppRatingPoll(repository, "app-library-APP-rating-Q-Chat");
+
+			// Test getting all app ratings
+			AppRatingsResponse response = this.pollsResource.getAppRatings(null, null, null, null, null);
+			assertNotNull(response);
+			assertNotNull(response.ratings);
+			assertTrue(response.count >= 3);
+
+			// Verify response contains our test polls
+			assertTrue(response.ratings.containsKey("app-library-APP-rating-Q-Tube"));
+			assertTrue(response.ratings.containsKey("app-library-WEBSITE-rating-Q-Blog"));
+			assertTrue(response.ratings.containsKey("app-library-APP-rating-Q-Chat"));
+
+			// Clean up
+			deleteTestPoll(repository, "app-library-APP-rating-Q-Tube");
+			deleteTestPoll(repository, "app-library-WEBSITE-rating-Q-Blog");
+			deleteTestPoll(repository, "app-library-APP-rating-Q-Chat");
+		}
+	}
+
+	@Test
+	public void testGetAppRatingsWithServiceFilter() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Create test polls
+			createTestAppRatingPoll(repository, "app-library-APP-rating-Test1");
+			createTestAppRatingPoll(repository, "app-library-WEBSITE-rating-Test2");
+
+			// Test filtering by APP service
+			AppRatingsResponse appResponse = this.pollsResource.getAppRatings("APP", null, null, null, null);
+			assertNotNull(appResponse);
+			assertTrue(appResponse.ratings.containsKey("app-library-APP-rating-Test1"));
+			assertFalse(appResponse.ratings.containsKey("app-library-WEBSITE-rating-Test2"));
+
+			// Test filtering by WEBSITE service
+			AppRatingsResponse websiteResponse = this.pollsResource.getAppRatings("WEBSITE", null, null, null, null);
+			assertNotNull(websiteResponse);
+			assertFalse(websiteResponse.ratings.containsKey("app-library-APP-rating-Test1"));
+			assertTrue(websiteResponse.ratings.containsKey("app-library-WEBSITE-rating-Test2"));
+
+			// Clean up
+			deleteTestPoll(repository, "app-library-APP-rating-Test1");
+			deleteTestPoll(repository, "app-library-WEBSITE-rating-Test2");
+		}
+	}
+
+	@Test
+	public void testGetAppRatingsWithPagination() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Create multiple test polls
+			for (int i = 1; i <= 5; i++) {
+				createTestAppRatingPoll(repository, "app-library-APP-rating-TestApp" + i);
+			}
+
+			// Test with limit
+			AppRatingsResponse response = this.pollsResource.getAppRatings(null, 2, null, null, null);
+			assertNotNull(response);
+			assertTrue(response.ratings.size() <= 2);
+
+			// Test with offset
+			AppRatingsResponse offsetResponse = this.pollsResource.getAppRatings(null, 2, 1, null, null);
+			assertNotNull(offsetResponse);
+			assertEquals(Integer.valueOf(1), offsetResponse.offset);
+
+			// Clean up
+			for (int i = 1; i <= 5; i++) {
+				deleteTestPoll(repository, "app-library-APP-rating-TestApp" + i);
+			}
+		}
+	}
+
+	@Test
+	public void testGetAppRatingsResponseStructure() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			String pollName = "app-library-APP-rating-StructureTest";
+			createTestAppRatingPoll(repository, pollName);
+
+			AppRatingsResponse response = this.pollsResource.getAppRatings(null, null, null, null, null);
+			assertNotNull(response);
+			assertTrue(response.ratings.containsKey(pollName));
+
+			AppRatingsResponse.AppRating rating = response.ratings.get(pollName);
+			assertNotNull(rating);
+			assertEquals(pollName, rating.pollName);
+			assertEquals("APP", rating.service);
+			assertEquals("StructureTest", rating.appName);
+			assertNotNull(rating.owner);
+			assertNotNull(rating.published);
+			assertNotNull(rating.totalVotes);
+			assertNotNull(rating.totalWeight);
+			assertNotNull(rating.voteCounts);
+			assertNotNull(rating.voteWeights);
+
+			// Clean up
+			deleteTestPoll(repository, pollName);
+		}
+	}
+
+	@Test
+	public void testGetAppRatingsEmptyResult() {
+		// Test with non-existent service type
+		AppRatingsResponse response = this.pollsResource.getAppRatings(null, null, null, null, null);
+		assertNotNull(response);
+		assertNotNull(response.ratings);
+		// Should return successfully even if empty
+	}
+
+	// Helper methods
+
+	private void createTestAppRatingPoll(Repository repository, String pollName) throws DataException {
+		// Create poll options (1-5 star rating)
+		List<PollOptionData> options = new ArrayList<>();
+		options.add(new PollOptionData("1"));
+		options.add(new PollOptionData("2"));
+		options.add(new PollOptionData("3"));
+		options.add(new PollOptionData("4"));
+		options.add(new PollOptionData("5"));
+
+		// Create poll data
+		PollData pollData = new PollData(
+				Common.getTestAccount(repository, "alice").getPublicKey(),
+				aliceAddress,
+				pollName,
+				"Test app rating poll",
+				options,
+				System.currentTimeMillis()
+		);
+
+		// Save to repository
+		repository.getVotingRepository().save(pollData);
+		repository.saveChanges();
+	}
+
+	private void deleteTestPoll(Repository repository, String pollName) throws DataException {
+		try {
+			repository.getVotingRepository().delete(pollName);
+			repository.saveChanges();
+		} catch (DataException e) {
+			// Ignore if poll doesn't exist
+		}
+	}
+
+}

--- a/src/test/java/org/qortal/test/repository/VotingRepositoryTests.java
+++ b/src/test/java/org/qortal/test/repository/VotingRepositoryTests.java
@@ -1,0 +1,274 @@
+package org.qortal.test.repository;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.qortal.data.voting.PollData;
+import org.qortal.data.voting.PollDataWithVotes;
+import org.qortal.data.voting.PollOptionData;
+import org.qortal.data.voting.VoteOnPollData;
+import org.qortal.repository.DataException;
+import org.qortal.repository.Repository;
+import org.qortal.repository.RepositoryManager;
+import org.qortal.test.common.Common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class VotingRepositoryTests extends Common {
+
+	@Before
+	public void beforeTest() throws DataException {
+		Common.useDefaultSettings();
+	}
+
+	@After
+	public void afterTest() throws DataException {
+		// Clean up any test polls
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			cleanupTestPolls(repository);
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixBasic() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Create test polls
+			createTestPoll(repository, "app-library-APP-rating-TestApp1");
+			createTestPoll(repository, "app-library-APP-rating-TestApp2");
+			createTestPoll(repository, "other-poll-name");
+
+			// Fetch polls with app-library prefix
+			List<PollDataWithVotes> results = repository.getVotingRepository()
+					.getPollsByPrefix("app-library-", null, null);
+
+			assertNotNull(results);
+			assertTrue(results.size() >= 2);
+
+			// Verify that only app-library polls are returned
+			boolean foundTestApp1 = false;
+			boolean foundTestApp2 = false;
+			boolean foundOtherPoll = false;
+
+			for (PollDataWithVotes pollWithVotes : results) {
+				String pollName = pollWithVotes.getPollData().getPollName();
+				if (pollName.equals("app-library-APP-rating-TestApp1")) foundTestApp1 = true;
+				if (pollName.equals("app-library-APP-rating-TestApp2")) foundTestApp2 = true;
+				if (pollName.equals("other-poll-name")) foundOtherPoll = true;
+			}
+
+			assertTrue(foundTestApp1);
+			assertTrue(foundTestApp2);
+			assertFalse(foundOtherPoll);
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixWithVotes() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			String pollName = "app-library-APP-rating-VoteTest";
+			createTestPoll(repository, pollName);
+
+			// Add some votes
+			byte[] voterPublicKey = Common.getTestAccount(repository, "alice").getPublicKey();
+			VoteOnPollData vote = new VoteOnPollData(pollName, voterPublicKey, 4); // Vote for option index 4 (5 stars)
+			repository.getVotingRepository().save(vote);
+			repository.saveChanges();
+
+			// Fetch polls with votes
+			List<PollDataWithVotes> results = repository.getVotingRepository()
+					.getPollsByPrefix("app-library-APP-rating-VoteTest", null, null);
+
+			assertNotNull(results);
+			assertEquals(1, results.size());
+
+			PollDataWithVotes pollWithVotes = results.get(0);
+			assertNotNull(pollWithVotes.getTotalVotes());
+			assertNotNull(pollWithVotes.getTotalWeight());
+			assertNotNull(pollWithVotes.getVoteCountMap());
+			assertNotNull(pollWithVotes.getVoteWeightMap());
+
+			// Verify vote counts
+			assertTrue(pollWithVotes.getTotalVotes() >= 1);
+
+			// Verify option "5" has at least one vote
+			Map<String, Integer> voteCountMap = pollWithVotes.getVoteCountMap();
+			assertTrue(voteCountMap.containsKey("5"));
+			assertTrue(voteCountMap.get("5") >= 1);
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixWithLimit() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Create multiple test polls
+			for (int i = 1; i <= 5; i++) {
+				createTestPoll(repository, "app-library-APP-rating-LimitTest" + i);
+			}
+
+			// Fetch with limit of 2
+			List<PollDataWithVotes> results = repository.getVotingRepository()
+					.getPollsByPrefix("app-library-APP-rating-LimitTest", 2, null);
+
+			assertNotNull(results);
+			assertTrue(results.size() <= 2);
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixWithOffset() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Create multiple test polls
+			for (int i = 1; i <= 5; i++) {
+				createTestPoll(repository, "app-library-APP-rating-OffsetTest" + i);
+			}
+
+			// Fetch all
+			List<PollDataWithVotes> allResults = repository.getVotingRepository()
+					.getPollsByPrefix("app-library-APP-rating-OffsetTest", null, null);
+
+			// Fetch with offset
+			List<PollDataWithVotes> offsetResults = repository.getVotingRepository()
+					.getPollsByPrefix("app-library-APP-rating-OffsetTest", null, 2);
+
+			assertNotNull(allResults);
+			assertNotNull(offsetResults);
+			assertTrue(offsetResults.size() < allResults.size() || allResults.size() <= 2);
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixNoResults() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			// Search for non-existent prefix
+			List<PollDataWithVotes> results = repository.getVotingRepository()
+					.getPollsByPrefix("non-existent-prefix-", null, null);
+
+			assertNotNull(results);
+			assertTrue(results.isEmpty());
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixPollOptions() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			String pollName = "app-library-APP-rating-OptionsTest";
+			createTestPoll(repository, pollName);
+
+			List<PollDataWithVotes> results = repository.getVotingRepository()
+					.getPollsByPrefix(pollName, null, null);
+
+			assertNotNull(results);
+			assertEquals(1, results.size());
+
+			PollDataWithVotes pollWithVotes = results.get(0);
+			PollData pollData = pollWithVotes.getPollData();
+
+			// Verify poll options are populated
+			assertNotNull(pollData.getPollOptions());
+			assertEquals(5, pollData.getPollOptions().size());
+
+			// Verify option names (1-5 star ratings)
+			List<String> optionNames = new ArrayList<>();
+			for (PollOptionData option : pollData.getPollOptions()) {
+				optionNames.add(option.getOptionName());
+			}
+
+			assertTrue(optionNames.contains("1"));
+			assertTrue(optionNames.contains("2"));
+			assertTrue(optionNames.contains("3"));
+			assertTrue(optionNames.contains("4"));
+			assertTrue(optionNames.contains("5"));
+		}
+	}
+
+	@Test
+	public void testGetPollsByPrefixVoteMaps() throws DataException {
+		try (final Repository repository = RepositoryManager.getRepository()) {
+			String pollName = "app-library-APP-rating-MapTest";
+			createTestPoll(repository, pollName);
+
+			List<PollDataWithVotes> results = repository.getVotingRepository()
+					.getPollsByPrefix(pollName, null, null);
+
+			assertNotNull(results);
+			assertEquals(1, results.size());
+
+			PollDataWithVotes pollWithVotes = results.get(0);
+
+			// Verify vote count map contains all options
+			Map<String, Integer> voteCountMap = pollWithVotes.getVoteCountMap();
+			assertNotNull(voteCountMap);
+			assertTrue(voteCountMap.containsKey("1"));
+			assertTrue(voteCountMap.containsKey("2"));
+			assertTrue(voteCountMap.containsKey("3"));
+			assertTrue(voteCountMap.containsKey("4"));
+			assertTrue(voteCountMap.containsKey("5"));
+
+			// Verify vote weight map contains all options
+			Map<String, Integer> voteWeightMap = pollWithVotes.getVoteWeightMap();
+			assertNotNull(voteWeightMap);
+			assertTrue(voteWeightMap.containsKey("1"));
+			assertTrue(voteWeightMap.containsKey("2"));
+			assertTrue(voteWeightMap.containsKey("3"));
+			assertTrue(voteWeightMap.containsKey("4"));
+			assertTrue(voteWeightMap.containsKey("5"));
+		}
+	}
+
+	// Helper methods
+
+	private void createTestPoll(Repository repository, String pollName) throws DataException {
+		// Create poll options (1-5 star rating)
+		List<PollOptionData> options = new ArrayList<>();
+		options.add(new PollOptionData("1"));
+		options.add(new PollOptionData("2"));
+		options.add(new PollOptionData("3"));
+		options.add(new PollOptionData("4"));
+		options.add(new PollOptionData("5"));
+
+		// Create poll data
+		PollData pollData = new PollData(
+				Common.getTestAccount(repository, "alice").getPublicKey(),
+				Common.getTestAccount(repository, "alice").getAddress(),
+				pollName,
+				"Test poll",
+				options,
+				System.currentTimeMillis()
+		);
+
+		// Save to repository
+		repository.getVotingRepository().save(pollData);
+		repository.saveChanges();
+	}
+
+	private void cleanupTestPolls(Repository repository) throws DataException {
+		String[] testPollPrefixes = {
+				"app-library-APP-rating-TestApp",
+				"app-library-APP-rating-VoteTest",
+				"app-library-APP-rating-LimitTest",
+				"app-library-APP-rating-OffsetTest",
+				"app-library-APP-rating-OptionsTest",
+				"app-library-APP-rating-MapTest",
+				"other-poll-name"
+		};
+
+		for (String prefix : testPollPrefixes) {
+			try {
+				// Try to get and delete polls with this prefix
+				List<PollDataWithVotes> polls = repository.getVotingRepository()
+						.getPollsByPrefix(prefix, null, null);
+				for (PollDataWithVotes poll : polls) {
+					repository.getVotingRepository().delete(poll.getPollData().getPollName());
+				}
+				repository.saveChanges();
+			} catch (DataException e) {
+				// Ignore errors during cleanup
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Closes #329 

## Add Bulk App Ratings Endpoint

## Summary

Adds a new API endpoint that dramatically improves performance when fetching app ratings in Qortal-Hub.

## Problem

Currently, displaying app ratings requires making 2 separate API calls for each app (one for poll metadata, one for vote counts). For the community apps tab with hundreds of apps, this means 100-1000+ API calls, causing slow load times and unnecessary server load.

## Solution

New endpoint `GET /polls/apps/ratings` returns all app rating data in a single request, reducing hundreds of API calls down to just one.

**Performance Improvement**:
- Featured carousel: 12 calls → 1 call
- Official apps tab: 34 calls → 1 call
- Community apps (500+): 1000+ calls → 1 call

## Changes

- Added bulk ratings endpoint with filtering and pagination support
- Created optimized database query to fetch polls with vote counts
- Includes comprehensive test coverage
- Fully backward compatible with existing API

## Impact

Users will experience significantly faster app browsing, especially on initial page load. The server will handle fewer concurrent requests, improving overall system performance.
