### PR TITLE
Performance optimizations to HSQLDB arbitrary data queries

### DIFF
--- a/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataCleanupManager.java
+++ b/src/main/java/org/qortal/controller/arbitrary/ArbitraryDataCleanupManager.java
@@ -62,6 +62,8 @@ public class ArbitraryDataCleanupManager extends Thread {
 	 */
 	private static final int CHUNK_DELETION_BATCH_SIZE = 1000;
 
+	private static final long TRANSACTION_LIST_REFRESH_INTERVAL = 6 * 60 * 60 * 1000L; // 6 hours
+
 
 	/*
 	TODO:
@@ -89,14 +91,17 @@ public class ArbitraryDataCleanupManager extends Thread {
 		int offset = 0;
 
 		List<ArbitraryTransactionData> allArbitraryTransactionsInDescendingOrder;
+		long listFetchedAt;
 
 		try (final Repository repository = RepositoryManager.getRepository()) {
 			allArbitraryTransactionsInDescendingOrder
 					= repository.getArbitraryRepository()
 					.getLatestArbitraryTransactions();
+			listFetchedAt = System.currentTimeMillis();
 		} catch( Exception e) {
 			LOGGER.error(e.getMessage(), e);
 			allArbitraryTransactionsInDescendingOrder = new ArrayList<>(0);
+			listFetchedAt = System.currentTimeMillis();
 		}
 
 		Set<ArbitraryTransactionDataHashWrapper> processedTransactions = new HashSet<>();
@@ -141,9 +146,12 @@ public class ArbitraryDataCleanupManager extends Thread {
 
 					if (transactions == null || transactions.isEmpty()) {
 						offset = 0;
-						allArbitraryTransactionsInDescendingOrder
-								= repository.getArbitraryRepository()
-								.getLatestArbitraryTransactions();
+						if (System.currentTimeMillis() - listFetchedAt >= TRANSACTION_LIST_REFRESH_INTERVAL) {
+							allArbitraryTransactionsInDescendingOrder
+									= repository.getArbitraryRepository()
+									.getLatestArbitraryTransactions();
+							listFetchedAt = System.currentTimeMillis();
+						}
 						transactions = allArbitraryTransactionsInDescendingOrder.stream().limit(limit).collect(Collectors.toList());
 						processedTransactions.clear();
 					}

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
@@ -305,11 +305,10 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	@Override
 	public List<ArbitraryTransactionDataHashWrapper> getArbitraryTransactionSignaturesLite() throws DataException {
-		String sql = "SELECT signature, service, name, identifier, metadata_hash, Transactions.created_when " +
+		String sql = "SELECT signature, service, name, identifier, metadata_hash, created_when " +
 				"FROM ArbitraryTransactions " +
-				"JOIN Transactions USING (signature) " +
 				"WHERE name IS NOT NULL " +
-				"ORDER BY ArbitraryTransactions.created_when DESC";
+				"ORDER BY created_when DESC";
 
 		List<ArbitraryTransactionDataHashWrapper> results = new ArrayList<>();
 		try (ResultSet resultSet = this.repository.checkedExecute(sql)) {

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
@@ -30,6 +30,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -235,17 +236,43 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	@Override
 	public List<ArbitraryTransactionData> getLatestArbitraryTransactions(Integer limit) throws DataException {
+		// ponytail: when limited, pick the newest N signatures via an index-only scan on
+		// ArbitraryTransactions (no join, no sort pass — same plan as the "Lite" query), then
+		// constrain the join to just those N rows. Turns a 325k-row PK-probe join into N probes.
+		// No limit => we'd read every row anyway, so the join is unavoidable; keep it as-is.
+		Object[] bindParams = new Object[0];
+		String latestFilter = "name IS NOT NULL";
+		if (limit != null) {
+			List<byte[]> signatures = new ArrayList<>(limit);
+			String idSql = "SELECT signature FROM ArbitraryTransactions " +
+					"WHERE name IS NOT NULL ORDER BY created_when DESC LIMIT " + limit;
+			try (ResultSet idResultSet = this.repository.checkedExecute(idSql)) {
+				if (idResultSet == null)
+					return new ArrayList<>(0);
+				do {
+					signatures.add(idResultSet.getBytes(1));
+				} while (idResultSet.next());
+			} catch (SQLException e) {
+				throw new DataException("Unable to fetch latest arbitrary transaction signatures", e);
+			}
+
+			// Hydrate exactly those signatures. Order is re-applied by the ORDER BY below.
+			// Qualify the column: bare "signature" makes the planner full-scan ArbitraryTransactions;
+			// "ArbitraryTransactions.signature" lets it PK-seek both tables.
+			latestFilter = "ArbitraryTransactions.signature IN (" + String.join(", ", Collections.nCopies(signatures.size(), "?")) + ")";
+			bindParams = signatures.toArray();
+		}
+
 		String sql = "SELECT type, reference, signature, creator, Transactions.created_when, fee, " +
 				"tx_group_id, block_height, approval_status, approval_height, " +
 				"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 				"name, identifier, update_method, secret, compression FROM ArbitraryTransactions " +
 				"JOIN Transactions USING (signature) " +
-				"WHERE name IS NOT NULL " +
-				"ORDER BY ArbitraryTransactions.created_when DESC" +
-				(limit != null ? " LIMIT " + limit : "");
+				"WHERE " + latestFilter + " " +
+				"ORDER BY ArbitraryTransactions.created_when DESC";
 		List<ArbitraryTransactionData> arbitraryTransactionData = new ArrayList<>();
 
-		try (ResultSet resultSet = this.repository.checkedExecute(sql)) {
+		try (ResultSet resultSet = this.repository.checkedExecute(sql, bindParams)) {
 			if (resultSet == null)
 				return new ArrayList<>(0);
 

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBArbitraryRepository.java
@@ -161,14 +161,14 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	@Override
 	public List<ArbitraryTransactionData> getArbitraryTransactions(String name, Service service, String identifier, long since) throws DataException {
-		String sql = "SELECT type, reference, signature, creator, created_when, fee, " +
+		String sql = "SELECT type, reference, signature, creator, Transactions.created_when, fee, " +
 				"tx_group_id, block_height, approval_status, approval_height, " +
 				"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 				"name, identifier, update_method, secret, compression FROM ArbitraryTransactions " +
 				"JOIN Transactions USING (signature) " +
 				"WHERE lower(name) = ? AND service = ?" +
 				"AND (identifier = ? OR (identifier IS NULL AND ? IS NULL))" +
-				"AND created_when >= ? ORDER BY created_when ASC";
+				"AND Transactions.created_when >= ? ORDER BY Transactions.created_when ASC";
 		List<ArbitraryTransactionData> arbitraryTransactionData = new ArrayList<>();
 
 		try (ResultSet resultSet = this.repository.checkedExecute(sql, name.toLowerCase(), service.value, identifier, identifier, since)) {
@@ -235,13 +235,13 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	@Override
 	public List<ArbitraryTransactionData> getLatestArbitraryTransactions(Integer limit) throws DataException {
-		String sql = "SELECT type, reference, signature, creator, created_when, fee, " +
+		String sql = "SELECT type, reference, signature, creator, Transactions.created_when, fee, " +
 				"tx_group_id, block_height, approval_status, approval_height, " +
 				"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 				"name, identifier, update_method, secret, compression FROM ArbitraryTransactions " +
 				"JOIN Transactions USING (signature) " +
 				"WHERE name IS NOT NULL " +
-				"ORDER BY created_when DESC" +
+				"ORDER BY ArbitraryTransactions.created_when DESC" +
 				(limit != null ? " LIMIT " + limit : "");
 		List<ArbitraryTransactionData> arbitraryTransactionData = new ArrayList<>();
 
@@ -305,11 +305,11 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	@Override
 	public List<ArbitraryTransactionDataHashWrapper> getArbitraryTransactionSignaturesLite() throws DataException {
-		String sql = "SELECT signature, service, name, identifier, metadata_hash, created_when " +
+		String sql = "SELECT signature, service, name, identifier, metadata_hash, Transactions.created_when " +
 				"FROM ArbitraryTransactions " +
 				"JOIN Transactions USING (signature) " +
 				"WHERE name IS NOT NULL " +
-				"ORDER BY created_when DESC";
+				"ORDER BY ArbitraryTransactions.created_when DESC";
 
 		List<ArbitraryTransactionDataHashWrapper> results = new ArrayList<>();
 		try (ResultSet resultSet = this.repository.checkedExecute(sql)) {
@@ -333,13 +333,13 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	@Override
 	public List<ArbitraryTransactionData> getLatestArbitraryTransactionsByName( String name ) throws DataException {
-		String sql = "SELECT type, reference, signature, creator, created_when, fee, " +
+		String sql = "SELECT type, reference, signature, creator, Transactions.created_when, fee, " +
 				"tx_group_id, block_height, approval_status, approval_height, " +
 				"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 				"name, identifier, update_method, secret, compression FROM ArbitraryTransactions " +
 				"JOIN Transactions USING (signature) " +
 				"WHERE name = ? " +
-				"ORDER BY created_when DESC";
+				"ORDER BY ArbitraryTransactions.created_when DESC";
 		List<ArbitraryTransactionData> arbitraryTransactionData = new ArrayList<>();
 
 		try (ResultSet resultSet = this.repository.checkedExecute(sql, name)) {
@@ -408,7 +408,7 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 		StringBuilder sql = new StringBuilder(1024);
 
-		sql.append("SELECT type, reference, signature, creator, created_when, fee, " +
+		sql.append("SELECT type, reference, signature, creator, Transactions.created_when, fee, " +
 				"tx_group_id, block_height, approval_status, approval_height, " +
 				"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 				"name, identifier, update_method, secret, compression FROM ArbitraryTransactions " +
@@ -421,7 +421,7 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 			sql.append(method.value);
 		}
 
-		sql.append(" ORDER BY created_when");
+		sql.append(" ORDER BY ArbitraryTransactions.created_when");
 
 		if (firstNotLast) {
 			sql.append(" ASC");
@@ -489,7 +489,7 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 	public ArbitraryTransactionData getSingleTransactionBySignature(byte[] signature) throws DataException {
 		StringBuilder sql = new StringBuilder(1024);
 
-		sql.append("SELECT type, reference, signature, creator, created_when, fee, " +
+		sql.append("SELECT type, reference, signature, creator, tx.created_when, fee, " +
 				"tx_group_id, block_height, approval_status, approval_height, " +
 				"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 				"name, identifier, update_method, secret, compression FROM ArbitraryTransactions atx " +
@@ -558,7 +558,7 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 
 	public List<ArbitraryTransactionData> getArbitraryTransactions(boolean requireName, Integer limit, Integer offset, Boolean reverse) throws DataException {
 		StringBuilder sql = new StringBuilder(512);
-		sql.append("SELECT type, reference, signature, creator, created_when, fee, " +
+		sql.append("SELECT type, reference, signature, creator, Transactions.created_when, fee, " +
 			"tx_group_id, block_height, approval_status, approval_height, " +
 			"version, nonce, service, size, is_data_raw, data, metadata_hash, " +
 			"name, identifier, update_method, secret, compression FROM ArbitraryTransactions " +
@@ -568,7 +568,7 @@ public class HSQLDBArbitraryRepository implements ArbitraryRepository {
 			sql.append(" WHERE name IS NOT NULL");
 		}
 
-		sql.append(" ORDER BY created_when");
+		sql.append(" ORDER BY ArbitraryTransactions.created_when");
 
 		if (reverse != null && reverse) {
 			sql.append(" DESC");

--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBDatabaseUpdates.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBDatabaseUpdates.java
@@ -1069,6 +1069,17 @@ public class HSQLDBDatabaseUpdates {
 
 					break;
 
+				case 52:
+
+					LOGGER.info("Denormalizing created_when into ArbitraryTransactions - please wait...");
+					stmt.execute("ALTER TABLE ArbitraryTransactions ADD created_when EpochMillis");
+					stmt.execute("UPDATE ArbitraryTransactions SET created_when = "
+							+ "(SELECT created_when FROM Transactions WHERE signature = ArbitraryTransactions.signature)");
+					stmt.execute("ALTER TABLE ArbitraryTransactions ALTER COLUMN created_when SET NOT NULL");
+					stmt.execute("CREATE INDEX ArbitraryNameCreatedIndex ON ArbitraryTransactions (name, created_when DESC)");
+
+					break;
+
 				default:
 					// nothing to do
 					return false;

--- a/src/main/java/org/qortal/repository/hsqldb/transaction/HSQLDBArbitraryTransactionRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/transaction/HSQLDBArbitraryTransactionRepository.java
@@ -70,7 +70,8 @@ public class HSQLDBArbitraryTransactionRepository extends HSQLDBTransactionRepos
 				.bind("is_data_raw", arbitraryTransactionData.getDataType() == DataType.RAW_DATA).bind("data", arbitraryTransactionData.getData())
 				.bind("metadata_hash", arbitraryTransactionData.getMetadataHash()).bind("name", arbitraryTransactionData.getName())
 				.bind("identifier", arbitraryTransactionData.getIdentifier()).bind("update_method", method)
-				.bind("secret", arbitraryTransactionData.getSecret()).bind("compression", compression);
+				.bind("secret", arbitraryTransactionData.getSecret()).bind("compression", compression)
+				.bind("created_when", arbitraryTransactionData.getTimestamp());
 
 		try {
 			saveHelper.execute(this.repository);


### PR DESCRIPTION
[HSQLDB_summary.md](https://github.com/user-attachments/files/29538534/HSQLDB_summary.md)

## Summary

Performance optimizations to HSQLDB arbitrary data queries, eliminating slow full-table scans and redundant joins.

**Changes:**

- **Denormalize `created_when`** into `ArbitraryTransactions` table with a `name/created_when` index, removing the need to join against `Transactions` for time-based lookups
- **Two-step index scan** in `getLatestArbitraryTransactions`: fetch newest N signatures via index-only scan on `ArbitraryTransactions`, then hydrate only those rows via PK lookup — eliminates the ~325k-row `Transactions` probe that HSQLDB couldn't push LIMIT through. **Benchmarked 8–9× faster** at limits 10/100/1000 on a mainnet DB
- **Drop unnecessary JOIN** in `getArbitraryTransactionSignaturesLite` now that `created_when` is local to the table
- **Throttle transaction list refresh** in cleanup manager to every 6 hours, avoiding redundant DB queries between runs

## Test plan

- [ ]  Run on a mainnet DB snapshot and confirm query times at limits 10/100/1000
- [ ]  Verify `getArbitraryTransactionSignaturesLite` returns correct results without the JOIN
- [ ]  Confirm cleanup manager refresh interval respected across multiple cycles
- [ ]  Check `arbitrary-query-perf.md` EXPLAIN plans match expected index usage
[arbitrary-query-perf.md](https://github.com/user-attachments/files/29538713/arbitrary-query-perf.md)
