### PR TITLE
Fix/default true

### DIFF
--- a/src/main/java/org/qortal/api/resource/ArbitraryResource.java
+++ b/src/main/java/org/qortal/api/resource/ArbitraryResource.java
@@ -231,8 +231,17 @@ public class ArbitraryResource {
 
 		try (final Repository repository = RepositoryManager.getRepository()) {
 
+			// Treat empty identifier as null
+			if (identifier != null && identifier.isEmpty()) {
+				identifier = null;
+			}
+
 			boolean defaultRes = Boolean.TRUE.equals(defaultResource);
 			boolean usePrefixOnly = Boolean.TRUE.equals(prefixOnly);
+
+			if (defaultRes && identifier != null) {
+				throw ApiExceptionFactory.INSTANCE.createCustomException(request, ApiError.INVALID_CRITERIA, "identifier cannot be specified when requesting a default resource");
+			}
 
 			List<String> exactMatchNames = new ArrayList<>();
 

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
@@ -1101,6 +1101,10 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 			bindParams.add(service.value);
 		}
 
+		if (defaultResource) {
+			sql.append(" AND identifier='default'");
+		}
+
 		// Handle general query matches
 		if (query != null) {
 			// Search anywhere in the fields, unless "prefixOnly" has been requested
@@ -1109,8 +1113,8 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 			String queryWildcard = prefixOnly ? String.format("%s%%", query.toLowerCase()) : String.format("%%%s%%", query.toLowerCase());
 
 			if (defaultResource) {
-				// Default resource requested - use NULL identifier and search name only
-				sql.append(" AND LCASE(name) LIKE ? AND identifier='default'");
+				// Default resource requested - search name only
+				sql.append(" AND LCASE(name) LIKE ?");
 				bindParams.add(queryWildcard);
 			} else {
 				// Non-default resource requested

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBCacheUtils.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBCacheUtils.java
@@ -212,6 +212,10 @@ public class HSQLDBCacheUtils {
         if( service.isPresent() )
             stream = stream.filter(candidate -> candidate.service.equals(service.get()));
 
+        if (defaultResource) {
+            stream = stream.filter(candidate -> isDefaultIdentifier(candidate.identifier));
+        }
+
         // filter by query (either identifier, name, title or description)
         if (query.isPresent()) {
 
@@ -219,7 +223,7 @@ public class HSQLDBCacheUtils {
                     = prefixOnly ? getPrefixPredicate(query.get()) : getContainsPredicate(query.get());
 
             if (defaultResource) {
-                stream = stream.filter( candidate -> DEFAULT_IDENTIFIER.equals( candidate.identifier ) && predicate.test(candidate.name));
+                stream = stream.filter(candidate -> predicate.test(candidate.name));
             } else {
                 stream = stream.filter( candidate -> passQuery(predicate, candidate));
             }
@@ -445,6 +449,8 @@ public class HSQLDBCacheUtils {
                 if (r.name == null || !followedLower.contains(r.name.toLowerCase())) continue;
             }
 
+            if (defaultResource && !isDefaultIdentifier(r.identifier)) continue;
+
             if (identifier != null && !identifier.isEmpty()) {
                 String id = r.identifier;
                 if (id == null) continue;
@@ -457,7 +463,7 @@ public class HSQLDBCacheUtils {
                 String q = query.toLowerCase();
                 boolean queryMatch;
                 if (defaultResource) {
-                    queryMatch = DEFAULT_IDENTIFIER.equals(r.identifier) && r.name != null
+                    queryMatch = r.name != null
                             && (prefixOnly ? r.name.toLowerCase().startsWith(q) : r.name.toLowerCase().contains(q));
                 } else {
                     queryMatch = (r.name != null && (prefixOnly ? r.name.toLowerCase().startsWith(q) : r.name.toLowerCase().contains(q)))
@@ -535,6 +541,10 @@ public class HSQLDBCacheUtils {
         }
 
         return stream;
+    }
+
+    private static boolean isDefaultIdentifier(String identifier) {
+        return identifier == null || DEFAULT_IDENTIFIER.equals(identifier);
     }
 
     /**

--- a/src/test/java/org/qortal/test/repository/HSQLDBCacheUtilsTests.java
+++ b/src/test/java/org/qortal/test/repository/HSQLDBCacheUtilsTests.java
@@ -430,6 +430,60 @@ public class HSQLDBCacheUtilsTests {
     }
 
     @Test
+    public void testDefaultResourceExcludesIdentifiersWithoutQuery() {
+
+        ArbitraryResourceData defaultResource = new ArbitraryResourceData();
+        defaultResource.name = "Joe";
+
+        ArbitraryResourceData identifiedResource = new ArbitraryResourceData();
+        identifiedResource.name = "Joe";
+        identifiedResource.identifier = "app";
+
+        List<ArbitraryResourceData> result = filterListByMap(
+                List.of(defaultResource, identifiedResource),
+                NAME_LEVEL, new HashMap<>(Map.of(DEFAULT_RESOURCE, true)),
+                1
+        );
+
+        Assert.assertNull(result.get(0).identifier);
+    }
+
+    @Test
+    public void testDefaultResourceQuerySearchesNameOnly() {
+
+        ArbitraryResourceData defaultResource = new ArbitraryResourceData();
+        defaultResource.name = "Joe";
+
+        ArbitraryResourceData identifiedResource = new ArbitraryResourceData();
+        identifiedResource.name = "Other";
+        identifiedResource.identifier = "Joe";
+
+        List<ArbitraryResourceData> result = filterListByMap(
+                List.of(defaultResource, identifiedResource),
+                NAME_LEVEL, new HashMap<>(Map.of(DEFAULT_RESOURCE, true, QUERY, "Joe")),
+                1
+        );
+
+        Assert.assertNull(result.get(0).identifier);
+    }
+
+    @Test
+    public void testDefaultResourceAcceptsDefaultIdentifierLiteral() {
+
+        ArbitraryResourceData data = new ArbitraryResourceData();
+        data.name = "Joe";
+        data.identifier = "default";
+
+        List<ArbitraryResourceData> result = filterListByMap(
+                List.of(data),
+                NAME_LEVEL, new HashMap<>(Map.of(DEFAULT_RESOURCE, true)),
+                1
+        );
+
+        Assert.assertEquals("default", result.get(0).identifier);
+    }
+
+    @Test
     public void testFollowedNamesNegative() {
 
         ArbitraryResourceData data = new ArbitraryResourceData();


### PR DESCRIPTION
Fixes `/arbitrary/resources/search?default=true` so it reliably returns only default resources, including when no query parameter is provided.

Changes:
- Apply the default=true identifier filter independently of query.
- Keep default-resource query behavior as name-only search.
- Normalize empty identifier= to null in the search endpoint.
- Reject default=true combined with a non-empty identifier, matching /arbitrary/resources.
- Fix in-memory cache filtering to treat both null and "default" as default identifiers.
- Add regression tests for default-resource filtering with and without query.