### PR TITLE
Optimize AT state pruning with set-based deletion

### DIFF
--- a/src/main/java/org/qortal/repository/hsqldb/HSQLDBATRepository.java
+++ b/src/main/java/org/qortal/repository/hsqldb/HSQLDBATRepository.java
@@ -875,6 +875,14 @@ public class HSQLDBATRepository implements ATRepository {
 		synchronized (this.repository.latestATStatesLock) {
 
 			int deletedCount = 0;
+			// Prune each height in one database operation instead of deleting individual AT states.
+			String deleteSql = "DELETE FROM ATStates "
+					+ "WHERE height = ? "
+					+ "AND NOT EXISTS ("
+					+ "SELECT TRUE FROM LatestATStates "
+					+ "WHERE LatestATStates.AT_address = ATStates.AT_address "
+					+ "AND LatestATStates.height = ATStates.height"
+					+ ")";
 
 			for (int height = minHeight; height <= maxHeight; height++) {
 
@@ -883,44 +891,11 @@ public class HSQLDBATRepository implements ATRepository {
 					return deletedCount;
 				}
 
-				// Get latest AT states for this height
-				List<String> atAddresses = new ArrayList<>();
-				String updateSql = "SELECT AT_address FROM LatestATStates WHERE height = ?";
-				try (ResultSet resultSet = this.repository.checkedExecute(updateSql, height)) {
-					if (resultSet != null) {
-						do {
-							String atAddress = resultSet.getString(1);
-							atAddresses.add(atAddress);
-
-						} while (resultSet.next());
-					}
+				try {
+					deletedCount += this.repository.executeCheckedUpdate(deleteSql, height);
 				} catch (SQLException e) {
-					throw new DataException("Unable to fetch latest AT states from repository", e);
-				}
-
-				List<ATStateData> atStates = this.getBlockATStatesAtHeight(height);
-				for (ATStateData atState : atStates) {
-					//LOGGER.info("Found atState {} at height {}", atState.getATAddress(), atState.getHeight());
-
-					// Give up if we're stopping
-					if (Controller.isStopping()) {
-						return deletedCount;
-					}
-
-					if (atAddresses.contains(atState.getATAddress())) {
-						// We don't want to delete this AT state because it is still active
-						LOGGER.trace("Skipping atState {} at height {}", atState.getATAddress(), atState.getHeight());
-						continue;
-					}
-
-					// Safe to delete everything else for this height
-					try {
-						this.repository.delete("ATStates", "AT_address = ? AND height = ?",
-								atState.getATAddress(), atState.getHeight());
-						deletedCount++;
-					} catch (SQLException e) {
-						throw new DataException("Unable to delete AT state data from repository", e);
-					}
+					repository.examineException(e);
+					throw new DataException("Unable to prune AT states from repository", e);
 				}
 			}
 			this.repository.saveChanges();


### PR DESCRIPTION
Refs #122

## Summary

- replace the per-state pruning loop with one set-based `DELETE` per block height
- preserve every state referenced by `LatestATStates`
- retain shutdown checks between heights and the existing transaction boundary
- avoid loading full `ATStateData` objects and allocating intermediate address/state lists

Previously, pruning one height required two reads followed by one delete statement for every obsolete AT state. The new query lets HSQLDB identify and delete those obsolete rows directly with `NOT EXISTS`.

## Validation

- `mvn -B -DskipJUnitTests=false -Dtest=PruneTests test`
  - 2 tests passed, including preservation of the latest AT state and sleeping/finished AT orphaning behavior
- `mvn -B -DskipJUnitTests package`
  - build successful on JDK 17
- `git diff --check`
  - clean

## Performance evidence

A synthetic in-memory HSQLDB benchmark used 48,000 `ATStates` rows across 1,200 heights and 40 AT addresses, with one latest state preserved per address. Median of three measured runs after warm-up:

| Implementation | Median prune time | Database statements |
| --- | ---: | ---: |
| Existing per-row loop | 74.343 ms | 50,360 |
| Set-based deletion | 32.117 ms | 1,200 |

That is a 2.31x speedup in the synthetic benchmark and a 41.97x reduction in executed database statements. Persistent-node databases should particularly benefit from eliminating per-row delete round trips; the timing is synthetic and is included as directional evidence rather than a production guarantee.

## Scope

The change is limited to `HSQLDBATRepository.pruneAtStates`. No schema, API, or persisted-data-format changes are involved.

