### PR TITLE
Add formatBytes function in StringUtils

### DIFF
--- a/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataStorageManager.java
+++ b/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataStorageManager.java
@@ -509,7 +509,7 @@ public class ArbitraryDataStorageManager extends Thread {
            LOGGER.error(e.getMessage(), e);
         }
 
-        LOGGER.info("Total used: {} bytes, Total capacity: {} bytes", this.totalDirectorySize, this.storageCapacity);
+        LOGGER.info("Total used: {}, Total capacity: {}", StringUtils.formatBytes(this.totalDirectorySize), StringUtils.formatBytes(this.storageCapacity));
     }
 
     /**

--- a/src/main/java/org/qortal/repository/BlockArchiveWriter.java
+++ b/src/main/java/org/qortal/repository/BlockArchiveWriter.java
@@ -14,6 +14,7 @@ import org.qortal.settings.Settings;
 import org.qortal.transform.TransformationException;
 import org.qortal.transform.block.BlockTransformation;
 import org.qortal.transform.block.BlockTransformer;
+import org.qortal.utils.StringUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
@@ -243,14 +244,14 @@ public class BlockArchiveWriter {
 
             // Log every 1000 blocks
             if (this.shouldLogProgress && i % 1000 == 0) {
-                LOGGER.info("Archived up to block height {}. Size of current file: {} bytes", currentHeight, (headerBytes.size() + bytes.size()));
+                LOGGER.info("Archived up to block height {}. Size of current file: {}", currentHeight, StringUtils.formatBytes(headerBytes.size() + bytes.size()));
             }
 
             i++;
 
         }
         int totalLength = headerBytes.size() + bytes.size();
-        LOGGER.info(String.format("Total length of %d blocks is %d bytes", i, totalLength));
+        LOGGER.info(String.format("Total length of %d blocks is {}", i, StringUtils.formatBytes(totalLength)));
 
         // Validate file size, in case something went wrong
         if (totalLength < fileSizeTarget && this.shouldEnforceFileSizeTarget) {

--- a/src/main/java/org/qortal/repository/BlockArchiveWriter.java
+++ b/src/main/java/org/qortal/repository/BlockArchiveWriter.java
@@ -251,7 +251,7 @@ public class BlockArchiveWriter {
 
         }
         int totalLength = headerBytes.size() + bytes.size();
-        LOGGER.info(String.format("Total length of %d blocks is {}", i, StringUtils.formatBytes(totalLength)));
+        LOGGER.info("Total length of {} blocks is {}", i, StringUtils.formatBytes(totalLength));
 
         // Validate file size, in case something went wrong
         if (totalLength < fileSizeTarget && this.shouldEnforceFileSizeTarget) {

--- a/src/main/java/org/qortal/utils/StringUtils.java
+++ b/src/main/java/org/qortal/utils/StringUtils.java
@@ -10,4 +10,23 @@ public class StringUtils {
 
         return sanitized;
     }
+
+    /**
+     * Format a byte count into a human-readable string using binary units (KB, MB, GB, ...).
+     *
+     * @param bytes the number of bytes
+     * @return a string such as "51.6 GB" or "512 bytes"
+     */
+    public static String formatBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " bytes";
+        }
+
+        String[] units = { "KB", "MB", "GB", "TB", "PB", "EB" };
+        int exponent = (int) (Math.log(bytes) / Math.log(1024));
+        exponent = Math.min(exponent, units.length); // guard against overflow beyond EB
+
+        double value = bytes / Math.pow(1024, exponent);
+        return String.format("%.2f %s", value, units[exponent - 1]);
+    }
 }


### PR DESCRIPTION
Improve the format of log line:

`INFO  ArbitraryDataStorageManager:512 - Total used: 55376728963 bytes, Total capacity: 899919614851 bytes`

making it more human-readable (with KB, MB, GB), like:

`INFO  ArbitraryDataStorageManager:512 - Total used: 51.57 GB, Total capacity: 839.13 GB`
