### PR TITLE
Reticulum Integration Test Stage

### DIFF
--- a/log4j2.properties
+++ b/log4j2.properties
@@ -38,11 +38,11 @@ rootLogger.appenderRef.rolling.ref = FILE
 #logger.ReticulumPeer.name = org.qortal.network.ReticulumPeer
 #logger.ReticulumPeer.level = debug
 
-# add DEBUG for RNS components
-logger.rns.name = org.qortal.network.RNS
-logger.rns.level = DEBUG
-logger.reticulumpeer.name = org.qortal.network.ReticulumPeer
-logger.reticulumpeer.level = DEBUG
+## add DEBUG for RNS components
+#logger.rns.name = org.qortal.network.RNS
+#logger.rns.level = DEBUG
+#logger.reticulumpeer.name = org.qortal.network.ReticulumPeer
+#logger.reticulumpeer.level = DEBUG
 
 ### end additional debug options
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 		<protoc.skip>true</protoc.skip>
 		<protobuf.version>3.25.7</protobuf.version>
 		<replacer.version>1.5.3</replacer.version>
-		<!--<reticulum.version>5afd959</reticulum.version>-->
-		<reticulum.version>ef41e9b</reticulum.version>
+		<!--<reticulum.version>ef41e9b</reticulum.version>-->
+		<reticulum.version>b228bb3</reticulum.version>
 		<jinjava.version>2.8.0</jinjava.version>
 		<simplemagic.version>1.17</simplemagic.version>
 		<!--<swagger-api.version>2.0.10</swagger-api.version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 		<protoc.skip>true</protoc.skip>
 		<protobuf.version>3.25.7</protobuf.version>
 		<replacer.version>1.5.3</replacer.version>
-		<!--<reticulum.version>ef41e9b</reticulum.version>-->
-		<reticulum.version>b228bb3</reticulum.version>
+		<!--<reticulum.version>b228bb3</reticulum.version>-->
+		<reticulum.version>8b892d4</reticulum.version>
 		<jinjava.version>2.8.0</jinjava.version>
 		<simplemagic.version>1.17</simplemagic.version>
 		<!--<swagger-api.version>2.0.10</swagger-api.version>-->

