### PR TITLE
6.1.7 validation patch - 6.1.8 Patch Release Candidate

### DIFF
--- a/src/main/java/org/qortal/network/message/GetTradePresencesMessage.java
+++ b/src/main/java/org/qortal/network/message/GetTradePresencesMessage.java
@@ -75,25 +75,15 @@ public class GetTradePresencesMessage extends Message {
 	}
 
 	public static Message fromByteBuffer(int id, ByteBuffer bytes) throws MessageException {
-		int groupedEntriesCount = bytes.getInt();
-
-		if (groupedEntriesCount < 0)
-			throw new MessageException("invalid grouped entries count");
-
-		if (groupedEntriesCount == 0) {
-			if (bytes.hasRemaining())
-				throw new MessageException("invalid grouped entries count");
-
+		int groupedEntriesCount = GroupedMessageUtils.readInitialGroupCount(bytes, "invalid grouped entries count");
+		if (groupedEntriesCount == 0)
 			return new GetTradePresencesMessage(id, List.of());
-		}
 
-		// if (count * public key size) + timestamp > remaining, then invalid count
-		if ((((long) groupedEntriesCount * Transformer.PUBLIC_KEY_LENGTH) + Transformer.LONG_LENGTH) > bytes.remaining())
-			throw new MessageException("invalid grouped entries count");
+		GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, Transformer.PUBLIC_KEY_LENGTH, "invalid grouped entries count");
 
 		List<TradePresenceData> tradePresences = new ArrayList<>(groupedEntriesCount);
 
