### PR TITLE
fixed issue for some local node users when getting certs

### DIFF
--- a/src/main/java/org/qortal/api/restricted/resource/AdminResource.java
+++ b/src/main/java/org/qortal/api/restricted/resource/AdminResource.java
@@ -155,7 +155,7 @@ public class AdminResource {
 			return "CA certificate not found.";
 		}
 		try {
-			KeyStore keyStore = KeyStore.getInstance("PKCS12", "BC");
+			KeyStore keyStore = KeyStore.getInstance("PKCS12");
 			try (FileInputStream fis = new FileInputStream(keystorePath.toFile())) {
 				keyStore.load(fis, keystorePassword.toCharArray());
 			}
@@ -204,7 +204,7 @@ public class AdminResource {
 			return new CertificateSanInfo(dns, ip);
 		}
 		try {
-			KeyStore keyStore = KeyStore.getInstance("PKCS12", "BC");
+			KeyStore keyStore = KeyStore.getInstance("PKCS12");
 			try (FileInputStream fis = new FileInputStream(keystorePath.toFile())) {
 				keyStore.load(fis, keystorePassword.toCharArray());
 			}


### PR DESCRIPTION
Replaced KeyStore.getInstance("PKCS12", "BC") with KeyStore.getInstance("PKCS12") for the keystore used in createKeystore() (the one we write and store()).
Keystore file is still standard PKCS12 (one key entry with cert chain).
Avoids “JCE cannot authenticate the provider BC” during keyStore.store() on Oracle Java SE; cert/key generation in SslUtils still uses BC.