--- a/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataFileListManager.java
+++ b/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataFileListManager.java
@@ -1098,9 +1098,15 @@ public class ArbitraryDataFileListManager {
                             relayGetArbitraryDataFileListMessage.setId(message.getId());
 
                             LOGGER.debug("Rebroadcasting hash list request from peer {} for signature {} to our other peers... totalRequestTime: {}, requestHops: {}", peer, Base58.encode(signature), totalRequestTime, requestHops);
+                            final String senderHost = peer.getPeerData().getAddress().getHost();
                             NetworkData.getInstance().broadcast(
-                                    broadcastPeer ->
-                                            broadcastPeer == peer || Objects.equals(broadcastPeer.getPeerData().getAddress().getHost(), peer.getPeerData().getAddress().getHost()) ? null : relayGetArbitraryDataFileListMessage
+                                    broadcastPeer -> {
+                                        if (broadcastPeer == peer) return null;
+                                        // Skip same-IP peers (TCP/IP only; null-host Reticulum peers are excluded from this check)
+                                        String bcastHost = broadcastPeer.getPeerData().getAddress().getHost();
+                                        if (senderHost != null && senderHost.equals(bcastHost)) return null;
+                                        return relayGetArbitraryDataFileListMessage;
+                                    }
                             );
                         } else {
                             LOGGER.trace("Request has reached the maximum number of allowed hops");

--- a/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataFileManager.java
+++ b/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataFileManager.java
@@ -31,6 +31,7 @@ import org.qortal.data.arbitrary.ArbitraryRelayInfo;
 import org.qortal.data.network.PeerData;
 import org.qortal.data.transaction.ArbitraryTransactionData;
 import org.qortal.network.NetworkData;
+import org.qortal.network.RNS;
 import org.qortal.network.Peer;
 import org.qortal.network.PeerAddress;
 import org.qortal.network.PeerList;
@@ -158,6 +159,23 @@ public class ArbitraryDataFileManager extends Thread {
      */
     private String createRelayKey(String hash58, Peer sourcePeer) {
         return hash58 + "|" + sourcePeer.getPeerData().getAddress().toString();
+    }
+
+    /**
+     * Compares two PeerAddresses for equality without assuming an IP host is present.
+     * Reticulum peers have no IP host; they're compared by destination hash.
+     * TCP/IP peers are compared by host:port.
+     */
+    private static boolean isSamePeerAddress(PeerAddress a, PeerAddress b) {
+        if (a == null || b == null) return false;
+        byte[] dhashA = a.getDestinationHash();
+        byte[] dhashB = b.getDestinationHash();
+        if (dhashA != null || dhashB != null) {
+            return Arrays.equals(dhashA, dhashB);
+        }
+        String hostA = a.getHost();
+        String hostB = b.getHost();
+        return hostA != null && hostA.equalsIgnoreCase(hostB) && a.getPort() == b.getPort();
     }
     
     /**
@@ -560,6 +578,23 @@ public class ArbitraryDataFileManager extends Thread {
 		Peer getRequestingPeer(PeerList connectedPeers) {
 			return connectedPeers.get(requestingPeerData);
 		}
+
+		/**
+		 * Resolves the Peer, falling back to a Reticulum peer list when TCP/IP lookup returns null
+		 * (Reticulum peers have no IP host and are excluded from PeerList's map).
+		 */
+		Peer getRequestingPeer(PeerList connectedPeers, List<? extends Peer> reticulumPeers) {
+			Peer found = getRequestingPeer(connectedPeers);
+			if (found != null) return found;
+			if (reticulumPeers == null || requestingPeerData == null) return null;
+			byte[] dhash = requestingPeerData.getAddress().getDestinationHash();
+			if (dhash == null) return null;
+			for (Peer p : reticulumPeers) {
+				if (Arrays.equals(p.getPeerData().getAddress().getDestinationHash(), dhash))
+					return p;
+			}
+			return null;
+		}
 	}
 
     private ArbitraryDataFileManager() {
@@ -573,13 +608,15 @@ public class ArbitraryDataFileManager extends Thread {
         cleaner.scheduleAtFixedRate(() -> {
             int totalRemoved = 0;
             PeerList connectedPeers = NetworkData.getInstance().getImmutableHandshakedPeers();
+            List<? extends Peer> rnsPeers = RNS.getInstance().isMeshStarted()
+                    ? RNS.getInstance().getActiveDataPeers() : Collections.emptyList();
             Iterator<Map.Entry<String, List<PendingRelayForward>>> iterator = pendingRelayForwards.entrySet().iterator();
-            
+
             while (iterator.hasNext()) {
                 Map.Entry<String, List<PendingRelayForward>> entry = iterator.next();
                 String compositeKey = entry.getKey();  // Format: hash58|peerAddress
                 List<PendingRelayForward> forwards = entry.getValue();
-                
+
                 // Remove stale forwards and disconnected peers from the list
                 int beforeSize = forwards.size();
                 forwards.removeIf(forward -> {
@@ -588,7 +625,7 @@ public class ArbitraryDataFileManager extends Thread {
                         return true;
                     }
                     // Remove if peer is no longer connected (prevents memory leak from stale Peer references)
-                    Peer peer = forward.getRequestingPeer(connectedPeers);
+                    Peer peer = forward.getRequestingPeer(connectedPeers, rnsPeers);
                     return peer == null;
                 });
                 int removedCount = beforeSize - forwards.size();
@@ -847,12 +884,14 @@ public class ArbitraryDataFileManager extends Thread {
         final long relayMinimumTimestamp = now - ArbitraryDataManager.getInstance().ARBITRARY_RELAY_TIMEOUT;
         // Clean up relay map: remove stale entries AND entries for disconnected peers
         PeerList connectedPeers = NetworkData.getInstance().getImmutableHandshakedPeers();
+        List<? extends Peer> rnsPeers = RNS.getInstance().isMeshStarted()
+                ? RNS.getInstance().getActiveDataPeers() : Collections.emptyList();
         arbitraryRelayMap.removeIf(entry -> {
             if (entry == null || entry.getTimestamp() == null || entry.getTimestamp() < relayMinimumTimestamp) {
                 return true; // Remove stale entries
             }
             // Also remove entries for peers that are no longer connected (prevents memory leak)
-            if (entry.getPeerData() != null && entry.getPeer(connectedPeers) == null) {
+            if (entry.getPeerData() != null && entry.getPeer(connectedPeers, rnsPeers) == null) {
                 LOGGER.trace("Removing relay map entry for disconnected peer: {}", entry.getPeerData());
                 return true;
             }
@@ -992,18 +1031,20 @@ public class ArbitraryDataFileManager extends Thread {
             
             // Get current connected peers snapshot for resolving Peer objects
             PeerList connectedPeers = NetworkData.getInstance().getImmutableHandshakedPeers();
-            
+            List<? extends Peer> rnsPeers = RNS.getInstance().isMeshStarted()
+                    ? RNS.getInstance().getActiveDataPeers() : Collections.emptyList();
+
             // Forward to all peers that requested this hash from us
             for (PendingRelayForward forward : pendingRequests) {
                 // Skip stale requests
                 if (forward.isStale()) {
-                    LOGGER.debug("Skipping stale relay forward for hash {} to peer {} (age: {}ms)", 
+                    LOGGER.debug("Skipping stale relay forward for hash {} to peer {} (age: {}ms)",
                             hash58, forward.requestingPeerData, NTP.getTime() - forward.timestamp);
                     continue;
                 }
-                
+
                 // Resolve Peer object from connected peers (filters out disconnected peers)
-                Peer requestingPeer = forward.getRequestingPeer(connectedPeers);
+                Peer requestingPeer = forward.getRequestingPeer(connectedPeers, rnsPeers);
                 if (requestingPeer == null) {
                     // Peer is no longer connected - skip this forward
                     LOGGER.debug("Skipping relay forward for hash {} - peer {} is no longer connected", 
@@ -1629,7 +1670,9 @@ public class ArbitraryDataFileManager extends Thread {
                 
                 // Get the relay peer info - resolve from connected peers to avoid stale references
                 PeerList connectedPeers = NetworkData.getInstance().getImmutableHandshakedPeers();
-                Peer relayPeer = relayInfo.getPeer(connectedPeers);
+                List<? extends Peer> rnsPeers = RNS.getInstance().isMeshStarted()
+                        ? RNS.getInstance().getActiveDataPeers() : Collections.emptyList();
+                Peer relayPeer = relayInfo.getPeer(connectedPeers, rnsPeers);
                 PeerData relayPeerData = relayInfo.getPeerData();
                 PeerAddress relayPeerAddress = relayPeerData != null ? relayPeerData.getAddress() : null;
                 
@@ -1645,18 +1688,16 @@ public class ArbitraryDataFileManager extends Thread {
                     if (relayPeer != null) {
                         PeerAddress requestingPeerAddress = peer.getPeerData().getAddress();
                         PeerAddress resolvedRelayAddress = relayPeer.getPeerData().getAddress();
-                        
-                        // Check if the relay peer is the same as the requesting peer (would create a loop)
-                        boolean isSamePeer = requestingPeerAddress.getHost().equalsIgnoreCase(resolvedRelayAddress.getHost())
-                                          && requestingPeerAddress.getPort() == resolvedRelayAddress.getPort();
-                        
+
+                        // Check if the relay peer is the same as the requesting peer (would create a loop).
+                        // Use destination hash for Reticulum peers (no IP host); host:port for TCP/IP peers.
+                        boolean isSamePeer = isSamePeerAddress(requestingPeerAddress, resolvedRelayAddress);
+
                         if (isSamePeer) {
-                            LOGGER.debug("Relay loop detected for hash {}! Optimal relay peer {} ({}:{}) is the SAME as requesting peer {} ({}:{})", 
-                                    hash58,
-                                    relayPeer, resolvedRelayAddress.getHost(), resolvedRelayAddress.getPort(),
-                                    peer, requestingPeerAddress.getHost(), requestingPeerAddress.getPort());
+                            LOGGER.debug("Relay loop detected for hash {}! Optimal relay peer {} is the SAME as requesting peer {}",
+                                    hash58, resolvedRelayAddress, requestingPeerAddress);
                             LOGGER.debug("This indicates multiple relay infos exist and hop-count optimization selected the requester");
-                            
+
                             // Try to find an alternative relay peer that ISN'T the requesting peer
                             if (allRelayInfos != null && allRelayInfos.size() > 1) {
                                 LOGGER.debug("Searching for alternative relay peer from {} available options", allRelayInfos.size());
@@ -1665,19 +1706,17 @@ public class ArbitraryDataFileManager extends Thread {
                                             PeerAddress infoAddr = info.getPeerData() != null ? info.getPeerData().getAddress() : null;
                                             if (infoAddr == null) return false;
                                             // Filter out the requesting peer to prevent loops
-                                            boolean isNotRequestingPeer = !(infoAddr.getHost().equalsIgnoreCase(requestingPeerAddress.getHost())
-                                                                         && infoAddr.getPort() == requestingPeerAddress.getPort());
-                                            return isNotRequestingPeer;
+                                            return !isSamePeerAddress(infoAddr, requestingPeerAddress);
                                         })
                                         .min(Comparator.comparingInt(info -> info.getRequestHops() != null ? info.getRequestHops() : Integer.MAX_VALUE))
                                         .orElse(null);
-                                
+
                                 if (alternativeRelayInfo != null) {
-                                    LOGGER.debug("Found alternative relay peer: {} (hops: {})", 
+                                    LOGGER.debug("Found alternative relay peer: {} (hops: {})",
                                             alternativeRelayInfo.getPeerData().getAddress(),
                                             alternativeRelayInfo.getRequestHops());
                                     relayInfo = alternativeRelayInfo;
-                                    relayPeer = relayInfo.getPeer(connectedPeers);
+                                    relayPeer = relayInfo.getPeer(connectedPeers, rnsPeers);
                                     relayPeerData = relayInfo.getPeerData();
                                     relayPeerAddress = relayPeerData != null ? relayPeerData.getAddress() : null;
                                 } else {

--- a/src/main/java/org/qortal/data/arbitrary/ArbitraryRelayInfo.java
+++ b/src/main/java/org/qortal/data/arbitrary/ArbitraryRelayInfo.java
@@ -4,6 +4,8 @@ import org.qortal.data.network.PeerData;
 import org.qortal.network.Peer;
 import org.qortal.network.PeerList;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -71,6 +73,23 @@ public class ArbitraryRelayInfo {
             return null;
         }
         return connectedPeers.get(peerData);
+    }
+
+    /**
+     * Resolves the Peer object, falling back to a Reticulum peer list when the TCP/IP lookup
+     * returns null (Reticulum peers have no IP host and are excluded from PeerList's map).
+     */
+    public Peer getPeer(PeerList connectedPeers, List<? extends Peer> reticulumPeers) {
+        Peer found = getPeer(connectedPeers);
+        if (found != null) return found;
+        if (reticulumPeers == null || peerData == null) return null;
+        byte[] dhash = peerData.getAddress().getDestinationHash();
+        if (dhash == null) return null;
+        for (Peer p : reticulumPeers) {
+            if (Arrays.equals(p.getPeerData().getAddress().getDestinationHash(), dhash))
+                return p;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/qortal/network/NetworkData.java
+++ b/src/main/java/org/qortal/network/NetworkData.java
@@ -2562,8 +2562,8 @@ public class NetworkData {
             // Use PeerSendManager for retry logic and backpressure handling
             try {
                 PeerSendManager sendManager = PeerSendManagement.getInstance().getOrCreateSendManager(peer, true);
-                
-                
+
+
                 // Calculate estimated message size for queue management
                 int estimatedSize;
                 try {
@@ -2573,7 +2573,7 @@ public class NetworkData {
                     LOGGER.warn("Failed to calculate message size for broadcast, using default: {}", e.getMessage());
                     estimatedSize = 1024;
                 }
-                
+
                 // Use HIGH_PRIORITY for broadcasts since they're important (file list requests, etc.)
                 sendManager.queueMessageFactoryWithPriority(
                     PeerSendManager.HIGH_PRIORITY,
@@ -2584,13 +2584,24 @@ public class NetworkData {
             } catch (MessageException e) {
                 // PeerSendManager rejected the message (cooldown, etc.)
                 LOGGER.debug("PeerSendManager rejected broadcast message to {}: {}", peer, e.getMessage());
-                
+
                 // Only disconnect if the socket is actually gone
                 if (peer.getSocketChannel() == null || !peer.getSocketChannel().isOpen()) {
                     LOGGER.trace("Failed to broadcast message to {} - socket closed", peer);
                     peer.disconnect("failed to broadcast message");
                 }
             }
+        }
+
+        // Reticulum DATA peers bypass PeerSendManager (no TCP socket); send directly via buffer.
+        for (org.qortal.network.ReticulumPeer rPeer : RNS.getInstance().getActiveDataPeers()) {
+            if (this.isShuttingDown)
+                return;
+            Message message = peerMessageBuilder.apply(rPeer);
+            if (message == null)
+                continue;
+            LOGGER.trace("Broadcasting Message {} to Reticulum DATA peer {}", message.getType(), rPeer);
+            rPeer.sendMessage(message);
         }
     }
 

--- a/src/main/java/org/qortal/network/PeerList.java
+++ b/src/main/java/org/qortal/network/PeerList.java
@@ -47,10 +47,12 @@ public class PeerList implements Iterable<Peer> {
         // Create an immutable list copy
         this.peerList = List.copyOf(sourcePeers);
 
-        // Build a map for fast lookups based on the peer's host (case-insensitive)
+        // Build a map for fast lookups based on the peer's host (case-insensitive).
+        // Peers without an IP host (e.g. Reticulum peers) are excluded from the map
+        // but remain in peerList for iteration.
         this.peerMap = this.peerList.stream()
+                .filter(peer -> peer.getPeerData().getAddress().getHost() != null)
                 .collect(Collectors.toMap(
-                        // Use the case-insensitive host as the key
                         peer -> peer.getPeerData().getAddress().getHost().toLowerCase(),
                         Function.identity(),
                         (existing, replacement) -> existing // Handle duplicates, keep existing
@@ -68,9 +70,10 @@ public class PeerList implements Iterable<Peer> {
         if (pd == null || pd.getAddress() == null) {
             return null;
         }
-        // Get host and lookup using the case-insensitive key
-        final String host = pd.getAddress().getHost().toLowerCase();
-        return peerMap.get(host);
+        // Get host and lookup using the case-insensitive key (null for Reticulum peers → not in map)
+        final String host = pd.getAddress().getHost();
+        if (host == null) return null;
+        return peerMap.get(host.toLowerCase());
     }
 
     /**
@@ -84,9 +87,10 @@ public class PeerList implements Iterable<Peer> {
         if (pa == null) {
             return null;
         }
-        // Get host and lookup using the case-insensitive key
-        final String host = pa.getHost().toLowerCase();
-        return peerMap.get(host);
+        // Get host and lookup using the case-insensitive key (null for Reticulum peers → not in map)
+        final String host = pa.getHost();
+        if (host == null) return null;
+        return peerMap.get(host.toLowerCase());
     }
 
     /**
@@ -100,9 +104,10 @@ public class PeerList implements Iterable<Peer> {
         if (pd == null || pd.getAddress() == null) {
             return false;
         }
-        // Get host and check using the case-insensitive key
-        final String host = pd.getAddress().getHost().toLowerCase();
-        return peerMap.containsKey(host);
+        // Get host and check using the case-insensitive key (null for Reticulum peers → not in map)
+        final String host = pd.getAddress().getHost();
+        if (host == null) return false;
+        return peerMap.containsKey(host.toLowerCase());
     }
 
     /**
@@ -116,9 +121,10 @@ public class PeerList implements Iterable<Peer> {
         if (pa == null) {
             return false;
         }
-        // Get host and check using the case-insensitive key
-        final String host = pa.getHost().toLowerCase();
-        return peerMap.containsKey(host);
+        // Get host and check using the case-insensitive key (null for Reticulum peers → not in map)
+        final String host = pa.getHost();
+        if (host == null) return false;
+        return peerMap.containsKey(host.toLowerCase());
     }
 
     /**

--- a/src/main/java/org/qortal/network/RNS.java
+++ b/src/main/java/org/qortal/network/RNS.java
@@ -108,7 +108,6 @@ import com.google.common.collect.Maps;
 @Data
 @Slf4j
 public class RNS {
-//public class RNS extends Thread {
 
     //private static RNS instance;
     Reticulum reticulum;
@@ -168,7 +167,7 @@ public class RNS {
     //private final ExecuteProduceConsume rnsEPC;
     private ExecutorService rnsWorkerPool;
     // Dedicated single-thread executors for announce and reconnect (BASE and DATA).
-    // Root cause of prior failures: Transport.outbound() busy-waits on jobsLock (non-interruptibly).
+    // Root cause of prior failures: Transport.outbound() busy-waits on jobsLock (non-interruptible).
     // A full table cull triggered by link drops holds jobsLock for 30-60s. With a shared pool,
     // each watchdog reset spawns a new thread, creating 20+ threads all spinning on jobsLock
     // simultaneously — massively worsening contention and making the cull take even longer.
@@ -286,16 +285,6 @@ public class RNS {
         log.debug("reticulum instance created: {}", reticulum);
         //        Settings.getInstance().getMaxRNSNetworkThreadPoolSize(),
         var rnsThreadPriority = Settings.getInstance().getNetworkThreadPriority(); // default: 7
-        ////// if possible one higher than NetworkThreadPriority
-        ////if (rnsThreadPriority < 10) {
-        ////    rnsThreadPriority++;
-        ////}
-        //ExecutorService RNSExecutor = new ThreadPoolExecutor(1,
-        //        Settings.getInstance().getReticulumMaxNetworkThreadPoolSize(),  // we don't need many max threads
-        //        NETWORK_EPC_KEEPALIVE, TimeUnit.SECONDS,
-        //        new SynchronousQueue<Runnable>(),
-        //        new NamedThreadFactory("RNS-EPC", rnsThreadPriority));
-        //rnsEPC = new RNSProcessor(RNSExecutor);        // Worker pool: message handling only (MessageTask, ConnectTask). I/O runs on dedicated ioThread.
         this.rnsWorkerPool = new ThreadPoolExecutor(
                 3, Settings.getInstance().getReticulumMaxNetworkThreadPoolSize(),
                 NETWORK_EPC_KEEPALIVE, TimeUnit.SECONDS,

--- a/src/main/java/org/qortal/network/RNS.java
+++ b/src/main/java/org/qortal/network/RNS.java
@@ -118,6 +118,7 @@ public class RNS {
     //static final String defaultConfigPath = ".reticulum"; // if empty will look in Reticulums default paths
     static final String defaultConfigPath = Settings.getInstance().isTestNet() ? RNSCommon.defaultRNSConfigPathTestnet: RNSCommon.defaultRNSConfigPath;
     static final String CORE_ASPECT = "qortal.core";
+    static final String QDN_ASPECT  = "qortal.qdn";
     private final int MAX_PEERS = Settings.getInstance().getReticulumMaxPeers();
     private final int MIN_DESIRED_CORE_PEERS = Settings.getInstance().getReticulumMinDesiredCorePeers();
     private final int MIN_DESIRED_DATA_PEERS = Settings.getInstance().getReticulumMinDesiredDataPeers();
@@ -163,9 +164,10 @@ public class RNS {
 
     /** Produces Connect tasks for the baseDestination and submits to worker pool. */
     private Thread rnsBaseThread;
+    private Thread rnsDataThread;
     //private final ExecuteProduceConsume rnsEPC;
     private ExecutorService rnsWorkerPool;
-    // Dedicated single-thread executors for announce and reconnect.
+    // Dedicated single-thread executors for announce and reconnect (BASE and DATA).
     // Root cause of prior failures: Transport.outbound() busy-waits on jobsLock (non-interruptibly).
     // A full table cull triggered by link drops holds jobsLock for 30-60s. With a shared pool,
     // each watchdog reset spawns a new thread, creating 20+ threads all spinning on jobsLock
@@ -174,6 +176,8 @@ public class RNS {
     // spin on jobsLock; tasks queue up naturally and complete when the cull finishes.
     private ExecutorService announceExecutor;
     private ExecutorService reconnectExecutor;
+    private ExecutorService dataAnnounceExecutor;
+    private ExecutorService dataReconnectExecutor;
     private static final long NETWORK_EPC_KEEPALIVE = 5L; // 1 second
     //private int totalThreadCount = 0;
     private final int reticulumMaxNetworkThreadPoolSize = Settings.getInstance().getReticulumMaxNetworkThreadPoolSize();
@@ -217,6 +221,23 @@ public class RNS {
     // library's built-in auto-reconnect rather than spinning on a stuck jobsLock forever.
     private volatile int consecutiveStuckTasks = 0;
     private static final int BACKBONE_FORCE_RECONNECT_THRESHOLD = 2;
+
+    // DATA loop timing — mirrors BASE, separate so DATA and BASE don't interfere
+    private static final long DATA_LOOP_ANNOUNCE_INTERVAL_MS  = 30_000L;
+    private static final long DATA_LOOP_RECONNECT_INTERVAL_MS = 15_000L;
+    private volatile long lastDataLoopAnnounceMs  = 0;
+    private volatile long lastDataLoopReconnectMs = 0;
+    private volatile long dataAnnounceTaskStartedMs  = 0L;
+    private volatile long dataReconnectTaskStartedMs = 0L;
+    private volatile java.util.concurrent.Future<?> dataAnnounceTaskFuture  = null;
+    private volatile java.util.concurrent.Future<?> dataReconnectTaskFuture = null;
+
+    // Persisted DATA peer hashes — same semantics as knownPeerHashes / loadedPeerHashes for BASE
+    private static final String KNOWN_DATA_PEERS_FILE = "known_data_peer_hashes.txt";
+    private final Set<String> knownDataPeerHashes  = Collections.synchronizedSet(new HashSet<>());
+    private final Set<String> loadedDataPeerHashes = Collections.synchronizedSet(new HashSet<>());
+    private final java.util.concurrent.ConcurrentHashMap<String, Long> pendingDataLinkFailureMs =
+            new java.util.concurrent.ConcurrentHashMap<>();
 
     /** Called by ReticulumPeer.linkClosed() to kick the announce/path-recovery cycle soon.
      *  Uses a 5s delay rather than 0 to avoid tight reconnect loops when links close rapidly
@@ -290,6 +311,14 @@ public class RNS {
                 NETWORK_EPC_KEEPALIVE, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<>(1),
                 new NamedThreadFactory("RNS-Reconnect", rnsThreadPriority));
+        this.dataAnnounceExecutor = new ThreadPoolExecutor(1, 1,
+                NETWORK_EPC_KEEPALIVE, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(1),
+                new NamedThreadFactory("RNS-DataAnnounce", rnsThreadPriority));
+        this.dataReconnectExecutor = new ThreadPoolExecutor(1, 1,
+                NETWORK_EPC_KEEPALIVE, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(1),
+                new NamedThreadFactory("RNS-DataReconnect", rnsThreadPriority));
     }
 
     // Note: potentially create persistent serverIdentity (utility rnid) and load it from file
@@ -339,42 +368,39 @@ public class RNS {
    
         baseDestination.setProofStrategy(ProofStrategy.PROVE_ALL);
         baseDestination.setAcceptLinkRequests(true);
-        //dataDestination.setProofStrategy(ProofStrategy.PROVE_ALL);
-        //dataDestination.setAcceptLinkRequests(true);
-        
+        dataDestination.setProofStrategy(ProofStrategy.PROVE_ALL);
+        dataDestination.setAcceptLinkRequests(true);
+
         baseDestination.setLinkEstablishedCallback(this::baseClientConnected);
-        //dataDestination.setLinkEstablishedCallback(this::dataClientConnected);
+        dataDestination.setLinkEstablishedCallback(this::dataClientConnected);
         //Transport.getInstance().registerAnnounceHandler(new QAnnounceHandler());
         Transport.getInstance().registerAnnounceHandler(new QAnnounceHandler("qortal.core"));
         Transport.getInstance().registerAnnounceHandler(new QAnnounceHandler("qortal.qdn"));
         log.debug("announceHandlers: {}", Transport.getInstance().getAnnounceHandlers());
         // Load peer hashes persisted from previous run so we can call requestPath() fast on restart.
         loadKnownPeerHashes();
+        loadKnownDataPeerHashes();
         // do a first announce (across all configured interfaces)
         baseDestination.announce();
         log.info("Sent initial announce from {} ({})", encodeHexString(baseDestination.getHash()), baseDestination.getName());
-        // Seed the base-loop announce timer. If we loaded known peer hashes (i.e. this is a restart),
-        // fire path requests at t=15s to give the backbone time to connect — much faster than
-        // waiting 30s with zero peers. On a first-ever start knownPeerHashes is empty so we use
-        // the normal 30s window.
+        dataDestination.announce();
+        log.info("Sent initial announce from {} ({})", encodeHexString(dataDestination.getHash()), dataDestination.getName());
+        // Seed loop announce timers. On restart (non-empty loaded hashes) fire path requests
+        // at t=15s; on first-ever start use the full 30s window.
         this.lastBaseLoopAnnounceMs = loadedPeerHashes.isEmpty()
                 ? System.currentTimeMillis()
                 : System.currentTimeMillis() - BASE_LOOP_ANNOUNCE_INTERVAL_MS + 15_000L;
-        // announce QDN destination (across all configured interfaces)
-        //dataDestination.announce();
-        //log.debug("Sent initial announce from {} ({})", encodeHexString(dataDestination.getHash()), dataDestination.getName());
+        this.lastDataLoopAnnounceMs = loadedDataPeerHashes.isEmpty()
+                ? System.currentTimeMillis()
+                : System.currentTimeMillis() - DATA_LOOP_ANNOUNCE_INTERVAL_MS + 15_000L;
 
-        // Start up first networking thread (the RNS main thread, similar to the "server loop" in a standalone Reticulum app)
-        //rnsEPC.start();
-
-        // Start up "main" thread, one for each destination to handle aspects separately.
-        // Note: Each such thread is equivalent to the peerTypes "NETWORK" and "NETWORKDATA".
+        // Start up "main" threads, one per destination / peer aspect.
         this.rnsBaseThread = new Thread(this::runBaseLoop, "rnsMesh-BASE");
-        this.rnsBaseThread.setDaemon(true); // daemon so SIGTERM doesn't hang JVM exit
+        this.rnsBaseThread.setDaemon(true);
         this.rnsBaseThread.start();
-        //this.rnsDataThread = new Thread(this::runDataLoop, "rnsMesh-DATA");
-        //this.rnsDataThread.setDaemon(false);
-        //this.rnsDataThread.start();
+        this.rnsDataThread = new Thread(this::runDataLoop, "rnsMesh-DATA");
+        this.rnsDataThread.setDaemon(true);
+        this.rnsDataThread.start();
 
         this.meshStarted = true;
         log.info("RNS mesh started, baseDestination: {}", encodeHexString(baseDestination.getHash()));
@@ -703,10 +729,166 @@ public class RNS {
         log.debug("Mesh loop for destination {} exiting.", baseDestination.getName());
     }
 
-    //// "main" loop for dataDestination (QDN tasks)
-    //private void runDataLoop() {
-    //    //... TODO (similar to runBaseLoop()
-    //}
+    /** Kick the DATA announce/reconnect cycle within ~5s (mirrors triggerImmediateAnnounce()). */
+    public void triggerImmediateDataAnnounce() {
+        this.lastDataLoopAnnounceMs = System.currentTimeMillis() - DATA_LOOP_ANNOUNCE_INTERVAL_MS + 5_000L;
+    }
+
+    // "main" loop for dataDestination (QDN tasks) — mirrors runBaseLoop() for DATA aspect
+    private void runDataLoop() {
+        while (!isShuttingDown && !Thread.currentThread().isInterrupted()) {
+            try {
+                final List<ReticulumPeer> peersThisRound = Stream.concat(
+                        this.getActiveImmutableLinkedPeers().stream()
+                                .filter(p -> p.getPeerAspect() == RNSCommon.PeerAspect.DATA),
+                        this.getImmutableIncomingPeers().stream()
+                                .filter(p -> p.getPeerAspect() == RNSCommon.PeerAspect.DATA)
+                                .filter(p -> {
+                                    var pl = p.getPeerLink();
+                                    return nonNull(pl) && pl.getStatus() == ACTIVE;
+                                })
+                ).collect(Collectors.toList());
+
+                final Long now = NTP.getTime();
+                for (ReticulumPeer peer : peersThisRound) {
+                    ExecuteProduceConsume.Task task;
+                    // DATA messages are routed to NetworkData.onMessage() via MessageTask(NETWORKDATA)
+                    while ((task = peer.getMessageTask(Peer.NETWORKDATA)) != null) {
+                        final ExecuteProduceConsume.Task t = task;
+                        try {
+                            rnsWorkerPool.execute(() -> {
+                                try {
+                                    t.perform();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                } catch (Exception e) {
+                                    log.warn("Reticulum DATA worker task threw: {}", e.getMessage(), e);
+                                }
+                            });
+                        } catch (java.util.concurrent.RejectedExecutionException e) {
+                            log.warn("[{}] Reticulum DATA worker pool rejected message task", peer.getPeerConnectionId());
+                            break;
+                        }
+                    }
+
+                    ExecuteProduceConsume.Task pingTask = peer.getPingTask(now);
+                    if (pingTask != null) {
+                        final ExecuteProduceConsume.Task pt = pingTask;
+                        try {
+                            rnsWorkerPool.execute(() -> {
+                                try {
+                                    pt.perform();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                } catch (Exception e) {
+                                    log.warn("Reticulum DATA ping task threw: {}", e.getMessage(), e);
+                                }
+                            });
+                        } catch (java.util.concurrent.RejectedExecutionException e) {
+                            log.warn("[{}] Reticulum DATA worker pool rejected ping task", peer.getPeerConnectionId());
+                        }
+                    }
+                }
+
+                long nowMs = System.currentTimeMillis();
+
+                // Periodic DATA announce
+                if (nowMs - lastDataLoopAnnounceMs >= DATA_LOOP_ANNOUNCE_INTERVAL_MS) {
+                    lastDataLoopAnnounceMs = nowMs;
+                    if (dataAnnounceTaskStartedMs == 0L) {
+                        dataAnnounceTaskStartedMs = nowMs;
+                        try {
+                            dataAnnounceTaskFuture = dataAnnounceExecutor.submit(() -> {
+                                Thread.interrupted();
+                                try {
+                                    maybeAnnounce(dataDestination, RNSCommon.PeerAspect.DATA);
+                                } catch (Exception e) {
+                                    log.warn("Exception in data loop announce: {}", e.getMessage(), e);
+                                } finally {
+                                    if (dataAnnounceTaskStartedMs != 0L) {
+                                        dataAnnounceTaskStartedMs = 0L;
+                                    }
+                                }
+                            });
+                        } catch (java.util.concurrent.RejectedExecutionException e) {
+                            dataAnnounceTaskStartedMs = 0L;
+                        }
+                    }
+                }
+
+                // Periodic DATA peer reconnect
+                if (nowMs - lastDataLoopReconnectMs >= DATA_LOOP_RECONNECT_INTERVAL_MS) {
+                    lastDataLoopReconnectMs = nowMs;
+                    if (dataReconnectTaskStartedMs == 0L) {
+                        dataReconnectTaskStartedMs = nowMs;
+                        final int activeData = (int) getActiveImmutableLinkedPeers().stream()
+                                .filter(p -> p.getPeerAspect() == RNSCommon.PeerAspect.DATA).count();
+                        final List<ReticulumPeer> currentDataLinked = getImmutableLinkedPeers().stream()
+                                .filter(p -> p.getPeerAspect() == RNSCommon.PeerAspect.DATA)
+                                .collect(Collectors.toList());
+                        final Set<String> dataTargets = new HashSet<>(knownDataPeerHashes);
+                        dataTargets.addAll(loadedDataPeerHashes);
+                        try {
+                            dataReconnectTaskFuture = dataReconnectExecutor.submit(() -> {
+                                Thread.interrupted();
+                                try {
+                                    if (activeData < MIN_DESIRED_DATA_PEERS && !dataTargets.isEmpty()) {
+                                        log.info("Active DATA peers {} < desired {} (data loop); requesting paths to {} known peers",
+                                                activeData, MIN_DESIRED_DATA_PEERS, dataTargets.size());
+                                        for (String hashHex : dataTargets) {
+                                            try {
+                                                byte[] dhash = org.apache.commons.codec.binary.Hex.decodeHex(hashHex);
+                                                boolean tracked = currentDataLinked.stream()
+                                                        .anyMatch(p -> Arrays.equals(p.getDestinationHash(), dhash));
+                                                if (tracked) continue;
+                                                long lastFailure = pendingDataLinkFailureMs.getOrDefault(hashHex, 0L);
+                                                boolean recentlyFailed = (System.currentTimeMillis() - lastFailure) < PENDING_FAILURE_BACKOFF_MS;
+                                                Identity cachedIdentity = recentlyFailed ? null
+                                                        : IdentityKnownDestination.recall(dhash);
+                                                if (cachedIdentity != null) {
+                                                    log.info("DATA: proactively connecting to {} via cached identity", hashHex);
+                                                    createLinkedDataPeerFromIdentity(dhash, cachedIdentity);
+                                                } else {
+                                                    if (recentlyFailed)
+                                                        log.info("DATA: backing off to requestPath for {} (recent PENDING failure)", hashHex);
+                                                    else
+                                                        log.info("DATA: requestPath for {} (no cached identity)", hashHex);
+                                                    Transport.getInstance().requestPath(dhash);
+                                                }
+                                            } catch (Exception e) {
+                                                log.warn("DATA path request/reconnect failed for {}: {}", hashHex, e.getMessage());
+                                            }
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    log.warn("Exception in data loop reconnect: {}", e.getMessage(), e);
+                                } finally {
+                                    if (dataReconnectTaskStartedMs != 0L) {
+                                        dataReconnectTaskStartedMs = 0L;
+                                    }
+                                }
+                            });
+                        } catch (java.util.concurrent.RejectedExecutionException e) {
+                            dataReconnectTaskStartedMs = 0L;
+                        }
+                    }
+                }
+
+            } catch (Exception e) {
+                log.error("runDataLoop: unexpected exception — loop continues", e);
+            }
+
+            if (!isShuttingDown && !Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        log.debug("Data mesh loop for destination {} exiting.", dataDestination.getName());
+    }
 
     public void broadcast(Function<ReticulumPeer, Message> peerMessageBuilder) {
         List<ReticulumPeer> allPeers = Stream.concat(
@@ -756,19 +938,12 @@ public class RNS {
 
     public void shutdown() {
         this.isShuttingDown = true;
-        saveKnownPeerHashes(); // Persist before shutting down so next restart reconnects fast.
+        saveKnownPeerHashes();
+        saveKnownDataPeerHashes();
         log.info("shutting down Reticulum");
         baseDestination.setProofStrategy(ProofStrategy.PROVE_NONE);
-        //dataDestination.setProofStrategy(ProofStrategy.PROVE_NONE);
+        dataDestination.setProofStrategy(ProofStrategy.PROVE_NONE);
 
-        // Stop processing threads
-        //try {
-        //    if (!this.rnsEPC.shutdown(5000)) {
-        //        log.warn("Reticulum threads failed to terminate");
-        //    }
-        //} catch (InterruptedException e) {
-        //    log.warn("Interrupted while waiting for rnsEPC threads to terminate");
-        //}
         if (this.rnsBaseThread != null && this.rnsBaseThread.isAlive()) {
             this.rnsBaseThread.interrupt();
             try {
@@ -779,16 +954,16 @@ public class RNS {
                 log.warn("Interrupted while waiting for RNS base thread");
             }
         }
-        //if (this.rnsDataThread != null && this.rnsDataThread.isAlive()) {
-        //    this.rnsDataThread.interrupt();
-        //    try {
-        //        this.rnsDataThread.join(5000);
-        //        if (this.rnsDataThread.isAlive())
-        //            log.warn("RNS base thread did not terminate in time");
-        //    } catch (InterruptedException e) {
-        //        log.warn("Interrupted while waiting for RNS base thread");
-        //    }
-        //}
+        if (this.rnsDataThread != null && this.rnsDataThread.isAlive()) {
+            this.rnsDataThread.interrupt();
+            try {
+                this.rnsDataThread.join(5000);
+                if (this.rnsDataThread.isAlive())
+                    log.warn("RNS data thread did not terminate in time");
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while waiting for RNS data thread");
+            }
+        }
         
         // gracefully close links of peers that point to us
         for (ReticulumPeer p: incomingPeers) {
@@ -813,6 +988,8 @@ public class RNS {
         this.rnsWorkerPool.shutdown();
         this.announceExecutor.shutdown();
         this.reconnectExecutor.shutdown();
+        this.dataAnnounceExecutor.shutdown();
+        this.dataReconnectExecutor.shutdown();
         try {
             if (!this.rnsWorkerPool.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS))
                 this.rnsWorkerPool.shutdownNow();
@@ -820,10 +997,16 @@ public class RNS {
                 this.announceExecutor.shutdownNow();
             if (!this.reconnectExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS))
                 this.reconnectExecutor.shutdownNow();
+            if (!this.dataAnnounceExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS))
+                this.dataAnnounceExecutor.shutdownNow();
+            if (!this.dataReconnectExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS))
+                this.dataReconnectExecutor.shutdownNow();
         } catch (InterruptedException e) {
             this.rnsWorkerPool.shutdownNow();
             this.announceExecutor.shutdownNow();
             this.reconnectExecutor.shutdownNow();
+            this.dataAnnounceExecutor.shutdownNow();
+            this.dataReconnectExecutor.shutdownNow();
         }
 
         // exitHandler() can block indefinitely if a zombie link's channel holds a lock
@@ -967,14 +1150,17 @@ public class RNS {
             }
 
             // add to peer list if we can use more peers
+            boolean isDataAspect = "qortal.qdn".equals(this.aspectFilter);
+            int peerLimit = isDataAspect ? MIN_DESIRED_DATA_PEERS : MIN_DESIRED_CORE_PEERS;
+            RNSCommon.PeerAspect matchAspect = isDataAspect ? RNSCommon.PeerAspect.DATA : RNSCommon.PeerAspect.BASE;
             var lps =  RNS.getInstance().getImmutableLinkedPeers();
             for (ReticulumPeer p: lps) {
                 var pl = p.getPeerLink();
-                if ((nonNull(pl) && (pl.getStatus() == ACTIVE))) {
+                if (nonNull(pl) && pl.getStatus() == ACTIVE && p.getPeerAspect() == matchAspect) {
                     activePeerCount = activePeerCount + 1;
                 }
             }
-            if (activePeerCount < MAX_PEERS) {
+            if (activePeerCount < peerLimit) {
                 for (ReticulumPeer p: lps) {
                     if (Arrays.equals(p.getDestinationHash(), destinationHash)) {
                         log.info("QAnnounceHandler - peer exists - found peer matching destinationHash");
@@ -1014,19 +1200,12 @@ public class RNS {
         }
 
         private ReticulumPeer getNewPeer(byte[] destinationHash, Identity announcedIdentity) {
-            ReticulumPeer newPeer = new ReticulumPeer(destinationHash);
+            boolean isDataAspect = "qortal.qdn".equals(this.aspectFilter);
+            RNSCommon.PeerAspect aspect = isDataAspect ? RNSCommon.PeerAspect.DATA : RNSCommon.PeerAspect.BASE;
+            ReticulumPeer newPeer = new ReticulumPeer(destinationHash, aspect);
             newPeer.setServerIdentity(announcedIdentity);
-
             newPeer.setIsInitiator(true);
-            if ("qortal.qdn".equals(this.aspectFilter)) {
-                // data peer
-                newPeer.setPeerAspect(RNSCommon.PeerAspect.DATA);
-                newPeer.setIsDataPeer(true);
-            } else {
-                // core peer
-                newPeer.setPeerAspect(RNSCommon.PeerAspect.BASE);
-                newPeer.setIsDataPeer(false);
-            }
+            newPeer.setIsDataPeer(isDataAspect);
             newPeer.setMessageMagic(getMessageMagic());
             log.debug(">>> ReticulumPeer created - PeerData: {} - {}", newPeer.getPeerData().toString(), newPeer.getPeerAddress().getDestinationHash());
             return newPeer;
@@ -1060,6 +1239,23 @@ public class RNS {
             log.warn("createLinkedPeerFromIdentity: LINKREQUEST to {} failed immediately — switching to requestPath backoff",
                     encodeHexString(destinationHash));
             pendingLinkFailureMs.put(encodeHexString(destinationHash), System.currentTimeMillis());
+        }
+    }
+
+    // Mirror of createLinkedPeerFromIdentity() for DATA-aspect peers.
+    private void createLinkedDataPeerFromIdentity(byte[] destinationHash, Identity identity) {
+        ReticulumPeer newPeer = new ReticulumPeer(destinationHash, RNSCommon.PeerAspect.DATA);
+        newPeer.setServerIdentity(identity);
+        newPeer.setIsInitiator(true);
+        newPeer.setIsDataPeer(true);
+        newPeer.setMessageMagic(getMessageMagic());
+        addLinkedPeer(newPeer);
+        log.info("DATA: proactively connecting to known peer {} via cached identity", encodeHexString(destinationHash));
+        Link lnk = newPeer.getPeerLink();
+        if (lnk != null && lnk.getStatus() == CLOSED) {
+            log.warn("createLinkedDataPeerFromIdentity: LINKREQUEST to {} failed immediately — switching to requestPath backoff",
+                    encodeHexString(destinationHash));
+            pendingDataLinkFailureMs.put(encodeHexString(destinationHash), System.currentTimeMillis());
         }
     }
 
@@ -1277,19 +1473,24 @@ public class RNS {
     //}
 
     public void addIncomingPeer(ReticulumPeer peer) {
-        // Dedup by remote identity: if a stale incoming peer from the same node already exists
-        // (e.g. rapid reconnects leave old ACTIVE links lingering for up to 3 min), replace it.
-        // This prevents incomingPeers from growing to 10+ during a reconnect storm.
+        // Dedup by remote identity + aspect: evict any existing incoming peer from the same
+        // node with the same aspect. Called from linkEstablished() where identity is known.
+        // Using CORE_ASPECT for both aspects would incorrectly match CORE/DATA peer pairs
+        // from the same remote node and evict the wrong one.
         Identity newId = peer.getServerIdentity();
+        String newAspect = (peer.getPeerAspect() == RNSCommon.PeerAspect.DATA) ? QDN_ASPECT : CORE_ASPECT;
         synchronized (this.incomingPeers) {
             if (newId != null) {
-                byte[] newHash = hashFromNameAndIdentity(CORE_ASPECT, newId);
+                byte[] newHash = hashFromNameAndIdentity(newAspect, newId);
                 Iterator<ReticulumPeer> it = this.incomingPeers.iterator();
                 while (it.hasNext()) {
                     ReticulumPeer existing = it.next();
                     Identity existingId = existing.getServerIdentity();
-                    if (existingId != null && Arrays.equals(hashFromNameAndIdentity(CORE_ASPECT, existingId), newHash)) {
-                        log.info("addIncomingPeer: replacing stale incoming peer from {}", encodeHexString(newHash));
+                    String existingAspect = (existing.getPeerAspect() == RNSCommon.PeerAspect.DATA) ? QDN_ASPECT : CORE_ASPECT;
+                    if (existingId != null && existingAspect.equals(newAspect)
+                            && Arrays.equals(hashFromNameAndIdentity(existingAspect, existingId), newHash)) {
+                        log.info("addIncomingPeer: replacing stale {} incoming peer from {}",
+                                newAspect, encodeHexString(newHash));
                         it.remove();
                         existing.shutdownChannel();
                     }
@@ -1425,7 +1626,12 @@ public class RNS {
                         p.setIsPeerAvailable(false);
                         // Record failure so the reconnect loop backs off to requestPath() for this
                         // peer for PENDING_FAILURE_BACKOFF_MS, avoiding the cull cascade.
-                        pendingLinkFailureMs.put(encodeHexString(p.getDestinationHash()), System.currentTimeMillis());
+                        String phex = encodeHexString(p.getDestinationHash());
+                        if (p.getPeerAspect() == RNSCommon.PeerAspect.DATA) {
+                            pendingDataLinkFailureMs.put(phex, System.currentTimeMillis());
+                        } else {
+                            pendingLinkFailureMs.put(phex, System.currentTimeMillis());
+                        }
                         removeLinkedPeer(p);
                         // Do NOT call pLink.teardown() here.
                         // teardown() sets status=CLOSED → jobs() finds CLOSED link in pendingLinks
@@ -1468,7 +1674,8 @@ public class RNS {
                 if (nonNull(pl) && pl.getStatus() == ACTIVE) {
                     Identity remoteId = p.getServerIdentity();
                     if (remoteId != null) {
-                        String key = encodeHexString(hashFromNameAndIdentity(CORE_ASPECT, remoteId));
+                        String aspect = (p.getPeerAspect() == RNSCommon.PeerAspect.DATA) ? QDN_ASPECT : CORE_ASPECT;
+                        String key = encodeHexString(hashFromNameAndIdentity(aspect, remoteId));
                         byIdentity.computeIfAbsent(key, k -> new ArrayList<>()).add(p);
                     }
                 }
@@ -1536,10 +1743,21 @@ public class RNS {
                 log.error("Cannot announce - destination is null");
             }
         }
-        //if ((dataPeerCount <= MIN_DESIRED_DATA_PEERS) && (pa == RNSCommon.PeerAspect.DATA)) {
-        //    log.info("Active qdn peers ({}) <= desired data peers ({}). Announcing", dataPeerCount, MIN_DESIRED_CORE_PEERS);
-        //    d.announce();
-        //}
+        if ((dataPeerCount <= MIN_DESIRED_DATA_PEERS) && (pa == RNSCommon.PeerAspect.DATA)) {
+            log.info("Active DATA peers ({}) <= desired data peers ({}). Announcing (dest={})",
+                    dataPeerCount, MIN_DESIRED_DATA_PEERS, d != null ? encodeHexString(d.getHash()) : "null");
+            if (nonNull(d)) {
+                long announceT0 = System.currentTimeMillis();
+                d.announce();
+                long announceMs = System.currentTimeMillis() - announceT0;
+                log.info("DATA announce attempt completed in {}ms", announceMs);
+                if (announceMs > 5_000) {
+                    log.warn("DATA announce took {}ms — possible jobsLock contention", announceMs);
+                }
+            } else {
+                log.error("Cannot announce DATA - destination is null");
+            }
+        }
     }
 
     /**
@@ -1562,11 +1780,19 @@ public class RNS {
 
     // Called from ReticulumPeer.createPeerBuffer() when a peer's buffer is confirmed ACTIVE.
     // Only initiator peers call this (non-initiators have our own destination hash, not the remote's).
-    void confirmPeerHash(String hashHex) {
-        boolean isNew = this.knownPeerHashes.add(hashHex);
-        if (isNew) {
-            saveKnownPeerHashes();
-            log.debug("Confirmed ACTIVE peer hash {}", hashHex);
+    void confirmPeerHash(String hashHex, RNSCommon.PeerAspect aspect) {
+        if (aspect == RNSCommon.PeerAspect.DATA) {
+            boolean isNew = this.knownDataPeerHashes.add(hashHex);
+            if (isNew) {
+                saveKnownDataPeerHashes();
+                log.debug("Confirmed ACTIVE DATA peer hash {}", hashHex);
+            }
+        } else {
+            boolean isNew = this.knownPeerHashes.add(hashHex);
+            if (isNew) {
+                saveKnownPeerHashes();
+                log.debug("Confirmed ACTIVE peer hash {}", hashHex);
+            }
         }
     }
 
@@ -1589,6 +1815,40 @@ public class RNS {
             }
         } catch (IOException e) {
             log.warn("Failed to load known peer hashes: {}", e.getMessage());
+        }
+    }
+
+    private void saveKnownDataPeerHashes() {
+        if (reticulum == null) return;
+        try {
+            Path file = reticulum.getStoragePath().resolve(KNOWN_DATA_PEERS_FILE);
+            Set<String> toSave = knownDataPeerHashes.isEmpty() ? loadedDataPeerHashes : knownDataPeerHashes;
+            Files.write(file, toSave, UTF_8);
+            log.debug("Saved {} known DATA peer hashes to {}", toSave.size(), file);
+        } catch (IOException e) {
+            log.warn("Failed to save known DATA peer hashes: {}", e.getMessage());
+        }
+    }
+
+    private void loadKnownDataPeerHashes() {
+        if (reticulum == null) return;
+        try {
+            Path file = reticulum.getStoragePath().resolve(KNOWN_DATA_PEERS_FILE);
+            if (!Files.isReadable(file)) return;
+            List<String> lines = Files.readAllLines(file, UTF_8);
+            int loaded = 0;
+            for (String line : lines) {
+                String hex = line.trim();
+                if (!hex.isEmpty()) {
+                    loadedDataPeerHashes.add(hex);
+                    loaded++;
+                }
+            }
+            if (loaded > 0) {
+                log.info("Loaded {} known DATA peer hashes from {}", loaded, file);
+            }
+        } catch (IOException e) {
+            log.warn("Failed to load known DATA peer hashes: {}", e.getMessage());
         }
     }
 
@@ -1642,6 +1902,21 @@ public class RNS {
                 .filter(p -> p.isDataPeer())
                 .map(ReticulumPeer::getPeerData)
                 .collect(Collectors.toList());
+    }
+
+    // Returns all active DATA-aspect ReticulumPeers (both initiator and incoming).
+    // Used by NetworkData for outbound QDN dispatch over Reticulum.
+    public List<ReticulumPeer> getActiveDataPeers() {
+        return Stream.concat(
+                getActiveImmutableLinkedPeers().stream()
+                        .filter(p -> p.getPeerAspect() == RNSCommon.PeerAspect.DATA),
+                getImmutableIncomingPeers().stream()
+                        .filter(p -> p.getPeerAspect() == RNSCommon.PeerAspect.DATA)
+                        .filter(p -> {
+                            var pl = p.getPeerLink();
+                            return nonNull(pl) && pl.getStatus() == ACTIVE;
+                        })
+        ).collect(Collectors.toList());
     }
 
     public ReticulumPeer findPeerByLink(Link link) {

--- a/src/main/java/org/qortal/network/ReticulumPeer.java
+++ b/src/main/java/org/qortal/network/ReticulumPeer.java
@@ -231,6 +231,11 @@ public class ReticulumPeer implements Peer {
      */
     @PeerCtor("destination-hash")
     public ReticulumPeer(byte[] dhash) {
+        this(dhash, RNSCommon.PeerAspect.BASE);
+    }
+
+    public ReticulumPeer(byte[] dhash, RNSCommon.PeerAspect aspect) {
+        this.peerAspect = aspect;
         this.destinationHash = dhash;
         this.serverIdentity = recall(dhash);
         //this.sendStreamId = getRandomStreamId();
@@ -302,10 +307,10 @@ public class ReticulumPeer implements Peer {
     public void initPeerLink() {
         peerDestination = new Destination(
             this.serverIdentity,
-            Direction.OUT, 
+            Direction.OUT,
             DestinationType.SINGLE,
             APP_NAME,
-            "core"
+            peerAspect == RNSCommon.PeerAspect.DATA ? "qdn" : "core"
         );
         peerDestination.setProofStrategy(ProofStrategy.PROVE_ALL);
 
@@ -414,7 +419,7 @@ public class ReticulumPeer implements Peer {
             // Record this peer's hash as confirmed-active so it's saved for fast reconnect on restart.
             // Only initiator peers have the remote's destination hash; non-initiators have our own hash.
             if (Boolean.TRUE.equals(isInitiator)) {
-                RNS.getInstance().confirmPeerHash(encodeHexString(destinationHash));
+                RNS.getInstance().confirmPeerHash(encodeHexString(destinationHash), this.peerAspect);
             }
             // Chain tip is NOT sent here — sending immediately on link establishment caused
             // Channel "retry count exceeded" teardowns. broadcastOurChain() delivers it shortly.
@@ -469,17 +474,11 @@ public class ReticulumPeer implements Peer {
     }
 
     public void disconnect(String reason) {
-        log.debug("@@@-> Disconnecting peer {} after {} - reason: {}", this.toString(), getConnectionAge(), reason);
+        log.info("@@@-> Disconnecting peer {} after {} - reason: {}", this.toString(), getConnectionAge(), reason);
         var isShuttingDown = RNS.getInstance().isShuttingDown();
         log.debug("ReticulumPeer disconnect, RNS isShuttingDown: {}", isShuttingDown);
         if (!isShuttingDown) {
             makePeerUnavailable();
-            //if (nonNull(this.peerBuffer)) {
-            //    shutdownChannel();
-            //    this.peerBuffer.close();
-            ////    this.peerBuffer = null;
-            //}
-            //this.peerLink.teardown();
         }
         this.isPeerAvailable = false;
     }
@@ -536,19 +535,27 @@ public class ReticulumPeer implements Peer {
     }
 
     public void makePeerAvailable() {
-        var network = Network.getInstance();
-        network.addConnectedPeer(this);
-        network.addOutboundHandshakedPeer(this);
-        network.addHandshakedPeer(this);
+        if (this.peerAspect != RNSCommon.PeerAspect.DATA) {
+            // DATA peers are tracked by RNS's own linkedPeers/incomingPeers lists.
+            // NetworkData accesses them via RNS.getActiveDataPeers() — no registration here.
+            var network = Network.getInstance();
+            network.addConnectedPeer(this);
+            network.addHandshakedPeer(this);
+            if (Boolean.TRUE.equals(this.isInitiator)) {
+                network.addOutboundHandshakedPeer(this);
+            }
+        }
         this.isPeerAvailable = true;
     }
 
     public void makePeerUnavailable() {
         this.isPeerAvailable = false;
-        var network = Network.getInstance();
-        network.removeHandshakedPeer(this);
-        network.removeOutboundHandshakedPeer(this);
-        network.removeConnectedPeer(this);
+        if (this.peerAspect != RNSCommon.PeerAspect.DATA) {
+            var network = Network.getInstance();
+            network.removeHandshakedPeer(this);
+            network.removeOutboundHandshakedPeer(this);
+            network.removeConnectedPeer(this);
+        }
         this.isPeerAvailable = false;
     }
 
@@ -615,8 +622,16 @@ public class ReticulumPeer implements Peer {
         } else {
             log.info("linkClosed callback: no handled standard reason");
         }
+        // Remove incoming peers immediately when their link closes, so reconnecting nodes
+        // don't accumulate stale-but-still-ACTIVE entries in incomingPeers between pruning
+        // cycles (which run every ~60s). Submitted to rnsWorkerPool to avoid calling
+        // removeIncomingPeer() directly from the Reticulum I/O thread while prunePeers()
+        // may be iterating the list on the Controller thread.
+        if (!Boolean.TRUE.equals(isInitiator) && !RNS.getInstance().isShuttingDown()) {
+            RNS.getInstance().markPeerForImmediateRemoval(this);
+        }
     }
-    
+
     public void linkPacketReceived(byte[] message, Packet packet) {
         var msgText = new String(message, StandardCharsets.UTF_8);
         if (msgText.equals("ping")) {
@@ -1062,11 +1077,10 @@ public class ReticulumPeer implements Peer {
         //    // Send failure
         //    return false;
         } catch (IllegalStateException e) {
-            //log.warn("Can't write to buffer (remote buffer down?)");
-            //shutdownChannel();
-            //this.peerLink.teardown();
-            //this.peerBuffer = null;
-            log.error("IllegalStateException - can't write to buffer: {}", e);
+            log.warn("sendMessage (queued): buffer closed for {} (link tearing down), marking for removal",
+                    encodeHexString(destinationHash));
+            this.setDeleteMe(true);
+            RNS.getInstance().markPeerForImmediateRemoval(this);
             return false;
         } catch (MessageException e) {
             log.error(e.getMessage(), e);
@@ -1178,17 +1192,18 @@ public class ReticulumPeer implements Peer {
                 return false;
             }
         } catch (IllegalStateException e) {
-            log.error("IllegalStateException - can't write to buffer: {}", e);
-            //shutdownChannel();
-            //this.peerLink.teardown();
-            //this.peerBuffer = null;
-            //return false;
+            // Buffer is closed — the link is tearing down. Mark for removal so this peer
+            // disappears from getActiveDataPeers() / getActiveImmutableLinkedPeers() on the
+            // next loop iteration without waiting for prunePeers().
+            log.warn("sendMessage: buffer closed for {} (link tearing down), marking for removal",
+                    encodeHexString(destinationHash));
+            this.setDeleteMe(true);
+            RNS.getInstance().markPeerForImmediateRemoval(this);
+            return false;
         } catch (MessageException e) {
             log.error(e.getMessage(), e);
-            //return false;
+            return false;
         }
-        // ReticulumPeer state is not governed by the network.
-        // Regardless we need to satisfy the Peer interface.
         return true;
     }
 

--- a/src/main/java/org/qortal/settings/Settings.java
+++ b/src/main/java/org/qortal/settings/Settings.java
@@ -696,7 +696,7 @@ public class Settings {
 			""
 	};
 	private String[] reticulumBackboneGatewayServers = new String[]{
-			"phantom.mobilefabrik.com:4242"
+			""
 	};
 	/** There is a Python rnsd running on the node with a gateway inteface to use */
 	private boolean reticulumUsePythonRNS = false;


### PR DESCRIPTION
This PR marks the first full testing stage for Qortal Core Reticulum integration.

The base for the Reticulum integration into Qortal Core (Peer interface, baseDestination and integration into main Network) was added in the last PR. This PR adds:

-  the dataDestination and it's integration into the second Qortal network implemented by NetworkData
-  data relay over Reticulum

The Reticulum Network Stack runs alongside TCP/IP.
Peers from both stacks share a common interface. However they have separate sets of Peers and they are managed separately.