-		while (groupedEntriesCount > 0) {
+		while (true) {
 			long timestamp = bytes.getLong();
 
 			for (int i = 0; i < groupedEntriesCount; ++i) {
@@ -103,12 +93,11 @@ public class GetTradePresencesMessage extends Message {
 				tradePresences.add(new TradePresenceData(timestamp, publicKey));
 			}
 
-			if (bytes.hasRemaining()) {
-				groupedEntriesCount = bytes.getInt();
-			} else {
-				// we've finished
-				groupedEntriesCount = 0;
-			}
+			if (!bytes.hasRemaining())
+				break;
+
+			groupedEntriesCount = GroupedMessageUtils.readNextGroupCount(bytes, "invalid grouped entries count");
+			GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, Transformer.PUBLIC_KEY_LENGTH, "invalid grouped entries count");
 		}
 
 		return new GetTradePresencesMessage(id, tradePresences);

--- a/src/main/java/org/qortal/network/message/GetTradePresencesMessage.java
+++ b/src/main/java/org/qortal/network/message/GetTradePresencesMessage.java
@@ -77,8 +77,18 @@ public class GetTradePresencesMessage extends Message {
 	public static Message fromByteBuffer(int id, ByteBuffer bytes) throws MessageException {
 		int groupedEntriesCount = bytes.getInt();
 
-		// if negative or (count * public key size) + timestamp > remaining, then invalid count
-		if (groupedEntriesCount < 0 || (((long) groupedEntriesCount * Transformer.PUBLIC_KEY_LENGTH) + Transformer.LONG_LENGTH) > bytes.remaining())
+		if (groupedEntriesCount < 0)
+			throw new MessageException("invalid grouped entries count");
+
+		if (groupedEntriesCount == 0) {
+			if (bytes.hasRemaining())
+				throw new MessageException("invalid grouped entries count");
+
+			return new GetTradePresencesMessage(id, List.of());
+		}
+
+		// if (count * public key size) + timestamp > remaining, then invalid count
+		if ((((long) groupedEntriesCount * Transformer.PUBLIC_KEY_LENGTH) + Transformer.LONG_LENGTH) > bytes.remaining())
 			throw new MessageException("invalid grouped entries count");
 
 		List<TradePresenceData> tradePresences = new ArrayList<>(groupedEntriesCount);

--- a/src/main/java/org/qortal/network/message/GetTradePresencesMessage.java
+++ b/src/main/java/org/qortal/network/message/GetTradePresencesMessage.java
@@ -75,11 +75,9 @@ public class GetTradePresencesMessage extends Message {
 	}
 
 	public static Message fromByteBuffer(int id, ByteBuffer bytes) throws MessageException {
-		int groupedEntriesCount = GroupedMessageUtils.readInitialGroupCount(bytes, "invalid grouped entries count");
+		int groupedEntriesCount = GroupedMessageUtils.readInitialGroupCount(bytes, Transformer.PUBLIC_KEY_LENGTH, "invalid grouped entries count");
 		if (groupedEntriesCount == 0)
 			return new GetTradePresencesMessage(id, List.of());
-
-		GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, Transformer.PUBLIC_KEY_LENGTH, "invalid grouped entries count");
 
 		List<TradePresenceData> tradePresences = new ArrayList<>(groupedEntriesCount);
 
@@ -96,8 +94,7 @@ public class GetTradePresencesMessage extends Message {
 			if (!bytes.hasRemaining())
 				break;
 
-			groupedEntriesCount = GroupedMessageUtils.readNextGroupCount(bytes, "invalid grouped entries count");
-			GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, Transformer.PUBLIC_KEY_LENGTH, "invalid grouped entries count");
+			groupedEntriesCount = GroupedMessageUtils.readNextGroupCount(bytes, Transformer.PUBLIC_KEY_LENGTH, "invalid grouped entries count");
 		}
 
 		return new GetTradePresencesMessage(id, tradePresences);

--- a/src/main/java/org/qortal/network/message/GroupedMessageUtils.java
+++ b/src/main/java/org/qortal/network/message/GroupedMessageUtils.java
@@ -9,15 +9,20 @@ final class GroupedMessageUtils {
 	private GroupedMessageUtils() {
 	}
 
-	static int readInitialGroupCount(ByteBuffer bytes, String errorMessage) throws MessageException {
-		return readGroupCount(bytes, true, errorMessage);
+	static int readInitialGroupCount(ByteBuffer bytes, long entrySize, String errorMessage) throws MessageException {
+		int count = readGroupCount(bytes, true, errorMessage);
+		if (count > 0)
+			validateGroupCount(count, bytes, entrySize, errorMessage);
+		return count;
 	}
 
-	static int readNextGroupCount(ByteBuffer bytes, String errorMessage) throws MessageException {
-		return readGroupCount(bytes, false, errorMessage);
+	static int readNextGroupCount(ByteBuffer bytes, long entrySize, String errorMessage) throws MessageException {
+		int count = readGroupCount(bytes, false, errorMessage);
+		validateGroupCount(count, bytes, entrySize, errorMessage);
+		return count;
 	}
 
-	static void validateGroupCount(int count, ByteBuffer bytes, long entrySize, String errorMessage) throws MessageException {
+	private static void validateGroupCount(int count, ByteBuffer bytes, long entrySize, String errorMessage) throws MessageException {
 		long requiredBytes = Transformer.LONG_LENGTH + ((long) count * entrySize);
 		if (requiredBytes > bytes.remaining())
 			throw new MessageException(errorMessage);

--- a/src/main/java/org/qortal/network/message/GroupedMessageUtils.java
+++ b/src/main/java/org/qortal/network/message/GroupedMessageUtils.java
@@ -1,0 +1,40 @@
+package org.qortal.network.message;
+
+import org.qortal.transform.Transformer;
+
+import java.nio.ByteBuffer;
+
+final class GroupedMessageUtils {
+
+	private GroupedMessageUtils() {
+	}
+
+	static int readInitialGroupCount(ByteBuffer bytes, String errorMessage) throws MessageException {
+		return readGroupCount(bytes, true, errorMessage);
+	}
+
+	static int readNextGroupCount(ByteBuffer bytes, String errorMessage) throws MessageException {
+		return readGroupCount(bytes, false, errorMessage);
+	}
+
+	static void validateGroupCount(int count, ByteBuffer bytes, long entrySize, String errorMessage) throws MessageException {
+		long requiredBytes = Transformer.LONG_LENGTH + ((long) count * entrySize);
+		if (requiredBytes > bytes.remaining())
+			throw new MessageException(errorMessage);
+	}
+
+	private static int readGroupCount(ByteBuffer bytes, boolean allowZeroCount, String errorMessage) throws MessageException {
+		if (bytes.remaining() < Transformer.INT_LENGTH)
+			throw new MessageException(errorMessage);
+
+		int count = bytes.getInt();
+		if (count < 0 || (!allowZeroCount && count == 0))
+			throw new MessageException(errorMessage);
+
+		if (count == 0 && bytes.hasRemaining())
+			throw new MessageException(errorMessage);
+
+		return count;
+	}
+
+}

--- a/src/main/java/org/qortal/network/message/NamesMessage.java
+++ b/src/main/java/org/qortal/network/message/NamesMessage.java
@@ -18,16 +18,14 @@ import java.util.List;
 public class NamesMessage extends Message {
 
 	private static final int SIGNATURE_LENGTH = Transformer.SIGNATURE_LENGTH;
-	private static final long ENTRY_SIZE
-		= Name.MAX_NAME_SIZE + // name
-			Name.MAX_NAME_SIZE + // reduced name
+	private static final long MIN_ENTRY_SIZE
+		= Transformer.INT_LENGTH + // name length
+			Transformer.INT_LENGTH + // reduced name length
 			Transformer.ADDRESS_LENGTH + // owner
-			Name.MAX_DATA_SIZE + // data
+			Transformer.INT_LENGTH + // data length
 			Transformer.LONG_LENGTH + // registered timestamp
 			Transformer.INT_LENGTH + // was updated
-			Transformer.LONG_LENGTH + // updated timestamp
 			Transformer.INT_LENGTH + // is for sale
-			Transformer.LONG_LENGTH + // sale price
 			SIGNATURE_LENGTH + // reference
 			Transformer.INT_LENGTH; // creation group Id
 
@@ -97,8 +95,8 @@ public class NamesMessage extends Message {
 		try {
 			final int nameCount = bytes.getInt();
 
-			// if negative count or count * entry size > remaining, then invalid count
-			if (nameCount < 0 || ((long) nameCount * ENTRY_SIZE) > bytes.remaining())
+			// if negative count or count * minimum entry size > remaining, then invalid count
+			if (nameCount < 0 || ((long) nameCount * MIN_ENTRY_SIZE) > bytes.remaining())
 				throw new MessageException("invalid name count");
 
 			List<NameData> nameDataList = new ArrayList<>(nameCount);

--- a/src/main/java/org/qortal/network/message/OnlineAccountsV3Message.java
+++ b/src/main/java/org/qortal/network/message/OnlineAccountsV3Message.java
@@ -88,11 +88,9 @@ public class OnlineAccountsV3Message extends Message {
 	}
 
 	public static Message fromByteBuffer(int id, ByteBuffer bytes) throws MessageException {
-		int accountCount = GroupedMessageUtils.readInitialGroupCount(bytes, "invalid online accounts count");
+		int accountCount = GroupedMessageUtils.readInitialGroupCount(bytes, ENTRY_SIZE, "invalid online accounts count");
 		if (accountCount == 0)
 			return new OnlineAccountsV3Message(id, List.of());
-
-		GroupedMessageUtils.validateGroupCount(accountCount, bytes, ENTRY_SIZE, "invalid online accounts count");
 
 		List<OnlineAccountData> onlineAccounts = new ArrayList<>(accountCount);
 
@@ -119,8 +117,7 @@ public class OnlineAccountsV3Message extends Message {
 			if (!bytes.hasRemaining())
 				break;
 
-			accountCount = GroupedMessageUtils.readNextGroupCount(bytes, "invalid online accounts count");
-			GroupedMessageUtils.validateGroupCount(accountCount, bytes, ENTRY_SIZE, "invalid online accounts count");
+			accountCount = GroupedMessageUtils.readNextGroupCount(bytes, ENTRY_SIZE, "invalid online accounts count");
 		}
 
 		return new OnlineAccountsV3Message(id, onlineAccounts);

--- a/src/main/java/org/qortal/network/message/OnlineAccountsV3Message.java
+++ b/src/main/java/org/qortal/network/message/OnlineAccountsV3Message.java
@@ -90,8 +90,18 @@ public class OnlineAccountsV3Message extends Message {
 	public static Message fromByteBuffer(int id, ByteBuffer bytes) throws MessageException {
 		int accountCount = bytes.getInt();
 
-		// if negative count or (count * entry size) + timestamp > remaining, then invalid count
-		if (accountCount < 0 || (((long) accountCount * ENTRY_SIZE) + Transformer.LONG_LENGTH) > bytes.remaining())
+		if (accountCount < 0)
+			throw new MessageException("invalid online accounts count");
+
+		if (accountCount == 0) {
+			if (bytes.hasRemaining())
+				throw new MessageException("invalid online accounts count");
+
+			return new OnlineAccountsV3Message(id, List.of());
+		}
+
+		// if (count * entry size) + timestamp > remaining, then invalid count
+		if ((((long) accountCount * ENTRY_SIZE) + Transformer.LONG_LENGTH) > bytes.remaining())
 			throw new MessageException("invalid online accounts count");
 
 		List<OnlineAccountData> onlineAccounts = new ArrayList<>(accountCount);

--- a/src/main/java/org/qortal/network/message/OnlineAccountsV3Message.java
+++ b/src/main/java/org/qortal/network/message/OnlineAccountsV3Message.java
@@ -88,25 +88,15 @@ public class OnlineAccountsV3Message extends Message {
 	}
 
 	public static Message fromByteBuffer(int id, ByteBuffer bytes) throws MessageException {
-		int accountCount = bytes.getInt();
-
-		if (accountCount < 0)
-			throw new MessageException("invalid online accounts count");
-
-		if (accountCount == 0) {
-			if (bytes.hasRemaining())
-				throw new MessageException("invalid online accounts count");
-
+		int accountCount = GroupedMessageUtils.readInitialGroupCount(bytes, "invalid online accounts count");
+		if (accountCount == 0)
 			return new OnlineAccountsV3Message(id, List.of());
-		}
 
-		// if (count * entry size) + timestamp > remaining, then invalid count
-		if ((((long) accountCount * ENTRY_SIZE) + Transformer.LONG_LENGTH) > bytes.remaining())
-			throw new MessageException("invalid online accounts count");
+		GroupedMessageUtils.validateGroupCount(accountCount, bytes, ENTRY_SIZE, "invalid online accounts count");
 
 		List<OnlineAccountData> onlineAccounts = new ArrayList<>(accountCount);
 
-		while (accountCount > 0) {
+		while (true) {
 			long timestamp = bytes.getLong();
 
 			for (int i = 0; i < accountCount; ++i) {
@@ -126,12 +116,11 @@ public class OnlineAccountsV3Message extends Message {
 				onlineAccounts.add(new OnlineAccountData(timestamp, signature, publicKey, nonce));
 			}
 
-			if (bytes.hasRemaining()) {
-				accountCount = bytes.getInt();
-			} else {
-				// we've finished
-				accountCount = 0;
-			}
+			if (!bytes.hasRemaining())
+				break;
+
+			accountCount = GroupedMessageUtils.readNextGroupCount(bytes, "invalid online accounts count");
+			GroupedMessageUtils.validateGroupCount(accountCount, bytes, ENTRY_SIZE, "invalid online accounts count");
 		}
 
 		return new OnlineAccountsV3Message(id, onlineAccounts);

--- a/src/main/java/org/qortal/network/message/TradePresencesMessage.java
+++ b/src/main/java/org/qortal/network/message/TradePresencesMessage.java
@@ -89,8 +89,18 @@ public class TradePresencesMessage extends Message {
 	public static Message fromByteBuffer(int id, ByteBuffer bytes)  throws MessageException {
 		int groupedEntriesCount = bytes.getInt();
 
-		// if negative or (count * entry size) + timestamp > remaining, then invalid count
-		if (groupedEntriesCount < 0 || (((long) groupedEntriesCount * ENTRY_SIZE) + Transformer.LONG_LENGTH) > bytes.remaining())
+		if (groupedEntriesCount < 0)
+			throw new MessageException("invalid grouped entries count");
+
+		if (groupedEntriesCount == 0) {
+			if (bytes.hasRemaining())
+				throw new MessageException("invalid grouped entries count");
+
+			return new TradePresencesMessage(id, List.of());
+		}
+
+		// if (count * entry size) + timestamp > remaining, then invalid count
+		if ((((long) groupedEntriesCount * ENTRY_SIZE) + Transformer.LONG_LENGTH) > bytes.remaining())
 			throw new MessageException("invalid grouped entries count");
 
 		List<TradePresenceData> tradePresences = new ArrayList<>(groupedEntriesCount);

--- a/src/main/java/org/qortal/network/message/TradePresencesMessage.java
+++ b/src/main/java/org/qortal/network/message/TradePresencesMessage.java
@@ -87,11 +87,9 @@ public class TradePresencesMessage extends Message {
 	}
 
 	public static Message fromByteBuffer(int id, ByteBuffer bytes)  throws MessageException {
-		int groupedEntriesCount = GroupedMessageUtils.readInitialGroupCount(bytes, "invalid grouped entries count");
+		int groupedEntriesCount = GroupedMessageUtils.readInitialGroupCount(bytes, ENTRY_SIZE, "invalid grouped entries count");
 		if (groupedEntriesCount == 0)
 			return new TradePresencesMessage(id, List.of());
-
-		GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, ENTRY_SIZE, "invalid grouped entries count");
 
 		List<TradePresenceData> tradePresences = new ArrayList<>(groupedEntriesCount);
 
@@ -115,8 +113,7 @@ public class TradePresencesMessage extends Message {
 			if (!bytes.hasRemaining())
 				break;
 
-			groupedEntriesCount = GroupedMessageUtils.readNextGroupCount(bytes, "invalid grouped entries count");
-			GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, ENTRY_SIZE, "invalid grouped entries count");
+			groupedEntriesCount = GroupedMessageUtils.readNextGroupCount(bytes, ENTRY_SIZE, "invalid grouped entries count");
 		}
 
 		return new TradePresencesMessage(id, tradePresences);

--- a/src/main/java/org/qortal/network/message/TradePresencesMessage.java
+++ b/src/main/java/org/qortal/network/message/TradePresencesMessage.java
@@ -87,25 +87,15 @@ public class TradePresencesMessage extends Message {
 	}
 
 	public static Message fromByteBuffer(int id, ByteBuffer bytes)  throws MessageException {
-		int groupedEntriesCount = bytes.getInt();
-
-		if (groupedEntriesCount < 0)
-			throw new MessageException("invalid grouped entries count");
-
-		if (groupedEntriesCount == 0) {
-			if (bytes.hasRemaining())
-				throw new MessageException("invalid grouped entries count");
-
+		int groupedEntriesCount = GroupedMessageUtils.readInitialGroupCount(bytes, "invalid grouped entries count");
+		if (groupedEntriesCount == 0)
 			return new TradePresencesMessage(id, List.of());
-		}
 
-		// if (count * entry size) + timestamp > remaining, then invalid count
-		if ((((long) groupedEntriesCount * ENTRY_SIZE) + Transformer.LONG_LENGTH) > bytes.remaining())
-			throw new MessageException("invalid grouped entries count");
+		GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, ENTRY_SIZE, "invalid grouped entries count");
 
 		List<TradePresenceData> tradePresences = new ArrayList<>(groupedEntriesCount);
 
-		while (groupedEntriesCount > 0) {
+		while (true) {
 			long timestamp = bytes.getLong();
 
 			for (int i = 0; i < groupedEntriesCount; ++i) {
@@ -122,12 +112,11 @@ public class TradePresencesMessage extends Message {
 				tradePresences.add(new TradePresenceData(timestamp, publicKey, signature, atAddress));
 			}
 
-			if (bytes.hasRemaining()) {
-				groupedEntriesCount = bytes.getInt();
-			} else {
-				// we've finished
-				groupedEntriesCount = 0;
-			}
+			if (!bytes.hasRemaining())
+				break;
+
+			groupedEntriesCount = GroupedMessageUtils.readNextGroupCount(bytes, "invalid grouped entries count");
+			GroupedMessageUtils.validateGroupCount(groupedEntriesCount, bytes, ENTRY_SIZE, "invalid grouped entries count");
 		}
 
 		return new TradePresencesMessage(id, tradePresences);

--- a/src/main/java/org/qortal/settings/Settings.java
+++ b/src/main/java/org/qortal/settings/Settings.java
@@ -232,7 +232,7 @@ public class Settings {
 	public long recoveryModeTimeout = 9999999999999L;
 
 	/** Minimum peer version number required in order to sync with them */
-	private String minPeerVersion = "6.1.0";
+	private String minPeerVersion = "6.1.6";
 
 	/** Whether to allow connections with peers below minPeerVersion
 	 * If true, we won't sync with them but they can still sync with us, and will show in the peers list

--- a/src/main/java/org/qortal/transform/transaction/AtTransactionTransformer.java
+++ b/src/main/java/org/qortal/transform/transaction/AtTransactionTransformer.java
@@ -8,6 +8,7 @@ import org.qortal.data.transaction.BaseTransactionData;
 import org.qortal.data.transaction.TransactionData;
 import org.qortal.group.Group;
 import org.qortal.transaction.Transaction;
+import org.qortal.transaction.AtTransaction;
 import org.qortal.transform.TransformationException;
 import org.qortal.utils.Serialization;
 
@@ -56,15 +57,14 @@ public class AtTransactionTransformer extends TransactionTransformer {
 		if (isMessageType) {
 			messageLength = byteBuffer.getInt();
 
-			if(messageLength > 0) {
+			if (messageLength < 0)
+				throw new TransformationException("negative message length " + messageLength);
 
-				if(messageLength > TransactionTransformer.SHA256_LENGTH) {
-					throw new TransformationException("excessive message length " + messageLength);
-				}
+			if (messageLength > AtTransaction.MAX_DATA_SIZE)
+				throw new TransformationException("excessive message length " + messageLength);
 
-				message = new byte[messageLength];
-				byteBuffer.get(message);
-			}
+			message = new byte[messageLength];
+			byteBuffer.get(message);
 		}
 		else {
 			// Assume PAYMENT-type, as there were no MESSAGE-type transactions until this time

--- a/src/main/java/org/qortal/transform/transaction/AtTransactionTransformer.java
+++ b/src/main/java/org/qortal/transform/transaction/AtTransactionTransformer.java
@@ -63,6 +63,9 @@ public class AtTransactionTransformer extends TransactionTransformer {
 			if (messageLength > AtTransaction.MAX_DATA_SIZE)
 				throw new TransformationException("excessive message length " + messageLength);
 
+			if (messageLength > byteBuffer.remaining())
+				throw new TransformationException("message length exceeds remaining bytes " + messageLength);
+
 			message = new byte[messageLength];
 			byteBuffer.get(message);
 		}

--- a/src/test/java/org/qortal/test/common/transaction/AtTestTransaction.java
+++ b/src/test/java/org/qortal/test/common/transaction/AtTestTransaction.java
@@ -29,14 +29,17 @@ public class AtTestTransaction extends TestTransaction {
 	}
 
 	public static TransactionData messageType(Repository repository, PrivateKeyAccount account, boolean wantValid) throws DataException {
+		byte[] message = new byte[32];
+		random.nextBytes(message);
+
+		return messageType(repository, account, wantValid, message);
+	}
+
+	public static TransactionData messageType(Repository repository, PrivateKeyAccount account, boolean wantValid, byte[] message) throws DataException {
 		byte[] signature = new byte[64];
 		random.nextBytes(signature);
 		String atAddress = Crypto.toATAddress(signature);
 		String recipient = account.getAddress();
-
-		// Use MESSAGE-type
-		byte[] message = new byte[32];
-		random.nextBytes(message);
 
 		return new ATTransactionData(generateBase(account), atAddress, recipient, message);
 	}

--- a/src/test/java/org/qortal/test/network/message/GroupedMessageEmptyTests.java
+++ b/src/test/java/org/qortal/test/network/message/GroupedMessageEmptyTests.java
@@ -1,0 +1,43 @@
+package org.qortal.test.network.message;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.qortal.network.message.GetTradePresencesMessage;
+import org.qortal.network.message.Message;
+import org.qortal.network.message.MessageException;
+import org.qortal.network.message.OnlineAccountsV3Message;
+import org.qortal.network.message.TradePresencesMessage;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+public class GroupedMessageEmptyTests {
+
+	@Test
+	public void testOnlineAccountsV3EmptyRoundTrip() throws MessageException {
+		OnlineAccountsV3Message messageOut = new OnlineAccountsV3Message(Collections.emptyList());
+		Message messageIn = Message.fromByteBuffer(ByteBuffer.wrap(messageOut.toBytes()).asReadOnlyBuffer());
+
+		Assert.assertTrue(messageIn instanceof OnlineAccountsV3Message);
+		Assert.assertEquals(0, ((OnlineAccountsV3Message) messageIn).getOnlineAccounts().size());
+	}
+
+	@Test
+	public void testTradePresencesEmptyRoundTrip() throws MessageException {
+		TradePresencesMessage messageOut = new TradePresencesMessage(Collections.emptyList());
+		Message messageIn = Message.fromByteBuffer(ByteBuffer.wrap(messageOut.toBytes()).asReadOnlyBuffer());
+
+		Assert.assertTrue(messageIn instanceof TradePresencesMessage);
+		Assert.assertEquals(0, ((TradePresencesMessage) messageIn).getTradePresences().size());
+	}
+
+	@Test
+	public void testGetTradePresencesEmptyRoundTrip() throws MessageException {
+		GetTradePresencesMessage messageOut = new GetTradePresencesMessage(Collections.emptyList());
+		Message messageIn = Message.fromByteBuffer(ByteBuffer.wrap(messageOut.toBytes()).asReadOnlyBuffer());
+
+		Assert.assertTrue(messageIn instanceof GetTradePresencesMessage);
+		Assert.assertEquals(0, ((GetTradePresencesMessage) messageIn).getTradePresences().size());
+	}
+
+}

--- a/src/test/java/org/qortal/test/network/message/GroupedMessageValidationTests.java
+++ b/src/test/java/org/qortal/test/network/message/GroupedMessageValidationTests.java
@@ -1,0 +1,174 @@
+package org.qortal.test.network.message;
+
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.junit.Assert;
+import org.junit.Test;
+import org.qortal.data.network.OnlineAccountData;
+import org.qortal.data.network.TradePresenceData;
+import org.qortal.network.message.GetTradePresencesMessage;
+import org.qortal.network.message.Message;
+import org.qortal.network.message.MessageException;
+import org.qortal.network.message.OnlineAccountsV3Message;
+import org.qortal.network.message.TradePresencesMessage;
+import org.qortal.transform.Transformer;
+import org.qortal.utils.Base58;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+public class GroupedMessageValidationTests {
+
+	@FunctionalInterface
+	private interface MessageParser {
+		Message parse(ByteBuffer bytes) throws MessageException;
+	}
+
+	@Test
+	public void testOnlineAccountsV3RejectsMalformedTrailingCounts() {
+		byte[] firstGroup = buildOnlineAccountsGroup(1_000_000L, (byte) 1, (byte) 2, 111);
+
+		assertRejected(bytes -> OnlineAccountsV3Message.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(-1)));
+		assertRejected(bytes -> OnlineAccountsV3Message.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(0)));
+		assertRejected(bytes -> OnlineAccountsV3Message.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(Integer.MAX_VALUE)));
+		assertRejected(bytes -> OnlineAccountsV3Message.fromByteBuffer(0, bytes), concat(firstGroup, new byte[] { 1, 2, 3 }));
+	}
+
+	@Test
+	public void testOnlineAccountsV3TwoGroupPayloadIsAccepted() throws MessageException {
+		byte[] payload = concat(
+				buildOnlineAccountsGroup(1_000_000L, (byte) 1, (byte) 2, 111),
+				buildOnlineAccountsGroup(2_000_000L, (byte) 3, (byte) 4, 222));
+
+		OnlineAccountsV3Message message = (OnlineAccountsV3Message) OnlineAccountsV3Message.fromByteBuffer(0, ByteBuffer.wrap(payload));
+		List<OnlineAccountData> onlineAccounts = message.getOnlineAccounts();
+
+		Assert.assertEquals(2, onlineAccounts.size());
+		assertOnlineAccount(onlineAccounts.get(0), 1_000_000L, (byte) 1, (byte) 2, 111);
+		assertOnlineAccount(onlineAccounts.get(1), 2_000_000L, (byte) 3, (byte) 4, 222);
+	}
+
+	@Test
+	public void testTradePresencesRejectsMalformedTrailingCounts() {
+		byte[] firstGroup = buildTradePresencesGroup(1_000_000L, (byte) 2, (byte) 3, (byte) 4);
+
+		assertRejected(bytes -> TradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(-1)));
+		assertRejected(bytes -> TradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(0)));
+		assertRejected(bytes -> TradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(Integer.MAX_VALUE)));
+		assertRejected(bytes -> TradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, new byte[] { 1, 2, 3 }));
+	}
+
+	@Test
+	public void testTradePresencesTwoGroupPayloadIsAccepted() throws MessageException {
+		byte[] payload = concat(
+				buildTradePresencesGroup(1_000_000L, (byte) 2, (byte) 3, (byte) 4),
+				buildTradePresencesGroup(2_000_000L, (byte) 5, (byte) 6, (byte) 7));
+
+		TradePresencesMessage message = (TradePresencesMessage) TradePresencesMessage.fromByteBuffer(0, ByteBuffer.wrap(payload));
+		List<TradePresenceData> tradePresences = message.getTradePresences();
+
+		Assert.assertEquals(2, tradePresences.size());
+		assertTradePresence(tradePresences.get(0), 1_000_000L, (byte) 2, (byte) 3, (byte) 4);
+		assertTradePresence(tradePresences.get(1), 2_000_000L, (byte) 5, (byte) 6, (byte) 7);
+	}
+
+	@Test
+	public void testGetTradePresencesRejectsMalformedTrailingCounts() {
+		byte[] firstGroup = buildGetTradePresencesGroup(1_000_000L, (byte) 8);
+
+		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(-1)));
+		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(0)));
+		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(Integer.MAX_VALUE)));
+		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, new byte[] { 1, 2, 3 }));
+	}
+
+	@Test
+	public void testGetTradePresencesTwoGroupPayloadIsAccepted() throws MessageException {
+		byte[] payload = concat(
+				buildGetTradePresencesGroup(1_000_000L, (byte) 8),
+				buildGetTradePresencesGroup(2_000_000L, (byte) 9));
+
+		GetTradePresencesMessage message = (GetTradePresencesMessage) GetTradePresencesMessage.fromByteBuffer(0, ByteBuffer.wrap(payload));
+		List<TradePresenceData> tradePresences = message.getTradePresences();
+
+		Assert.assertEquals(2, tradePresences.size());
+		assertTradePresence(tradePresences.get(0), 1_000_000L, (byte) 8);
+		assertTradePresence(tradePresences.get(1), 2_000_000L, (byte) 9);
+	}
+
+	private static void assertRejected(MessageParser parser, byte[] bytes) {
+		try {
+			parser.parse(ByteBuffer.wrap(bytes));
+			Assert.fail("Expected MessageException");
+		} catch (MessageException expected) {
+			// expected
+		}
+	}
+
+	private static void assertOnlineAccount(OnlineAccountData onlineAccountData, long timestamp, byte signatureFill, byte publicKeyFill, int nonce) {
+		Assert.assertEquals(timestamp, onlineAccountData.getTimestamp());
+		Assert.assertArrayEquals(filledBytes(Transformer.SIGNATURE_LENGTH, signatureFill), onlineAccountData.getSignature());
+		Assert.assertArrayEquals(filledBytes(Transformer.PUBLIC_KEY_LENGTH, publicKeyFill), onlineAccountData.getPublicKey());
+		Assert.assertEquals(Integer.valueOf(nonce), onlineAccountData.getNonce());
+	}
+
+	private static void assertTradePresence(TradePresenceData tradePresenceData, long timestamp, byte publicKeyFill, byte signatureFill, byte addressFill) {
+		Assert.assertEquals(timestamp, tradePresenceData.getTimestamp());
+		Assert.assertArrayEquals(filledBytes(Transformer.PUBLIC_KEY_LENGTH, publicKeyFill), tradePresenceData.getPublicKey());
+		Assert.assertArrayEquals(filledBytes(Transformer.SIGNATURE_LENGTH, signatureFill), tradePresenceData.getSignature());
+		Assert.assertEquals(Base58.encode(filledBytes(Transformer.ADDRESS_LENGTH, addressFill)), tradePresenceData.getAtAddress());
+	}
+
+	private static void assertTradePresence(TradePresenceData tradePresenceData, long timestamp, byte publicKeyFill) {
+		Assert.assertEquals(timestamp, tradePresenceData.getTimestamp());
+		Assert.assertArrayEquals(filledBytes(Transformer.PUBLIC_KEY_LENGTH, publicKeyFill), tradePresenceData.getPublicKey());
+	}
+
+	private static byte[] buildOnlineAccountsGroup(long timestamp, byte signatureFill, byte publicKeyFill, int nonce) {
+		return concat(
+				Ints.toByteArray(1),
+				Longs.toByteArray(timestamp),
+				filledBytes(Transformer.SIGNATURE_LENGTH, signatureFill),
+				filledBytes(Transformer.PUBLIC_KEY_LENGTH, publicKeyFill),
+				Ints.toByteArray(nonce));
+	}
+
+	private static byte[] buildTradePresencesGroup(long timestamp, byte publicKeyFill, byte signatureFill, byte addressFill) {
+		return concat(
+				Ints.toByteArray(1),
+				Longs.toByteArray(timestamp),
+				filledBytes(Transformer.PUBLIC_KEY_LENGTH, publicKeyFill),
+				filledBytes(Transformer.SIGNATURE_LENGTH, signatureFill),
+				filledBytes(Transformer.ADDRESS_LENGTH, addressFill));
+	}
+
+	private static byte[] buildGetTradePresencesGroup(long timestamp, byte publicKeyFill) {
+		return concat(
+				Ints.toByteArray(1),
+				Longs.toByteArray(timestamp),
+				filledBytes(Transformer.PUBLIC_KEY_LENGTH, publicKeyFill));
+	}
+
+	private static byte[] filledBytes(int length, byte value) {
+		byte[] bytes = new byte[length];
+		Arrays.fill(bytes, value);
+		return bytes;
+	}
+
+	private static byte[] concat(byte[]... parts) {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try {
+			for (byte[] part : parts) {
+				bytes.write(part);
+			}
+		} catch (IOException e) {
+			throw new AssertionError("IOException shouldn't occur with ByteArrayOutputStream");
+		}
+
+		return bytes.toByteArray();
+	}
+
+}

--- a/src/test/java/org/qortal/test/network/message/GroupedMessageValidationTests.java
+++ b/src/test/java/org/qortal/test/network/message/GroupedMessageValidationTests.java
@@ -38,6 +38,12 @@ public class GroupedMessageValidationTests {
 	}
 
 	@Test
+	public void testOnlineAccountsV3RejectsMalformedInitialGroup() {
+		assertRejected(bytes -> OnlineAccountsV3Message.fromByteBuffer(0, bytes), Ints.toByteArray(1));
+		assertRejected(bytes -> OnlineAccountsV3Message.fromByteBuffer(0, bytes), concat(Ints.toByteArray(1), Longs.toByteArray(1_000_000L), new byte[] { 1, 2, 3 }));
+	}
+
+	@Test
 	public void testOnlineAccountsV3TwoGroupPayloadIsAccepted() throws MessageException {
 		byte[] payload = concat(
 				buildOnlineAccountsGroup(1_000_000L, (byte) 1, (byte) 2, 111),
@@ -62,6 +68,12 @@ public class GroupedMessageValidationTests {
 	}
 
 	@Test
+	public void testTradePresencesRejectsMalformedInitialGroup() {
+		assertRejected(bytes -> TradePresencesMessage.fromByteBuffer(0, bytes), Ints.toByteArray(1));
+		assertRejected(bytes -> TradePresencesMessage.fromByteBuffer(0, bytes), concat(Ints.toByteArray(1), Longs.toByteArray(1_000_000L), new byte[] { 1, 2, 3 }));
+	}
+
+	@Test
 	public void testTradePresencesTwoGroupPayloadIsAccepted() throws MessageException {
 		byte[] payload = concat(
 				buildTradePresencesGroup(1_000_000L, (byte) 2, (byte) 3, (byte) 4),
@@ -83,6 +95,12 @@ public class GroupedMessageValidationTests {
 		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(0)));
 		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, Ints.toByteArray(Integer.MAX_VALUE)));
 		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(firstGroup, new byte[] { 1, 2, 3 }));
+	}
+
+	@Test
+	public void testGetTradePresencesRejectsMalformedInitialGroup() {
+		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), Ints.toByteArray(1));
+		assertRejected(bytes -> GetTradePresencesMessage.fromByteBuffer(0, bytes), concat(Ints.toByteArray(1), Longs.toByteArray(1_000_000L), new byte[] { 1, 2, 3 }));
 	}
 
 	@Test

--- a/src/test/java/org/qortal/test/network/message/NamesMessageTests.java
+++ b/src/test/java/org/qortal/test/network/message/NamesMessageTests.java
@@ -1,0 +1,61 @@
+package org.qortal.test.network.message;
+
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import org.junit.Assert;
+import org.junit.Test;
+import org.qortal.data.naming.NameData;
+import org.qortal.network.message.NamesMessage;
+import org.qortal.test.common.Common;
+import org.qortal.utils.Serialization;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+public class NamesMessageTests {
+
+	@Test
+	public void testShortEntryRoundTrip() throws Exception {
+		byte[] reference = new byte[64];
+		new Random().nextBytes(reference);
+
+		NameData nameData = new NameData(
+				"abc",
+				"abc",
+				Common.getTestAccount(null, "alice").getAddress(),
+				"{}",
+				1_000_000L,
+				null,
+				false,
+				null,
+				reference,
+				1);
+
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		bytes.write(Ints.toByteArray(1));
+		Serialization.serializeSizedStringV2(bytes, nameData.getName());
+		Serialization.serializeSizedStringV2(bytes, nameData.getReducedName());
+		Serialization.serializeAddress(bytes, nameData.getOwner());
+		Serialization.serializeSizedStringV2(bytes, nameData.getData());
+		bytes.write(Longs.toByteArray(nameData.getRegistered()));
+		bytes.write(Ints.toByteArray(0));
+		bytes.write(Ints.toByteArray(0));
+		bytes.write(nameData.getReference());
+		bytes.write(Ints.toByteArray(nameData.getCreationGroupId()));
+
+		NamesMessage message = (NamesMessage) NamesMessage.fromByteBuffer(0, ByteBuffer.wrap(bytes.toByteArray()));
+		Assert.assertNotNull(message);
+		Assert.assertEquals(1, message.getNameDataList().size());
+
+		NameData parsed = message.getNameDataList().get(0);
+		Assert.assertEquals(nameData.getName(), parsed.getName());
+		Assert.assertEquals(nameData.getReducedName(), parsed.getReducedName());
+		Assert.assertEquals(nameData.getOwner(), parsed.getOwner());
+		Assert.assertEquals(nameData.getData(), parsed.getData());
+		Assert.assertEquals(nameData.getRegistered(), parsed.getRegistered());
+		Assert.assertEquals(nameData.getCreationGroupId(), parsed.getCreationGroupId());
+		Assert.assertArrayEquals(nameData.getReference(), parsed.getReference());
+	}
+
+}

--- a/src/test/java/org/qortal/test/serialization/AtSerializationTests.java
+++ b/src/test/java/org/qortal/test/serialization/AtSerializationTests.java
@@ -12,11 +12,15 @@ import org.qortal.repository.Repository;
 import org.qortal.repository.RepositoryManager;
 import org.qortal.test.common.Common;
 import org.qortal.test.common.transaction.AtTestTransaction;
+import org.qortal.transaction.AtTransaction;
 import org.qortal.transaction.Transaction;
 import org.qortal.transform.TransformationException;
 import org.qortal.transform.transaction.TransactionTransformer;
 import org.qortal.utils.Base58;
 
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class AtSerializationTests extends Common {
@@ -90,6 +94,59 @@ public class AtSerializationTests extends Common {
 
             byte[] reserializedTransaction = TransactionTransformer.toBytes(deserializedTransactionData);
             assertEquals("Reserialized MESSAGE-type AT transaction bytes differ", HashCode.fromBytes(serializedTransaction).toString(), HashCode.fromBytes(reserializedTransaction).toString());
+        }
+    }
+
+    @Test
+    public void testEmptyMessageTypeAtSerialization() throws DataException, TransformationException {
+        try (final Repository repository = RepositoryManager.getRepository()) {
+            PrivateKeyAccount signingAccount = Common.getTestAccount(repository, "alice");
+            ATTransactionData transactionData = (ATTransactionData) AtTestTransaction.messageType(repository, signingAccount, true, new byte[0]);
+            Transaction transaction = Transaction.fromData(repository, transactionData);
+            transaction.sign(signingAccount);
+
+            final int claimedLength = TransactionTransformer.getDataLength(transactionData);
+            byte[] serializedTransaction = TransactionTransformer.toBytes(transactionData);
+            assertEquals("Serialized empty MESSAGE-type AT transaction length differs from declared length", claimedLength, serializedTransaction.length);
+
+            ATTransactionData deserializedTransactionData = (ATTransactionData) TransactionTransformer.fromBytes(serializedTransaction);
+            Transaction deserializedTransaction = Transaction.fromData(repository, deserializedTransactionData);
+            deserializedTransaction.sign(signingAccount);
+            assertArrayEquals("Deserialized empty MESSAGE-type AT transaction message differs", new byte[0], deserializedTransactionData.getMessage());
+
+            final int reclaimedLength = TransactionTransformer.getDataLength(deserializedTransactionData);
+            assertEquals("Reserialized empty MESSAGE-type AT transaction declared length differs", claimedLength, reclaimedLength);
+
+            byte[] reserializedTransaction = TransactionTransformer.toBytes(deserializedTransactionData);
+            assertEquals("Reserialized empty MESSAGE-type AT transaction bytes differ", HashCode.fromBytes(serializedTransaction).toString(), HashCode.fromBytes(reserializedTransaction).toString());
+        }
+    }
+
+    @Test
+    public void testMaximumMessageTypeAtSerialization() throws DataException, TransformationException {
+        try (final Repository repository = RepositoryManager.getRepository()) {
+            PrivateKeyAccount signingAccount = Common.getTestAccount(repository, "alice");
+            byte[] message = new byte[AtTransaction.MAX_DATA_SIZE];
+            new Random().nextBytes(message);
+
+            ATTransactionData transactionData = (ATTransactionData) AtTestTransaction.messageType(repository, signingAccount, true, message);
+            Transaction transaction = Transaction.fromData(repository, transactionData);
+            transaction.sign(signingAccount);
+
+            final int claimedLength = TransactionTransformer.getDataLength(transactionData);
+            byte[] serializedTransaction = TransactionTransformer.toBytes(transactionData);
+            assertEquals("Serialized maximum-size MESSAGE-type AT transaction length differs from declared length", claimedLength, serializedTransaction.length);
+
+            ATTransactionData deserializedTransactionData = (ATTransactionData) TransactionTransformer.fromBytes(serializedTransaction);
+            Transaction deserializedTransaction = Transaction.fromData(repository, deserializedTransactionData);
+            deserializedTransaction.sign(signingAccount);
+            assertArrayEquals("Deserialized maximum-size MESSAGE-type AT transaction message differs", message, deserializedTransactionData.getMessage());
+
+            final int reclaimedLength = TransactionTransformer.getDataLength(deserializedTransactionData);
+            assertEquals("Reserialized maximum-size MESSAGE-type AT transaction declared length differs", claimedLength, reclaimedLength);
+
+            byte[] reserializedTransaction = TransactionTransformer.toBytes(deserializedTransactionData);
+            assertEquals("Reserialized maximum-size MESSAGE-type AT transaction bytes differ", HashCode.fromBytes(serializedTransaction).toString(), HashCode.fromBytes(reserializedTransaction).toString());
         }
     }
 

--- a/src/test/java/org/qortal/test/serialization/AtSerializationTests.java
+++ b/src/test/java/org/qortal/test/serialization/AtSerializationTests.java
@@ -1,6 +1,7 @@
 package org.qortal.test.serialization;
 
 import com.google.common.hash.HashCode;
+import com.google.common.primitives.Ints;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,6 +15,7 @@ import org.qortal.test.common.Common;
 import org.qortal.test.common.transaction.AtTestTransaction;
 import org.qortal.transaction.AtTransaction;
 import org.qortal.transaction.Transaction;
+import org.qortal.transform.Transformer;
 import org.qortal.transform.TransformationException;
 import org.qortal.transform.transaction.TransactionTransformer;
 import org.qortal.utils.Base58;
@@ -22,6 +24,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class AtSerializationTests extends Common {
 
@@ -147,6 +150,35 @@ public class AtSerializationTests extends Common {
 
             byte[] reserializedTransaction = TransactionTransformer.toBytes(deserializedTransactionData);
             assertEquals("Reserialized maximum-size MESSAGE-type AT transaction bytes differ", HashCode.fromBytes(serializedTransaction).toString(), HashCode.fromBytes(reserializedTransaction).toString());
+        }
+    }
+
+    @Test
+    public void testMessageTypeAtSerializationRejectsDeclaredLengthOverrun() throws DataException, TransformationException {
+        try (final Repository repository = RepositoryManager.getRepository()) {
+            PrivateKeyAccount signingAccount = Common.getTestAccount(repository, "alice");
+            ATTransactionData transactionData = (ATTransactionData) AtTestTransaction.messageType(repository, signingAccount, true, new byte[0]);
+            Transaction transaction = Transaction.fromData(repository, transactionData);
+            transaction.sign(signingAccount);
+
+            byte[] serializedTransaction = TransactionTransformer.toBytes(transactionData);
+            byte[] mutatedTransaction = serializedTransaction.clone();
+
+            int messageLengthOffset = Transformer.INT_LENGTH
+                    + Transformer.LONG_LENGTH
+                    + Transformer.SIGNATURE_LENGTH
+                    + Transformer.ADDRESS_LENGTH
+                    + Transformer.ADDRESS_LENGTH
+                    + Transformer.INT_LENGTH;
+
+            System.arraycopy(Ints.toByteArray(serializedTransaction.length + 1), 0, mutatedTransaction, messageLengthOffset, Transformer.INT_LENGTH);
+
+            try {
+                TransactionTransformer.fromBytes(mutatedTransaction);
+                fail("Expected oversized AT message length to be rejected");
+            } catch (TransformationException expected) {
+                // Expected
+            }
         }
     }
 


### PR DESCRIPTION
### 6.1.7 validation follow-up

- Fixed edge-case validation in AT transaction serialization so empty MESSAGE payloads are accepted, max-size payloads still work, and oversized declared lengths are rejected cleanly.

- Corrected NamesMessage validation so valid short entries are no longer rejected by the precheck.

- Hardened grouped network message parsing for OnlineAccountsV3, TradePresences, and GetTradePresences so empty payloads are allowed, every group boundary is validated, and malformed trailing counts are rejected.

- Added regression tests covering empty payloads, valid multi-group payloads, malformed counts, and AT message-length overruns.