### PR TITLE
Fix sender derivation for unsigned group chat validation

### DIFF
--- a/src/main/java/org/qortal/data/transaction/ChatTransactionData.java
+++ b/src/main/java/org/qortal/data/transaction/ChatTransactionData.java
@@ -2,6 +2,7 @@ package org.qortal.data.transaction;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
+import org.qortal.crypto.Crypto;
 import org.qortal.transaction.Transaction.TransactionType;
 
 import javax.xml.bind.Unmarshaller;
@@ -42,6 +43,9 @@ public class ChatTransactionData extends TransactionData {
 
 	public void afterUnmarshal(Unmarshaller u, Object parent) {
 		this.creatorPublicKey = this.senderPublicKey;
+
+		if (this.senderPublicKey != null)
+			this.sender = Crypto.toAddress(this.senderPublicKey);
 	}
 
 	public ChatTransactionData(BaseTransactionData baseTransactionData,

--- a/src/test/java/org/qortal/test/data/transaction/ChatTransactionDataTests.java
+++ b/src/test/java/org/qortal/test/data/transaction/ChatTransactionDataTests.java
@@ -1,0 +1,67 @@
+package org.qortal.test.data.transaction;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.jaxb.UnmarshallerProperties;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.qortal.crypto.Crypto;
+import org.qortal.data.transaction.ChatTransactionData;
+import org.qortal.utils.Base58;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.stream.StreamSource;
+import java.io.StringReader;
+import java.security.Security;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ChatTransactionDataTests {
+
+	@BeforeClass
+	public static void beforeClass() {
+		Security.addProvider(new BouncyCastleProvider());
+	}
+
+	@Test
+	public void testJsonUnmarshalDerivesSenderFromPublicKey() throws JAXBException {
+		byte[] senderPublicKey = publicKeyBytes(1);
+		String expectedSender = Crypto.toAddress(senderPublicKey);
+
+		ChatTransactionData withoutSender = unmarshalChat(senderPublicKey, null);
+		assertArrayEquals(senderPublicKey, withoutSender.getCreatorPublicKey());
+		assertEquals(expectedSender, withoutSender.getSender());
+
+		String forgedSender = Crypto.toAddress(publicKeyBytes(2));
+		ChatTransactionData withForgedSender = unmarshalChat(senderPublicKey, forgedSender);
+		assertArrayEquals(senderPublicKey, withForgedSender.getCreatorPublicKey());
+		assertEquals(expectedSender, withForgedSender.getSender());
+	}
+
+	private static byte[] publicKeyBytes(int offset) {
+		byte[] publicKey = new byte[32];
+		for (int i = 0; i < publicKey.length; ++i)
+			publicKey[i] = (byte) (i + offset);
+
+		return publicKey;
+	}
+
+	private static ChatTransactionData unmarshalChat(byte[] senderPublicKey, String sender) throws JAXBException {
+		String senderJson = sender == null ? "" : String.format("\"sender\":\"%s\",", sender);
+		String json = String.format(
+				"{\"timestamp\":1,\"reference\":\"%s\",\"fee\":\"0\",\"txGroupId\":1," +
+						"\"senderPublicKey\":\"%s\",%s\"data\":\"%s\",\"isText\":true,\"isEncrypted\":true}",
+				Base58.encode(new byte[64]), Base58.encode(senderPublicKey), senderJson,
+				Base58.encode(new byte[] { 1 }));
+
+		JAXBContext context = JAXBContextFactory.createContext(new Class[] { ChatTransactionData.class }, null);
+		Unmarshaller unmarshaller = context.createUnmarshaller();
+		unmarshaller.setProperty(UnmarshallerProperties.MEDIA_TYPE, "application/json");
+		unmarshaller.setProperty(UnmarshallerProperties.JSON_INCLUDE_ROOT, false);
+
+		return unmarshaller.unmarshal(new StreamSource(new StringReader(json)), ChatTransactionData.class).getValue();
+	}
+}


### PR DESCRIPTION
## Summary

- Derive the CHAT sender address from `senderPublicKey` during JSON unmarshalling.
- Prevent a caller-supplied `sender` value from influencing pre-signing validation.
- Add regression coverage for omitted and mismatched sender values.

## Problem

`POST /chat` validates unsigned CHAT data before serialization. Group validation reads `ChatTransactionData.sender`, but JSON unmarshalling only copied `senderPublicKey` into `creatorPublicKey`. Since `sender` is read-only and normally omitted by clients, group chat requests were validated with a null sender and rejected. Group 0 bypassed membership validation, which hid the issue there.

## Security

The sender remains derived from `senderPublicKey`. It is not serialized as an independent transaction field, and signed transaction verification still requires the matching signing key. Supplying another address in JSON cannot impersonate that address because the supplied value is overwritten.

## Tests

- `mvn -Dmaven.gitcommitid.nativegit=true -DskipJUnitTests=false -Dtest=ChatTransactionDataTests test`
- `mvn -Dmaven.gitcommitid.nativegit=true -DskipJUnitTests=true clean package`